### PR TITLE
fix: adapt pylance api to latest pylance 4.0

### DIFF
--- a/lance_ray/compaction.py
+++ b/lance_ray/compaction.py
@@ -7,7 +7,7 @@ from lance.optimize import Compaction, CompactionOptions, CompactionTask
 from ray.util.multiprocessing import Pool
 
 from .utils import (
-    create_storage_options_provider,
+    get_namespace_kwargs,
     get_or_create_namespace,
     validate_uri_or_namespace,
 )
@@ -39,8 +39,7 @@ def _handle_compaction_task(
             Dictionary with status and result information
         """
         try:
-            # Create storage options provider in worker for credentials refresh
-            storage_options_provider = create_storage_options_provider(
+            namespace_kwargs = get_namespace_kwargs(
                 namespace_impl, namespace_properties, table_id
             )
 
@@ -48,7 +47,7 @@ def _handle_compaction_task(
             dataset = lance.LanceDataset(
                 dataset_uri,
                 storage_options=storage_options,
-                storage_options_provider=storage_options_provider,
+                **namespace_kwargs,
             )
 
             logger.info(f"Executing compaction task for fragments {task.fragments}")
@@ -133,16 +132,13 @@ def compact_files(
         if describe_response.storage_options:
             merged_storage_options.update(describe_response.storage_options)
 
-    # Create storage options provider for local operations
-    storage_options_provider = create_storage_options_provider(
-        namespace_impl, namespace_properties, table_id
-    )
+    namespace_kwargs = get_namespace_kwargs(namespace_impl, namespace_properties, table_id)
 
     # Load dataset
     dataset = lance.LanceDataset(
         uri,
         storage_options=merged_storage_options,
-        storage_options_provider=storage_options_provider,
+        **namespace_kwargs,
     )
 
     logger.info("Starting distributed compaction")

--- a/lance_ray/datasink.py
+++ b/lance_ray/datasink.py
@@ -15,7 +15,7 @@ from ray.data._internal.util import _check_import
 from ray.data.datasource.datasink import Datasink
 
 from .fragment import write_fragment
-from .utils import create_storage_options_provider, get_or_create_namespace
+from .utils import get_namespace_kwargs, get_or_create_namespace
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -74,7 +74,6 @@ class _BaseLanceDatasink(Datasink):
 
         if namespace is not None and table_id is not None:
             self.table_id = table_id
-            has_namespace_storage_options = False
 
             if mode == "append":
                 # For append mode, we need to get existing table URI
@@ -83,7 +82,6 @@ class _BaseLanceDatasink(Datasink):
                 self.uri = describe_response.location
                 if describe_response.storage_options:
                     merged_storage_options.update(describe_response.storage_options)
-                    has_namespace_storage_options = True
             elif mode == "overwrite":
                 # For overwrite mode, try to get existing table, fallback to declare
                 try:
@@ -92,7 +90,6 @@ class _BaseLanceDatasink(Datasink):
                     self.uri = describe_response.location
                     if describe_response.storage_options:
                         merged_storage_options.update(describe_response.storage_options)
-                        has_namespace_storage_options = True
                 except Exception:
                     uri, ns_storage_options = _declare_table_with_fallback(
                         namespace, table_id
@@ -100,7 +97,6 @@ class _BaseLanceDatasink(Datasink):
                     self.uri = uri
                     if ns_storage_options:
                         merged_storage_options.update(ns_storage_options)
-                        has_namespace_storage_options = True
             else:
                 # create mode, declare a new table
                 uri, ns_storage_options = _declare_table_with_fallback(
@@ -109,14 +105,9 @@ class _BaseLanceDatasink(Datasink):
                 self.uri = uri
                 if ns_storage_options:
                     merged_storage_options.update(ns_storage_options)
-                    has_namespace_storage_options = True
-
-            # Mark that we have namespace storage options for provider creation
-            self._has_namespace_storage_options = has_namespace_storage_options
         else:
             self.table_id = None
             self.uri = uri
-            self._has_namespace_storage_options = False
 
         self.schema = schema
         self.mode = mode
@@ -124,11 +115,9 @@ class _BaseLanceDatasink(Datasink):
         self.storage_options = merged_storage_options
 
     @property
-    def storage_options_provider(self):
-        """Lazily create storage options provider using namespace_impl/properties."""
-        if not self._has_namespace_storage_options:
-            return None
-        return create_storage_options_provider(
+    def namespace_kwargs(self) -> dict[str, Any]:
+        """Namespace wiring for pylance credential refresh."""
+        return get_namespace_kwargs(
             self._namespace_impl, self._namespace_properties, self.table_id
         )
 
@@ -145,7 +134,7 @@ class _BaseLanceDatasink(Datasink):
             ds = lance.LanceDataset(
                 self.uri,
                 storage_options=self.storage_options,
-                storage_options_provider=self.storage_options_provider,
+                **self.namespace_kwargs,
             )
             self.read_version = ds.version
             if self.schema is None:
@@ -191,7 +180,28 @@ class _BaseLanceDatasink(Datasink):
             return
         op = None
         if self.mode in {"create", "overwrite"}:
-            op = lance.LanceOperation.Overwrite(schema, fragments)
+            initial_bases = None
+            blob_v2_columns = [
+                field.name
+                for field in schema
+                if isinstance(field.type, pa.ExtensionType)
+                and getattr(field.type, "extension_name", None) == "lance.blob.v2"
+            ]
+            if blob_v2_columns:
+                initial_bases = [
+                    lance.DatasetBasePath(
+                        "file:///",
+                        name="external_file",
+                        is_dataset_root=False,
+                        id=1,
+                    )
+                ]
+
+            op = lance.LanceOperation.Overwrite(
+                schema,
+                fragments,
+                initial_bases=initial_bases,
+            )
         elif self.mode == "append":
             op = lance.LanceOperation.Append(fragments)
         if op:
@@ -200,7 +210,7 @@ class _BaseLanceDatasink(Datasink):
                 op,
                 read_version=self.read_version,
                 storage_options=self.storage_options,
-                storage_options_provider=self.storage_options_provider,
+                **self.namespace_kwargs,
             )
 
 

--- a/lance_ray/datasource.py
+++ b/lance_ray/datasource.py
@@ -9,7 +9,7 @@ from ray.data.context import DataContext
 from ray.data.datasource import Datasource
 from ray.data.datasource.datasource import ReadTask
 
-from .utils import array_split, create_storage_options_provider, get_or_create_namespace
+from .utils import array_split, get_namespace_kwargs, get_or_create_namespace
 
 if TYPE_CHECKING:
     import lance
@@ -83,9 +83,6 @@ class LanceDatasource(Datasource):
             dataset_options["namespace"] = self._namespace
             dataset_options["table_id"] = self._table_id
             dataset_options["storage_options"] = self._storage_options
-            # Note: lance.dataset() doesn't accept storage_options_provider.
-            # When namespace is provided, it handles credential refresh internally.
-            # For workers, we pass namespace_impl/properties to reconstruct the provider.
             self._lance_ds = lance.dataset(**dataset_options)
         return self._lance_ds
 
@@ -200,8 +197,7 @@ def _read_fragments_with_retry(
     scanner_options: dict[str, Any],
     retry_params: dict[str, Any],
 ) -> Iterator[pa.Table]:
-    # Reconstruct storage options provider on worker for credential refresh
-    storage_options_provider = create_storage_options_provider(
+    namespace_kwargs = get_namespace_kwargs(
         namespace_impl, namespace_properties, table_id
     )
 
@@ -212,7 +208,7 @@ def _read_fragments_with_retry(
         version=version,
         storage_options=storage_options,
         serialized_manifest=manifest,
-        storage_options_provider=storage_options_provider,
+        **namespace_kwargs,
     )
 
     return call_with_retry(
@@ -332,31 +328,103 @@ def _read_fragments(
                 continue
 
             # The scanned representation may be a struct descriptor or extension-backed
-            # array. We only rely on the null bitmap: None -> null bytes; non-null ->
-            # fetch bytes via LanceDataset.take_blobs.
+            # array. We rely on the scan output to decide whether a given row is null,
+            # but we must be careful about how ``take_blobs`` aligns its results:
+            #
+            # - Legacy blob columns often return one handle per requested row ID
+            #   (including null rows).
+            # - Blob v2 currently *skips* null rows, returning fewer handles.
             desc_py = table.column(col).to_pylist()
 
             # Fetch BlobFile handles in batch order
             blob_files = lance_ds.take_blobs(col, ids=row_ids)
 
-            # Convert BlobFile -> bytes, respecting nulls
             values: list[Optional[bytes]] = []
-            for i, desc in enumerate(desc_py):
-                if desc is None:
-                    values.append(None)
-                    continue
-                # Backward compatibility: older legacy blob layouts may encode
-                # nulls as a sentinel struct {position: 1, size: 0} instead of
-                # using the Arrow null bitmap. Treat this sentinel as null for
-                # metadata-based blob columns only.
-                if kind == "legacy" and isinstance(desc, dict):
-                    pos = desc.get("position")
-                    size = desc.get("size")
-                    if pos == 1 and size == 0:
+
+            if len(blob_files) == len(desc_py):
+                # 1:1 alignment with requested rows (legacy behavior).
+                for desc, blob_file in zip(desc_py, blob_files, strict=False):
+                    if desc is None:
                         values.append(None)
                         continue
-                with blob_files[i] as bf:
-                    values.append(bf.read())
+
+                    if kind == "legacy" and isinstance(desc, dict):
+                        pos = desc.get("position")
+                        size = desc.get("size")
+                        if pos == 1 and size == 0:
+                            values.append(None)
+                            continue
+
+                    if kind == "v2" and isinstance(desc, dict):
+                        v2_pos = desc.get("position")
+                        v2_size = desc.get("size")
+                        v2_blob_id = desc.get("blob_id")
+                        v2_uri = desc.get("blob_uri")
+                        if (
+                            v2_pos == 0
+                            and v2_size == 0
+                            and v2_blob_id == 0
+                            and (v2_uri == "" or v2_uri is None)
+                        ):
+                            values.append(None)
+                            continue
+
+                    if kind != "legacy":
+                        if isinstance(desc, bytes | bytearray | memoryview):
+                            values.append(bytes(desc))
+                            continue
+                        if isinstance(desc, dict) and "bytes" in desc:
+                            values.append(bytes(desc["bytes"]))
+                            continue
+
+                    with blob_file as bf:
+                        values.append(bf.read())
+            else:
+                # Sparse alignment (blob v2 behavior): consume a handle only for
+                # non-null rows.
+                blob_iter = iter(blob_files)
+                for desc in desc_py:
+                    if desc is None:
+                        values.append(None)
+                        continue
+
+                    if kind == "legacy" and isinstance(desc, dict):
+                        pos = desc.get("position")
+                        size = desc.get("size")
+                        if pos == 1 and size == 0:
+                            values.append(None)
+                            continue
+
+                    if kind == "v2" and isinstance(desc, dict):
+                        v2_pos = desc.get("position")
+                        v2_size = desc.get("size")
+                        v2_blob_id = desc.get("blob_id")
+                        v2_uri = desc.get("blob_uri")
+                        if (
+                            v2_pos == 0
+                            and v2_size == 0
+                            and v2_blob_id == 0
+                            and (v2_uri == "" or v2_uri is None)
+                        ):
+                            values.append(None)
+                            continue
+
+                    if kind != "legacy":
+                        if isinstance(desc, bytes | bytearray | memoryview):
+                            values.append(bytes(desc))
+                            continue
+                        if isinstance(desc, dict) and "bytes" in desc:
+                            values.append(bytes(desc["bytes"]))
+                            continue
+
+                    try:
+                        blob_file = next(blob_iter)
+                    except StopIteration as exc:  # pragma: no cover
+                        raise RuntimeError(
+                            "LanceDataset.take_blobs returned fewer blobs than expected"
+                        ) from exc
+                    with blob_file as bf:
+                        values.append(bf.read())
 
             # Construct LargeBinary array for Ray, preserving legacy metadata only
             # for metadata-based blob columns. Blob v2 extension columns are exposed

--- a/lance_ray/fragment.py
+++ b/lance_ray/fragment.py
@@ -11,6 +11,7 @@ from typing import (
     Optional,
     Union,
 )
+from urllib.parse import urlparse
 
 import pyarrow as pa
 from ray.data._internal.util import call_with_retry
@@ -26,7 +27,7 @@ __all__ = [
 ]
 
 from .pandas import pd_to_arrow
-from .utils import create_storage_options_provider
+from .utils import get_write_fragments_kwargs
 
 
 def write_fragment(
@@ -48,8 +49,13 @@ def write_fragment(
     from lance.dependencies import pandas as pd
     from lance.fragment import DEFAULT_MAX_BYTES_PER_FILE, write_fragments
 
+    stream_iter = iter(stream)
+    try:
+        first = next(stream_iter)
+    except StopIteration:
+        return []
+
     if schema is None:
-        first = next(iter(stream))
         if _PANDAS_AVAILABLE and isinstance(first, pd.DataFrame):
             schema = pa.Schema.from_pandas(first).remove_metadata()
         elif isinstance(first, dict):
@@ -57,11 +63,11 @@ def write_fragment(
             schema = tbl.schema.remove_metadata()
         else:
             schema = first.schema
-        if len(schema.names) == 0:
-            # Empty table.
-            schema = None
 
-        stream = chain([first], stream)
+    if schema is None or len(schema.names) == 0:
+        return []
+
+    stream = chain([first], stream_iter)
 
     def record_batch_converter():
         for block in stream:
@@ -83,10 +89,54 @@ def write_fragment(
             "max_backoff_s": 0,
         }
 
-    # Create storage options provider from namespace parameters
-    storage_options_provider = create_storage_options_provider(
+    write_kwargs = get_write_fragments_kwargs(
         namespace_impl, namespace_properties, table_id
     )
+
+    blob_v2_columns = [
+        field.name
+        for field in schema
+        if isinstance(field.type, pa.ExtensionType)
+        and getattr(field.type, "extension_name", None) == "lance.blob.v2"
+    ]
+    if blob_v2_columns:
+        import inspect
+
+        try:
+            write_sig = inspect.signature(write_fragments)
+        except (AttributeError, ValueError):  # pragma: no cover
+            write_sig = None
+
+        if write_sig is not None and "allow_external_blob_outside_bases" in write_sig.parameters:
+            write_kwargs.setdefault("allow_external_blob_outside_bases", True)
+
+        tbl_first = pd_to_arrow(first, schema)
+        has_external_file_blobs = False
+        for col in blob_v2_columns:
+            for item in tbl_first.column(col).to_pylist():
+                if not isinstance(item, dict):
+                    continue
+                uri_value = item.get("uri")
+                if not uri_value:
+                    continue
+                if urlparse(uri_value).scheme == "file":
+                    has_external_file_blobs = True
+                    break
+            if has_external_file_blobs:
+                break
+
+        if has_external_file_blobs:
+            import lance
+
+            initial_bases = [
+                lance.DatasetBasePath(
+                    "file:///",
+                    name="external_file",
+                    is_dataset_root=False,
+                    id=1,
+                )
+            ]
+            write_kwargs = {**write_kwargs, "initial_bases": initial_bases}
 
     fragments = call_with_retry(
         lambda: write_fragments(
@@ -98,7 +148,7 @@ def write_fragment(
             max_bytes_per_file=max_bytes_per_file,
             data_storage_version=data_storage_version,
             storage_options=storage_options,
-            storage_options_provider=storage_options_provider,
+            **write_kwargs,
         ),
         **retry_params,
     )

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -13,7 +13,7 @@ from packaging import version
 from ray.util.multiprocessing import Pool
 
 from .utils import (
-    create_storage_options_provider,
+    get_namespace_kwargs,
     get_or_create_namespace,
     validate_uri_or_namespace,
 )
@@ -160,8 +160,7 @@ def _handle_fragment_index(
                 if fragment_id < 0 or fragment_id > 0xFFFFFFFF:
                     raise ValueError(f"Invalid fragment_id: {fragment_id}")
 
-            # Create storage options provider in worker for credentials refresh
-            storage_options_provider = create_storage_options_provider(
+            namespace_kwargs = get_namespace_kwargs(
                 namespace_impl, namespace_properties, table_id
             )
 
@@ -169,7 +168,7 @@ def _handle_fragment_index(
             dataset = LanceDataset(
                 dataset_uri,
                 storage_options=storage_options,
-                storage_options_provider=storage_options_provider,
+                **namespace_kwargs,
             )
 
             available_fragments = {f.fragment_id for f in dataset.get_fragments()}
@@ -372,16 +371,13 @@ def create_scalar_index(
         if describe_response.storage_options:
             merged_storage_options.update(describe_response.storage_options)
 
-    # Create storage options provider for local operations
-    storage_options_provider = create_storage_options_provider(
-        namespace_impl, namespace_properties, table_id
-    )
+    namespace_kwargs = get_namespace_kwargs(namespace_impl, namespace_properties, table_id)
 
     # Load dataset
     dataset = LanceDataset(
         uri,
         storage_options=merged_storage_options,
-        storage_options_provider=storage_options_provider,
+        **namespace_kwargs,
     )
 
     try:
@@ -423,7 +419,23 @@ def create_scalar_index(
     if name is None:
         name = f"{column}_idx"
 
-    if not replace:
+    if replace:
+        try:
+            existing_indices = dataset.list_indices()
+        except Exception:  # pragma: no cover
+            existing_indices = []
+
+        if any(idx.get("name") == name for idx in existing_indices):
+            # Lance 4.0.0: fragment_ids + replace=True may hit an unimplemented path.
+            # Implement replace semantics at the driver by dropping the index first.
+            dataset.drop_index(name)
+            dataset = LanceDataset(
+                uri,
+                storage_options=merged_storage_options,
+                **namespace_kwargs,
+            )
+
+    else:
         index_exists = False
         try:
             existing_indices = dataset.list_indices()
@@ -465,7 +477,7 @@ def create_scalar_index(
         index_type=index_type,
         name=name,
         index_uuid=index_id,
-        replace=replace,
+        replace=False,
         train=train,
         storage_options=merged_storage_options,
         namespace_impl=namespace_impl,
@@ -497,7 +509,7 @@ def create_scalar_index(
     dataset = LanceDataset(
         uri,
         storage_options=merged_storage_options,
-        storage_options_provider=storage_options_provider,
+        **namespace_kwargs,
     )
 
     logger.info("Phase 2: Merging index metadata for index ID: %s", index_id)
@@ -530,7 +542,7 @@ def create_scalar_index(
         create_index_op,
         read_version=dataset.version,
         storage_options=merged_storage_options,
-        storage_options_provider=storage_options_provider,
+        **namespace_kwargs,
     )
 
     logger.info(
@@ -659,14 +671,13 @@ def _handle_vector_fragment_index(
                 if fragment_id < 0 or fragment_id > 0xFFFFFFFF:
                     raise ValueError(f"Invalid fragment_id: {fragment_id}")
 
-            # Create storage options provider in worker for credentials refresh
-            storage_options_provider = create_storage_options_provider(
+            namespace_kwargs = get_namespace_kwargs(
                 namespace_impl, namespace_properties, table_id
             )
             dataset = LanceDataset(
                 dataset_uri,
                 storage_options=storage_options,
-                storage_options_provider=storage_options_provider,
+                **namespace_kwargs,
             )
             available_fragments = {f.fragment_id for f in dataset.get_fragments()}
             invalid_fragments = set(fragment_ids) - available_fragments
@@ -679,7 +690,7 @@ def _handle_vector_fragment_index(
                 fragment_ids,
             )
 
-            dataset.create_index(
+            segment_index = dataset.create_index_uncommitted(
                 column=column,
                 index_type=index_type,
                 name=name,
@@ -692,14 +703,8 @@ def _handle_vector_fragment_index(
                 storage_options=storage_options,
                 train=True,
                 fragment_ids=fragment_ids,
-                index_uuid=index_uuid,
                 **kwargs,
             )
-
-            lance_field = dataset.lance_schema.field(column)
-            if lance_field is None:
-                raise KeyError(f"{column} not found in schema")
-            field_id = lance_field.id()
 
             logger.info(
                 "Fragment vector index created successfully for fragments %s",
@@ -709,8 +714,8 @@ def _handle_vector_fragment_index(
             return {
                 "status": "success",
                 "fragment_ids": fragment_ids,
-                "fields": [field_id],
-                "uuid": index_uuid,
+                "segment_index": segment_index,
+                "uuid": getattr(segment_index, "uuid", index_uuid),
             }
 
         except Exception as exc:  # pragma: no cover - exercised via integration tests
@@ -812,13 +817,13 @@ def create_index(
                 merged_storage_options.update(describe_response.storage_options)
 
         dataset_uri = uri
-        storage_options_provider = create_storage_options_provider(
+        namespace_kwargs = get_namespace_kwargs(
             namespace_impl, namespace_properties, table_id
         )
         dataset_obj = LanceDataset(
             dataset_uri,
             storage_options=merged_storage_options,
-            storage_options_provider=storage_options_provider,
+            **namespace_kwargs,
         )
     else:
         # LanceDataset object passed directly
@@ -826,7 +831,7 @@ def create_index(
         dataset_uri = dataset_obj.uri
         if not merged_storage_options:
             merged_storage_options = getattr(dataset_obj, "_storage_options", None) or {}
-        storage_options_provider = None
+        namespace_kwargs = {}
 
     try:
         dataset_obj.schema.field(column)
@@ -881,17 +886,15 @@ def create_index(
     num_rows = dataset_obj.count_rows()
     dimension = builder.dimension
 
-    computed_num_partitions = builder._determine_num_partitions(
-        num_partitions, num_rows
-    )
+    requested_num_partitions = num_partitions
     logger.info(
-        "Training IVF with num_partitions=%d, num_rows=%d, dimension=%d",
-        computed_num_partitions,
+        "Training IVF with requested_num_partitions=%s, num_rows=%d, dimension=%d",
+        requested_num_partitions,
         num_rows,
         dimension,
     )
     ivf_model = builder.train_ivf(
-        num_partitions=computed_num_partitions,
+        num_partitions=requested_num_partitions,
         distance_type=metric_lower,
     )
     ivf_centroids_artifact = ivf_model.centroids
@@ -902,21 +905,19 @@ def create_index(
     )
 
     if needs_pq:
-        computed_num_sub_vectors = builder._normalize_pq_params(
-            num_sub_vectors, dimension
-        )
+        requested_num_sub_vectors = num_sub_vectors
         logger.info(
-            "Training PQ codebook: num_sub_vectors=%d, sample_rate=%d",
-            computed_num_sub_vectors,
+            "Training PQ codebook: requested_num_sub_vectors=%s, sample_rate=%d",
+            requested_num_sub_vectors,
             kwargs.get("sample_rate", 256),
         )
         pq_model = builder.train_pq(
             ivf_model,
-            computed_num_sub_vectors,
+            num_subvectors=requested_num_sub_vectors,
             sample_rate=kwargs.get("sample_rate", 256),
         )
         pq_codebook_artifact = pq_model.codebook
-        num_sub_vectors = computed_num_sub_vectors
+        num_sub_vectors = pq_model.num_subvectors
         logger.info("PQ training completed: num_sub_vectors=%d", num_sub_vectors)
 
     if ivf_centroids_artifact is None:
@@ -976,49 +977,32 @@ def create_index(
     dataset_obj = LanceDataset(
         dataset_uri,
         storage_options=merged_storage_options,
-        storage_options_provider=storage_options_provider,
+        **namespace_kwargs,
     )
 
-    logger.info("Phase 3: Merging index metadata for index ID: %s", index_id)
-    merge_index_metadata_compat(
-        dataset_obj,
-        index_id,
-        index_type=index_type_name,
-        **kwargs,
+    logger.info(
+        "Phase 3: Building and committing index segments for vector index '%s'",
+        name,
     )
-
-    logger.info("Phase 4: Creating and committing vector index '%s'", name)
 
     successful_results = [r for r in results if r.get("status") == "success"]
     if not successful_results:
         raise RuntimeError("No successful vector index creation results found")
 
-    fields = successful_results[0]["fields"]
-
-    index = Index(
-        uuid=index_id,
-        name=name,
-        fields=fields,
-        dataset_version=dataset_obj.version,
-        fragment_ids=set(fragment_ids_to_use),
-        index_version=0,
+    segment_indices = [r["segment_index"] for r in successful_results]
+    segment_builder = dataset_obj.create_index_segment_builder().with_segments(
+        segment_indices
     )
+    segments = segment_builder.build_all()
 
-    create_index_op = lance.LanceOperation.CreateIndex(
-        new_indices=[index],
-        removed_indices=[],
-    )
-
-    updated_dataset = lance.LanceDataset.commit(
-        dataset_uri,
-        create_index_op,
-        read_version=dataset_obj.version,
-        storage_options=merged_storage_options,
-        storage_options_provider=storage_options_provider,
+    updated_dataset = dataset_obj.commit_existing_index_segments(
+        index_name=name,
+        column=column,
+        segments=segments,
     )
 
     logger.info(
-        "Successfully created distributed vector index '%s' with multi-phase workflow",
+        "Successfully created distributed vector index '%s'",
         name,
     )
     logger.info(
@@ -1123,14 +1107,12 @@ def optimize_indices(
             uri,
         )
 
-    storage_options_provider = create_storage_options_provider(
-        namespace_impl, namespace_properties, table_id
-    )
+    namespace_kwargs = get_namespace_kwargs(namespace_impl, namespace_properties, table_id)
 
     dataset = LanceDataset(
         uri,
         storage_options=merged_storage_options,
-        storage_options_provider=storage_options_provider,
+        **namespace_kwargs,
     )
     logger.info(
         "Loaded dataset: uri=%s, version=%s",

--- a/lance_ray/io.py
+++ b/lance_ray/io.py
@@ -15,7 +15,7 @@ from ray.util.multiprocessing import Pool
 from .datasink import LanceDatasink
 from .datasource import LanceDatasource
 from .utils import (
-    create_storage_options_provider,
+    get_namespace_kwargs,
     has_namespace_params,
     validate_uri_or_namespace,
 )
@@ -382,16 +382,15 @@ def _handle_fragment(
     """
 
     def func(fragment_id: int):
-        # Create storage options provider in worker for credentials refresh
-        storage_options_provider = create_storage_options_provider(
+        namespace_kwargs = get_namespace_kwargs(
             namespace_impl, namespace_properties, table_id
         )
 
         lance_ds = LanceDataset(
             uri=uri,
             storage_options=storage_options,
-            storage_options_provider=storage_options_provider,
             version=read_version,
+            **namespace_kwargs,
         )
         fragment = lance_ds.get_fragment(fragment_id)
         fragment_meta, schema = fragment.merge_columns(
@@ -461,16 +460,13 @@ def add_columns(
     """
     storage_options = storage_options or {}
 
-    # Create storage options provider for local operations
-    storage_options_provider = create_storage_options_provider(
-        namespace_impl, namespace_properties, table_id
-    )
+    namespace_kwargs = get_namespace_kwargs(namespace_impl, namespace_properties, table_id)
 
     lance_ds = LanceDataset(
         uri=uri,
         storage_options=storage_options,
-        storage_options_provider=storage_options_provider,
         version=read_version,
+        **namespace_kwargs,
     )
     fragment_ids = [f.metadata.id for f in lance_ds.get_fragments()]
     pool = Pool(processes=concurrency, ray_remote_args=ray_remote_args)
@@ -517,7 +513,7 @@ def add_columns(
         op,
         read_version=lance_ds.version,
         storage_options=storage_options,
-        storage_options_provider=storage_options_provider,
+        **namespace_kwargs,
     )
 
 

--- a/lance_ray/utils.py
+++ b/lance_ray/utils.py
@@ -1,8 +1,9 @@
+import inspect
 import os
 import sys
 from collections.abc import Iterable, Sequence
 from functools import lru_cache
-from typing import Optional, TypeVar
+from typing import Any, Optional, TypeVar
 
 T = TypeVar("T")
 
@@ -99,29 +100,31 @@ def get_or_create_namespace(
     return _get_cached_namespace(namespace_impl, namespace_properties_tuple)
 
 
+@lru_cache(maxsize=1)
+def _lance_namespace_kw() -> str:
+    import lance
+
+    params = inspect.signature(lance.dataset).parameters
+    if "namespace_client" in params:
+        return "namespace_client"
+    if "namespace" in params:
+        return "namespace"
+    return ""
+
+
+@lru_cache(maxsize=1)
+def _lance_supports_storage_options_provider() -> bool:
+    import lance
+
+    params = inspect.signature(lance.dataset).parameters
+    return "storage_options_provider" in params
+
+
 def create_storage_options_provider(
     namespace_impl: Optional[str],
     namespace_properties: Optional[dict[str, str]],
     table_id: Optional[list[str]],
 ):
-    """Create a LanceNamespaceStorageOptionsProvider if namespace parameters are provided.
-
-    This function reconstructs a namespace connection and creates a storage options
-    provider for credential refresh in distributed workers. Workers receive serializable
-    namespace_impl/properties/table_id instead of the non-serializable namespace object.
-
-    The namespace client is cached per-worker to avoid redundant connection overhead
-    across multiple task invocations within the same Ray worker.
-
-    Args:
-        namespace_impl: The namespace implementation type (e.g., "rest", "dir").
-        namespace_properties: Properties for connecting to the namespace (can be None).
-        table_id: The table identifier as a list of strings.
-
-    Returns:
-        LanceNamespaceStorageOptionsProvider if namespace_impl and table_id are provided,
-        None otherwise.
-    """
     if not has_namespace_params(namespace_impl, table_id):
         return None
 
@@ -129,9 +132,64 @@ def create_storage_options_provider(
     if namespace is None:
         return None
 
-    from lance import LanceNamespaceStorageOptionsProvider
+    import lance
 
-    return LanceNamespaceStorageOptionsProvider(namespace=namespace, table_id=table_id)
+    if not hasattr(lance, "LanceNamespaceStorageOptionsProvider"):
+        return None
+
+    return lance.LanceNamespaceStorageOptionsProvider(namespace=namespace, table_id=table_id)
+
+
+def get_namespace_kwargs(
+    namespace_impl: Optional[str],
+    namespace_properties: Optional[dict[str, str]],
+    table_id: Optional[list[str]],
+) -> dict[str, Any]:
+    """Return kwargs for pylance namespace / auth integration.
+
+    pylance 4.0.0 uses: `namespace`, `table_id`, `storage_options_provider`.
+    Newer pylance versions may use `namespace_client` instead of `namespace`.
+
+    This helper hides those naming differences and keeps call sites simple.
+    """
+    if not has_namespace_params(namespace_impl, table_id):
+        return {}
+
+    namespace = get_or_create_namespace(namespace_impl, namespace_properties)
+    if namespace is None:
+        return {}
+
+    kwargs: dict[str, Any] = {}
+    namespace_kw = _lance_namespace_kw()
+    if namespace_kw:
+        kwargs[namespace_kw] = namespace
+    kwargs["table_id"] = table_id
+
+    if _lance_supports_storage_options_provider():
+        provider = create_storage_options_provider(
+            namespace_impl, namespace_properties, table_id
+        )
+        if provider is not None:
+            kwargs["storage_options_provider"] = provider
+
+    return kwargs
+
+
+def get_write_fragments_kwargs(
+    namespace_impl: Optional[str],
+    namespace_properties: Optional[dict[str, str]],
+    table_id: Optional[list[str]],
+) -> dict[str, Any]:
+    """Return kwargs for `lance.fragment.write_fragments`.
+
+    pylance 4.0.0 supports `storage_options_provider` on write_fragments, but not
+    `namespace` / `table_id`.
+    """
+    provider = create_storage_options_provider(namespace_impl, namespace_properties, table_id)
+    if provider is None:
+        return {}
+
+    return {"storage_options_provider": provider}
 
 
 if sys.version_info >= (3, 12):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "lance-ray"
 version = "0.2.0"
 description = "Ray integration for Lance"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 license = {file = "LICENSE"}
 authors = [{ name = "LanceDB Devs", email = "dev@lancedb.com" }]
 keywords = ["ray", "lance", "distributed", "columnar", "data"]
@@ -24,17 +24,17 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=2.0.0",
+    "pylance>=4.0.0",
     "lance-namespace",
     "pyarrow>=17.0.0",
+    "pytest>=8.4.0",
+    "pytest-cov>=5.0.0",
     "more_itertools>=2.6.0; python_version<'3.12'",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=8.4.0",
     "pytest-asyncio>=1.0.0",
-    "pytest-cov>=5.0.0",
     "pytest-xdist>=3.6.0",
     "ruff>=0.8.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,9 +1,8 @@
 version = 1
 revision = 3
-requires-python = ">=3.10"
+requires-python = ">=3.10, <3.14"
 resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version == '3.12.*'",
+    "python_full_version >= '3.12'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -45,7 +44,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/55/07/f0b3375bf0d06014e9787797e6b7cc02b38ac9ff9726ccfe834d94e9991e/backrefs-5.9-py311-none-any.whl", hash = "sha256:6907635edebbe9b2dc3de3a2befff44d74f30a4562adbb8b36f21252ea19c5cf", size = 392072, upload-time = "2025-06-22T19:34:06.743Z" },
     { url = "https://files.pythonhosted.org/packages/9d/12/4f345407259dd60a0997107758ba3f221cf89a9b5a0f8ed5b961aef97253/backrefs-5.9-py312-none-any.whl", hash = "sha256:7fdf9771f63e6028d7fee7e0c497c81abda597ea45d6b8f89e8ad76994f5befa", size = 397947, upload-time = "2025-06-22T19:34:08.172Z" },
     { url = "https://files.pythonhosted.org/packages/10/bf/fa31834dc27a7f05e5290eae47c82690edc3a7b37d58f7fb35a1bdbf355b/backrefs-5.9-py313-none-any.whl", hash = "sha256:cc37b19fa219e93ff825ed1fed8879e47b4d89aa7a1884860e2db64ccd7c676b", size = 399843, upload-time = "2025-06-22T19:34:09.68Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/24/b29af34b2c9c41645a9f4ff117bae860291780d73880f449e0b5d948c070/backrefs-5.9-py314-none-any.whl", hash = "sha256:df5e169836cc8acb5e440ebae9aad4bf9d15e226d3bad049cf3f6a5c20cc8dc9", size = 411762, upload-time = "2025-06-22T19:34:11.037Z" },
     { url = "https://files.pythonhosted.org/packages/41/ff/392bff89415399a979be4a65357a41d92729ae8580a66073d8ec8d810f98/backrefs-5.9-py39-none-any.whl", hash = "sha256:f48ee18f6252b8f5777a22a00a09a85de0ca931658f1dd96d4406a34f3748c60", size = 380265, upload-time = "2025-06-22T19:34:12.405Z" },
 ]
 
@@ -328,19 +326,19 @@ wheels = [
 
 [[package]]
 name = "lance-namespace"
-version = "0.4.5"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b4/b5/0c3c55cf336b1e90392c2e24ac833551659e8bb3c61644b2d94825eb31bd/lance_namespace-0.4.5.tar.gz", hash = "sha256:0aee0abed3a1fa762c2955c7d12bb3004cea5c82ba28f6fcb9fe79d0cc19e317", size = 9827, upload-time = "2026-01-07T19:20:23.005Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/9f/7906ba4117df8d965510285eaf07264a77de2fd283b9d44ec7fc63a4a57a/lance_namespace-0.6.1.tar.gz", hash = "sha256:f0deea442bd3f1056a8e2fed056ae2778e3356517ec2e680db049058b824d131", size = 10666, upload-time = "2026-03-17T17:55:44.977Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/88/173687dad72baf819223e3b506898e386bc88c26ff8da5e8013291e02daf/lance_namespace-0.4.5-py3-none-any.whl", hash = "sha256:cd1a4f789de03ba23a0c16f100b1464cca572a5d04e428917a54d09db912d548", size = 11703, upload-time = "2026-01-07T19:20:25.394Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/91/aee1c0a04d17f2810173bd304bd444eb78332045df1b0c1b07cebd01f530/lance_namespace-0.6.1-py3-none-any.whl", hash = "sha256:9699c9e3f12236e5e08ea979cc4e036a8e3c67ed2f37ae6f25c5353ab908e1be", size = 12498, upload-time = "2026-03-17T17:55:44.062Z" },
 ]
 
 [[package]]
 name = "lance-namespace-urllib3-client"
-version = "0.4.5"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -348,9 +346,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/a9/4e527c2f05704565618b239b0965f829d1a194837f01234af3f8e2f33d92/lance_namespace_urllib3_client-0.4.5.tar.gz", hash = "sha256:184deda8cf8700926d994618187053c644eb1f2866a4479e7b80843cacc92b1c", size = 159726, upload-time = "2026-01-07T19:20:24.025Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/a1/8706a2be25bd184acccc411e48f1a42a4cbf3b6556cba15b9fcf4c15cfcc/lance_namespace_urllib3_client-0.6.1.tar.gz", hash = "sha256:31fbd058ce1ea0bf49045cdeaa756360ece0bc61e9e10276f41af6d217debe87", size = 182567, upload-time = "2026-03-17T17:55:46.87Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/86/0adee7190408a28dcc5a0562c674537457e3de59ee51d1c724ecdc4a9930/lance_namespace_urllib3_client-0.4.5-py3-none-any.whl", hash = "sha256:2ee154d616ba4721f0bfdf043d33c4fef2e79d380653e2f263058ab00fb4adf4", size = 277969, upload-time = "2026-01-07T19:20:26.597Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c7/cb9580602dec25f0fdd6005c1c9ba1d4c8c0c3dc8d543107e5a9f248bba8/lance_namespace_urllib3_client-0.6.1-py3-none-any.whl", hash = "sha256:b9c103e1377ad46d2bd70eec894bfec0b1e2133dae0964d7e4de543c6e16293b", size = 317111, upload-time = "2026-03-17T17:55:45.546Z" },
 ]
 
 [[package]]
@@ -362,14 +360,14 @@ dependencies = [
     { name = "more-itertools", marker = "python_full_version < '3.12'" },
     { name = "pyarrow" },
     { name = "pylance" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "ray", extra = ["data"] },
 ]
 
 [package.optional-dependencies]
 dev = [
-    { name = "pytest" },
     { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
     { name = "pytest-xdist" },
     { name = "ruff" },
 ]
@@ -387,10 +385,10 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.0.0" },
     { name = "more-itertools", marker = "python_full_version < '3.12'", specifier = ">=2.6.0" },
     { name = "pyarrow", specifier = ">=17.0.0" },
-    { name = "pylance", specifier = ">=2.0.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.0" },
+    { name = "pylance", specifier = ">=4.0.0" },
+    { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
+    { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.0" },
     { name = "ray", extras = ["data"], specifier = ">=2.41.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
@@ -693,8 +691,7 @@ name = "numpy"
 version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version == '3.12.*'",
+    "python_full_version >= '3.12'",
     "python_full_version == '3.11.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/19/d7c972dfe90a353dbd3efbbe1d14a5951de80c99c9dc1b93cd998d51dc0f/numpy-2.3.1.tar.gz", hash = "sha256:1ec9ae20a4226da374362cca3c62cd753faf2f951440b0e3b98e93c235441d2b", size = 20390372, upload-time = "2025-06-21T12:28:33.469Z" }
@@ -1025,7 +1022,7 @@ wheels = [
 
 [[package]]
 name = "pylance"
-version = "2.0.0"
+version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace" },
@@ -1034,12 +1031,12 @@ dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/1e/7cba63f641e25243521a73c85d9f198c970546904bd32d86a74d8a5503b4/pylance-2.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ecfc291cace1aae2faeac9b329ee9b42674e6cad505fafcfe223b7fcbbc15a34", size = 51673048, upload-time = "2026-02-05T19:53:58.676Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/b7/0674bea6e33a3edf466afa6d28271c495996a6f287f4426dd20d3cc08fcc/pylance-2.0.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c0397d7b9e7da2bbcc15c13edc52698a988f10e30ddb7577bebe82ec5deb82eb", size = 54124374, upload-time = "2026-02-05T20:01:43.278Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/16/43ddd4dab5ae785eb6b6fea10c747ef757edebd702d8cdd2f7c451c82810/pylance-2.0.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:25be16d2797d7b684365f44e2ccdc85da210a1763cf7abb9382fbb1b132a605f", size = 57604350, upload-time = "2026-02-05T20:10:03.402Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/91/94bd6e88cc59e9a3642479a448c636307cbe3919cfbb03a2894fe40004d7/pylance-2.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:63fcedecb88ff0ab18d538b32ed5d285a814f2bab0776a75ef9f3bd42d5b6d7d", size = 54139864, upload-time = "2026-02-05T20:02:07.957Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/ac/4cf5c2529cf7f10d1ed1195745c75e0817a09862297ad705ab539abab830/pylance-2.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a3792af7bb4e77aa80436d7553b8567a3ac63be9199a0ece786a9ef2438f7930", size = 57575193, upload-time = "2026-02-05T20:10:27.163Z" },
-    { url = "https://files.pythonhosted.org/packages/45/a3/05fd03f25c417e55f5f141e08585da8a5e5d0b17c71882b446388f203584/pylance-2.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:f08d9f87c6d6ac2d2dea6898a4364faef57d3c6a802f8faf3b62fe756fb6834b", size = 61682039, upload-time = "2026-02-05T20:30:48.272Z" },
+    { url = "https://files.pythonhosted.org/packages/19/29/5152da1261a628c293876917b6185538bd68f4cf1420da6265b5be79d09b/pylance-4.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7310892f3089eeddb1af1fe5c398b71cc483a3015646caceaa2f62fc92b227b2", size = 54420876, upload-time = "2026-03-30T18:18:37.525Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ae/7edbbfc18c3be43eedb886e74a17826c09fdf35588b35912f2733779ea43/pylance-4.0.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57f6a521b1b4b77a62d791850213a854093719c7d76b9641e8abcd445eb73e56", size = 56752552, upload-time = "2026-03-30T18:24:21.331Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/88/6d8bda83224bac52806f09d3e211d8886b81500384948a753c4b24c11f35/pylance-4.0.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e433d6bddd66de99c58e472bc3e8ed1590c7ff4ff7948479254c1c2111a601a8", size = 60305704, upload-time = "2026-03-30T18:35:23.425Z" },
+    { url = "https://files.pythonhosted.org/packages/52/f3/8d8369c756c4173ea070f6964213f9b622ac278bd04a058c48d00a549177/pylance-4.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f36dce83c11cd5d598cb0f64bad7c51fc21ed43df868b9029184a385c6bf4d84", size = 56771233, upload-time = "2026-03-30T18:25:40.012Z" },
+    { url = "https://files.pythonhosted.org/packages/66/e6/53e0713440685b1c76e20d72755eca2e531cc182ea9a612b4cb6a15abe50/pylance-4.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:9ca03f97f22e0b75f06378c4006d587aba26408122fd066f0e43e2b7a019c67e", size = 60260813, upload-time = "2026-03-30T18:36:07.976Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/04/5f22b88c8965d3982f68f67bfe24d756e7b788e10392d2bec6f97f5eb0e3/pylance-4.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:9261c32d3bd6aaab33025a45b20c2f2554804e1bc2a1ec2bfcb06f0c9d2e59b9", size = 65137830, upload-time = "2026-03-30T18:37:33.048Z" },
 ]
 
 [[package]]
@@ -1333,33 +1330,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/ae/769dc372211835bf759319a7aae70525c6eb523e3371842c65b7ef41c9c6/rpds_py-0.26.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dca83c498b4650a91efcf7b88d669b170256bf8017a5db6f3e06c2bf031f57e0", size = 554049, upload-time = "2025-07-01T15:55:13.004Z" },
     { url = "https://files.pythonhosted.org/packages/6b/f9/4c43f9cc203d6ba44ce3146246cdc38619d92c7bd7bad4946a3491bd5b70/rpds_py-0.26.0-cp313-cp313t-win32.whl", hash = "sha256:4d11382bcaf12f80b51d790dee295c56a159633a8e81e6323b16e55d81ae37e9", size = 218428, upload-time = "2025-07-01T15:55:14.486Z" },
     { url = "https://files.pythonhosted.org/packages/7e/8b/9286b7e822036a4a977f2f1e851c7345c20528dbd56b687bb67ed68a8ede/rpds_py-0.26.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ff110acded3c22c033e637dd8896e411c7d3a11289b2edf041f86663dbc791e9", size = 231524, upload-time = "2025-07-01T15:55:15.745Z" },
-    { url = "https://files.pythonhosted.org/packages/55/07/029b7c45db910c74e182de626dfdae0ad489a949d84a468465cd0ca36355/rpds_py-0.26.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:da619979df60a940cd434084355c514c25cf8eb4cf9a508510682f6c851a4f7a", size = 364292, upload-time = "2025-07-01T15:55:17.001Z" },
-    { url = "https://files.pythonhosted.org/packages/13/d1/9b3d3f986216b4d1f584878dca15ce4797aaf5d372d738974ba737bf68d6/rpds_py-0.26.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ea89a2458a1a75f87caabefe789c87539ea4e43b40f18cff526052e35bbb4fdf", size = 350334, upload-time = "2025-07-01T15:55:18.922Z" },
-    { url = "https://files.pythonhosted.org/packages/18/98/16d5e7bc9ec715fa9668731d0cf97f6b032724e61696e2db3d47aeb89214/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:feac1045b3327a45944e7dcbeb57530339f6b17baff154df51ef8b0da34c8c12", size = 384875, upload-time = "2025-07-01T15:55:20.399Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/13/aa5e2b1ec5ab0e86a5c464d53514c0467bec6ba2507027d35fc81818358e/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b818a592bd69bfe437ee8368603d4a2d928c34cffcdf77c2e761a759ffd17d20", size = 399993, upload-time = "2025-07-01T15:55:21.729Z" },
-    { url = "https://files.pythonhosted.org/packages/17/03/8021810b0e97923abdbab6474c8b77c69bcb4b2c58330777df9ff69dc559/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1a8b0dd8648709b62d9372fc00a57466f5fdeefed666afe3fea5a6c9539a0331", size = 516683, upload-time = "2025-07-01T15:55:22.918Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/b1/da8e61c87c2f3d836954239fdbbfb477bb7b54d74974d8f6fcb34342d166/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6d3498ad0df07d81112aa6ec6c95a7e7b1ae00929fb73e7ebee0f3faaeabad2f", size = 408825, upload-time = "2025-07-01T15:55:24.207Z" },
-    { url = "https://files.pythonhosted.org/packages/38/bc/1fc173edaaa0e52c94b02a655db20697cb5fa954ad5a8e15a2c784c5cbdd/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24a4146ccb15be237fdef10f331c568e1b0e505f8c8c9ed5d67759dac58ac246", size = 387292, upload-time = "2025-07-01T15:55:25.554Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/eb/3a9bb4bd90867d21916f253caf4f0d0be7098671b6715ad1cead9fe7bab9/rpds_py-0.26.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a9a63785467b2d73635957d32a4f6e73d5e4df497a16a6392fa066b753e87387", size = 420435, upload-time = "2025-07-01T15:55:27.798Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/16/e066dcdb56f5632713445271a3f8d3d0b426d51ae9c0cca387799df58b02/rpds_py-0.26.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:de4ed93a8c91debfd5a047be327b7cc8b0cc6afe32a716bbbc4aedca9e2a83af", size = 562410, upload-time = "2025-07-01T15:55:29.057Z" },
-    { url = "https://files.pythonhosted.org/packages/60/22/ddbdec7eb82a0dc2e455be44c97c71c232983e21349836ce9f272e8a3c29/rpds_py-0.26.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:caf51943715b12af827696ec395bfa68f090a4c1a1d2509eb4e2cb69abbbdb33", size = 590724, upload-time = "2025-07-01T15:55:30.719Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/b4/95744085e65b7187d83f2fcb0bef70716a1ea0a9e5d8f7f39a86e5d83424/rpds_py-0.26.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4a59e5bc386de021f56337f757301b337d7ab58baa40174fb150accd480bc953", size = 558285, upload-time = "2025-07-01T15:55:31.981Z" },
-    { url = "https://files.pythonhosted.org/packages/37/37/6309a75e464d1da2559446f9c811aa4d16343cebe3dbb73701e63f760caa/rpds_py-0.26.0-cp314-cp314-win32.whl", hash = "sha256:92c8db839367ef16a662478f0a2fe13e15f2227da3c1430a782ad0f6ee009ec9", size = 223459, upload-time = "2025-07-01T15:55:33.312Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/6f/8e9c11214c46098b1d1391b7e02b70bb689ab963db3b19540cba17315291/rpds_py-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:b0afb8cdd034150d4d9f53926226ed27ad15b7f465e93d7468caaf5eafae0d37", size = 236083, upload-time = "2025-07-01T15:55:34.933Z" },
-    { url = "https://files.pythonhosted.org/packages/47/af/9c4638994dd623d51c39892edd9d08e8be8220a4b7e874fa02c2d6e91955/rpds_py-0.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:ca3f059f4ba485d90c8dc75cb5ca897e15325e4e609812ce57f896607c1c0867", size = 223291, upload-time = "2025-07-01T15:55:36.202Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/db/669a241144460474aab03e254326b32c42def83eb23458a10d163cb9b5ce/rpds_py-0.26.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:5afea17ab3a126006dc2f293b14ffc7ef3c85336cf451564a0515ed7648033da", size = 361445, upload-time = "2025-07-01T15:55:37.483Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/2d/133f61cc5807c6c2fd086a46df0eb8f63a23f5df8306ff9f6d0fd168fecc/rpds_py-0.26.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:69f0c0a3df7fd3a7eec50a00396104bb9a843ea6d45fcc31c2d5243446ffd7a7", size = 347206, upload-time = "2025-07-01T15:55:38.828Z" },
-    { url = "https://files.pythonhosted.org/packages/05/bf/0e8fb4c05f70273469eecf82f6ccf37248558526a45321644826555db31b/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:801a71f70f9813e82d2513c9a96532551fce1e278ec0c64610992c49c04c2dad", size = 380330, upload-time = "2025-07-01T15:55:40.175Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/a8/060d24185d8b24d3923322f8d0ede16df4ade226a74e747b8c7c978e3dd3/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:df52098cde6d5e02fa75c1f6244f07971773adb4a26625edd5c18fee906fa84d", size = 392254, upload-time = "2025-07-01T15:55:42.015Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/7b/7c2e8a9ee3e6bc0bae26bf29f5219955ca2fbb761dca996a83f5d2f773fe/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9bc596b30f86dc6f0929499c9e574601679d0341a0108c25b9b358a042f51bca", size = 516094, upload-time = "2025-07-01T15:55:43.603Z" },
-    { url = "https://files.pythonhosted.org/packages/75/d6/f61cafbed8ba1499b9af9f1777a2a199cd888f74a96133d8833ce5eaa9c5/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9dfbe56b299cf5875b68eb6f0ebaadc9cac520a1989cac0db0765abfb3709c19", size = 402889, upload-time = "2025-07-01T15:55:45.275Z" },
-    { url = "https://files.pythonhosted.org/packages/92/19/c8ac0a8a8df2dd30cdec27f69298a5c13e9029500d6d76718130f5e5be10/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac64f4b2bdb4ea622175c9ab7cf09444e412e22c0e02e906978b3b488af5fde8", size = 384301, upload-time = "2025-07-01T15:55:47.098Z" },
-    { url = "https://files.pythonhosted.org/packages/41/e1/6b1859898bc292a9ce5776016c7312b672da00e25cec74d7beced1027286/rpds_py-0.26.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:181ef9b6bbf9845a264f9aa45c31836e9f3c1f13be565d0d010e964c661d1e2b", size = 412891, upload-time = "2025-07-01T15:55:48.412Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/b9/ceb39af29913c07966a61367b3c08b4f71fad841e32c6b59a129d5974698/rpds_py-0.26.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:49028aa684c144ea502a8e847d23aed5e4c2ef7cadfa7d5eaafcb40864844b7a", size = 557044, upload-time = "2025-07-01T15:55:49.816Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/27/35637b98380731a521f8ec4f3fd94e477964f04f6b2f8f7af8a2d889a4af/rpds_py-0.26.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e5d524d68a474a9688336045bbf76cb0def88549c1b2ad9dbfec1fb7cfbe9170", size = 585774, upload-time = "2025-07-01T15:55:51.192Z" },
-    { url = "https://files.pythonhosted.org/packages/52/d9/3f0f105420fecd18551b678c9a6ce60bd23986098b252a56d35781b3e7e9/rpds_py-0.26.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c1851f429b822831bd2edcbe0cfd12ee9ea77868f8d3daf267b189371671c80e", size = 554886, upload-time = "2025-07-01T15:55:52.541Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/c5/347c056a90dc8dd9bc240a08c527315008e1b5042e7a4cf4ac027be9d38a/rpds_py-0.26.0-cp314-cp314t-win32.whl", hash = "sha256:7bdb17009696214c3b66bb3590c6d62e14ac5935e53e929bcdbc5a495987a84f", size = 219027, upload-time = "2025-07-01T15:55:53.874Z" },
-    { url = "https://files.pythonhosted.org/packages/75/04/5302cea1aa26d886d34cadbf2dc77d90d7737e576c0065f357b96dc7a1a6/rpds_py-0.26.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f14440b9573a6f76b4ee4770c13f0b5921f71dde3b6fcb8dabbefd13b7fe05d7", size = 232821, upload-time = "2025-07-01T15:55:55.167Z" },
     { url = "https://files.pythonhosted.org/packages/ef/9a/1f033b0b31253d03d785b0cd905bc127e555ab496ea6b4c7c2e1f951f2fd/rpds_py-0.26.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:3c0909c5234543ada2515c05dc08595b08d621ba919629e94427e8e03539c958", size = 373226, upload-time = "2025-07-01T15:56:16.578Z" },
     { url = "https://files.pythonhosted.org/packages/58/29/5f88023fd6aaaa8ca3c4a6357ebb23f6f07da6079093ccf27c99efce87db/rpds_py-0.26.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:c1fb0cda2abcc0ac62f64e2ea4b4e64c57dfd6b885e693095460c61bde7bb18e", size = 359230, upload-time = "2025-07-01T15:56:17.978Z" },
     { url = "https://files.pythonhosted.org/packages/6c/6c/13eaebd28b439da6964dde22712b52e53fe2824af0223b8e403249d10405/rpds_py-0.26.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84d142d2d6cf9b31c12aa4878d82ed3b2324226270b89b676ac62ccd7df52d08", size = 382363, upload-time = "2025-07-01T15:56:19.977Z" },


### PR DESCRIPTION
- Pin `pylance==4.0.0` and adjust dependencies so `uv run pytest` works out-of-the-box.
- Adapt namespace / credential refresh wiring to match the new pylance 4.x API surface.
- Patch blob v2 external file:// base path handling by persisting `DatasetBasePath` (v2.2+ manifest paths).
- Fix blob reconstruction alignment differences between legacy blobs and blob v2.
- Update distributed scalar/vector indexing flows to match pylance 4.x behavior.


This is an initial fix to maintain compatibility with the new version. Going forward, we can rely on @hfutatzhanghb to continue contributing improvements.
Will initialize the project for Pylance 4.0 to ensure basic compatibility with the API code fixes.
Thanks @hfutatzhanghb for the report — and in advance for future contributions!