### PR TITLE
fix: remove redundant pool.close() in compact_files

### DIFF
--- a/lance_ray/compaction.py
+++ b/lance_ray/compaction.py
@@ -184,7 +184,6 @@ def compact_files(
     try:
         results = rst_futures.get()
     except Exception as e:
-        pool.close()
         raise RuntimeError(f"Failed to complete distributed compaction: {e}") from e
     finally:
         pool.close()


### PR DESCRIPTION
seealso： https://github.com/lance-format/lance-ray/issues/2484
Same double-close pattern as fixed in _map_async_with_pool: the                                                                                                                                 
  `except` block called `pool.close()` before re-raising, but `finally`                                                                                                                           
  unconditionally calls it again.                                                                                                                                                                 
                                                                                                                                                                                                  
  Remove the redundant call from the `except` block and let `finally`
  handle cleanup exclusively.