### PR TITLE
chore: update pylance dependency to v2.0.0rc4

### DIFF
--- a/lance_ray/datasource.py
+++ b/lance_ray/datasource.py
@@ -155,26 +155,19 @@ class LanceDatasource(Datasource):
                 )
 
             read_task = ReadTask(
-                lambda fids=fragment_ids,
-                uri=dataset_uri,
-                version=dataset_version,
-                storage_options=dataset_storage_options,
-                manifest=serialized_manifest,
-                ns_impl=namespace_impl,
-                ns_props=namespace_properties,
-                tbl_id=table_id,
-                scanner_options=self._scanner_options,
-                retry_params=self._retry_params: _read_fragments_with_retry(
-                    fids,
-                    uri,
-                    version,
-                    storage_options,
-                    manifest,
-                    ns_impl,
-                    ns_props,
-                    tbl_id,
-                    scanner_options,
-                    retry_params,
+                lambda fids=fragment_ids, uri=dataset_uri, version=dataset_version, storage_options=dataset_storage_options, manifest=serialized_manifest, ns_impl=namespace_impl, ns_props=namespace_properties, tbl_id=table_id, scanner_options=self._scanner_options, retry_params=self._retry_params: (
+                    _read_fragments_with_retry(
+                        fids,
+                        uri,
+                        version,
+                        storage_options,
+                        manifest,
+                        ns_impl,
+                        ns_props,
+                        tbl_id,
+                        scanner_options,
+                        retry_params,
+                    )
                 ),
                 metadata,
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=2.0.0b10",
+    "pylance>=2.0.0rc4",
     "lance-namespace",
     "pyarrow>=17.0.0",
     "more_itertools>=2.6.0; python_version<'3.12'",

--- a/uv.lock
+++ b/uv.lock
@@ -387,7 +387,7 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.0.0" },
     { name = "more-itertools", marker = "python_full_version < '3.12'", specifier = ">=2.6.0" },
     { name = "pyarrow", specifier = ">=17.0.0" },
-    { name = "pylance", specifier = ">=2.0.0b10" },
+    { name = "pylance", specifier = ">=2.0.0rc4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
@@ -1025,7 +1025,7 @@ wheels = [
 
 [[package]]
 name = "pylance"
-version = "2.0.0b10"
+version = "2.0.0rc4"
 source = { registry = "https://pypi.fury.io/lance-format" }
 dependencies = [
     { name = "lance-namespace" },
@@ -1034,12 +1034,11 @@ dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://pypi.fury.io/lance-format/-/ver_9UwtW/pylance-2.0.0b10-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:39e28b440c8a48c6042c89ca750b8f7109129131935116288bca8c83a467551d" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_2dIMLX/pylance-2.0.0b10-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f89da60e8be4070ce71cc24b438153044e91b13fb63d0903a7ea62531bdfe1f4" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1sMiqd/pylance-2.0.0b10-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d525378fe5293aefcbf2e6a5efaa408fa5ee413e99c7a32393ec3045ecb94d2" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1Gjz7s/pylance-2.0.0b10-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ce6a385783dd10d48b8f11ee85e91ed4967aa7d82e1d6784ea71cc71e4605716" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_20bLNa/pylance-2.0.0b10-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:946d36adc2e6ee189ad5bb1d9061d2943b7ad0b381196b8431bb743c41cd5312" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_2eqBKc/pylance-2.0.0b10-cp39-abi3-win_amd64.whl", hash = "sha256:e9fd39080bdf7fa23999f9f863f885b3fbefef3ca703968f6c1b7a3806d627da" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_LsnYx/pylance-2.0.0rc4-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:86a1f6f246b37d9e2431b6454246d4b69b2b1490007d750683645284752acac5" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1i0bJA/pylance-2.0.0rc4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:23d8715ba1ea3a65583c49034f611a9d04c6688ac25d9ef08ccec5267792c247" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1PFJs4/pylance-2.0.0rc4-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b48e81bf698dba6477a921060305c3f0ab8fdf45018390b34fd77ee4d5c2e85f" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1HgqEy/pylance-2.0.0rc4-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a02006f2be9e84c23cb9acf21d6eb15ae5009b0d08c3ab4ded5934d67b263134" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_2eNZY8/pylance-2.0.0rc4-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2add4971c3ad178a8cf913d2e77089ba4b1d83ef3267d54ade225f33348cb5d4" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump pylance dependency to v2.0.0rc4.
- Regenerate uv.lock for the new version.
- Apply formatting adjustments from ruff.

## Testing
- make lint

## Reference
- refs/tags/v2.0.0-rc.4
