### PR TITLE
fix: correctly pass storage_options in add_columns

### DIFF
--- a/lance_ray/io.py
+++ b/lance_ray/io.py
@@ -273,9 +273,7 @@ def add_columns(
     """
     _validate_uri_or_namespace_args(uri, namespace, table_id)
 
-    merged_storage_options = dict()
-    if storage_options:
-        merged_storage_options.update(storage_options)
+    storage_options = storage_options or {}
 
     # Resolve URI from namespace if provided
     if namespace is not None and table_id is not None:
@@ -285,10 +283,10 @@ def add_columns(
         describe_response = namespace.describe_table(describe_request)
         uri = describe_response.location
         if describe_response.storage_options:
-            merged_storage_options.update(describe_response.storage_options)
+            storage_options.update(describe_response.storage_options)
 
     lance_ds = LanceDataset(
-        uri=uri, storage_options=merged_storage_options, version=read_version
+        uri=uri, storage_options=storage_options, version=read_version
     )
     fragment_ids = [f.metadata.id for f in lance_ds.get_fragments()]
     pool = Pool(processes=concurrency, ray_remote_args=ray_remote_args)
@@ -317,7 +315,7 @@ def add_columns(
         uri,
         op,
         read_version=lance_ds.version,
-        storage_options=merged_storage_options,
+        storage_options=storage_options,
     )
     pool.close()
 


### PR DESCRIPTION
#57 When adding columns, storage_options can be obtained by describing table