### PR TITLE
chore: remove ping to lance-namespace

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 dependencies = [
     "ray[data]>=2.41.0",
     "pylance>=2.0.0b8",
-    "lance-namespace>=0.4.5",
+    "lance-namespace",
     "pyarrow>=17.0.0",
     "more_itertools>=2.6.0; python_version<'3.12'",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -381,7 +381,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "lance-namespace", specifier = ">=0.4.5" },
+    { name = "lance-namespace" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5.0" },
     { name = "mkdocs-awesome-pages-plugin", marker = "extra == 'docs'", specifier = ">=2.9.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.0.0" },


### PR DESCRIPTION
This ensures that we always use the same version as pylance