### PR TITLE
chore: update pylance dependency to v2.0.0rc2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=2.0.0b10",
+    "pylance>=2.0.0rc2",
     "lance-namespace",
     "pyarrow>=17.0.0",
     "more_itertools>=2.6.0; python_version<'3.12'",

--- a/uv.lock
+++ b/uv.lock
@@ -387,7 +387,7 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.0.0" },
     { name = "more-itertools", marker = "python_full_version < '3.12'", specifier = ">=2.6.0" },
     { name = "pyarrow", specifier = ">=17.0.0" },
-    { name = "pylance", specifier = ">=2.0.0b10" },
+    { name = "pylance", specifier = ">=2.0.0rc2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
@@ -1025,7 +1025,7 @@ wheels = [
 
 [[package]]
 name = "pylance"
-version = "2.0.0b10"
+version = "2.0.0rc2"
 source = { registry = "https://pypi.fury.io/lance-format" }
 dependencies = [
     { name = "lance-namespace" },
@@ -1034,12 +1034,11 @@ dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://pypi.fury.io/lance-format/-/ver_9UwtW/pylance-2.0.0b10-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:39e28b440c8a48c6042c89ca750b8f7109129131935116288bca8c83a467551d" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_2dIMLX/pylance-2.0.0b10-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f89da60e8be4070ce71cc24b438153044e91b13fb63d0903a7ea62531bdfe1f4" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1sMiqd/pylance-2.0.0b10-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d525378fe5293aefcbf2e6a5efaa408fa5ee413e99c7a32393ec3045ecb94d2" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1Gjz7s/pylance-2.0.0b10-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ce6a385783dd10d48b8f11ee85e91ed4967aa7d82e1d6784ea71cc71e4605716" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_20bLNa/pylance-2.0.0b10-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:946d36adc2e6ee189ad5bb1d9061d2943b7ad0b381196b8431bb743c41cd5312" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_2eqBKc/pylance-2.0.0b10-cp39-abi3-win_amd64.whl", hash = "sha256:e9fd39080bdf7fa23999f9f863f885b3fbefef3ca703968f6c1b7a3806d627da" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_2dAJKS/pylance-2.0.0rc2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ee939482304d20168e75414d264d6cd39b81781f54fc19d9b3e64f23231beadd" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_2eorbS/pylance-2.0.0rc2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:818b38760b2e56a9f4376490aab8ecb54da78f7b85c44ddf0ada0226755b0236" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_IeCGR/pylance-2.0.0rc2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c5a124a38252817041bb5856a408497a4b92fcff30340fa33272407528cf8566" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1EHkzf/pylance-2.0.0rc2-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d3cea3ee2ae67f6c8f4941af76cc61bcb770b4141ce02ea72dd5267f77359818" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1fG3xG/pylance-2.0.0rc2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:e85650a889169cfc7e0d5613c17ded3db69b4760a03a7a71dd4c27ad54f769dc" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump pylance dependency to 2.0.0rc2.
- Update lockfile accordingly.

## Testing
- `make lint`

## Reference
- refs/tags/v2.0.0-rc.2
