### PR TITLE
fix: remove redundant pool.close() in _map_async_with_pool

### DIFF
--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -124,7 +124,6 @@ def _map_async_with_pool(
     try:
         results = rst_futures.get()
     except Exception as exc:  # pragma: no cover - exercised via integration tests
-        pool.close()
         raise RuntimeError(f"{error_prefix}: {exc}") from exc
     finally:
         pool.close()


### PR DESCRIPTION
https://github.com/lance-format/lance-ray/issues/2301
The `except` block called `pool.close()` before re-raising, but the                                                                                                                             
  `finally` block unconditionally calls `pool.close()` as well, resulting                                                                                                                         
  in a double-close on every exception path.                                                                                                                                                      
                                                                                                                                                                                                  
  Remove the redundant call from the `except` block and let `finally`
  handle cleanup exclusively, which is the correct pattern for
  try/except/finally resource management.