### PR TITLE
fix: adapt namespace API for pylance 5.0 forward compatibility

### DIFF
--- a/lance_ray/datasource.py
+++ b/lance_ray/datasource.py
@@ -80,9 +80,11 @@ class LanceDatasource(Datasource):
 
             dataset_options = self._dataset_options.copy()
             dataset_options["uri"] = self._uri
-            dataset_options["namespace"] = self._namespace
-            dataset_options["table_id"] = self._table_id
             dataset_options["storage_options"] = self._storage_options
+            ns_kwargs = get_namespace_kwargs(
+                self._namespace_impl, self._namespace_properties, self._table_id
+            )
+            dataset_options.update(ns_kwargs)
             self._lance_ds = lance.dataset(**dataset_options)
         return self._lance_ds
 

--- a/lance_ray/utils.py
+++ b/lance_ray/utils.py
@@ -1,4 +1,3 @@
-import inspect
 import os
 import sys
 from collections.abc import Iterable, Sequence
@@ -9,6 +8,18 @@ T = TypeVar("T")
 
 # Cache size for namespace clients per worker, configurable via environment variable
 _NAMESPACE_CACHE_SIZE = int(os.environ.get("LANCE_RAY_NAMESPACE_CACHE_SIZE", "16"))
+
+_PYLANCE_5 = (5, 0, 0)
+
+
+@lru_cache(maxsize=1)
+def _pylance_version() -> tuple[int, ...]:
+    """Return the installed pylance version as a comparable tuple."""
+    import lance
+    from packaging.version import parse
+
+    v = parse(lance.__version__)
+    return (v.major, v.minor, v.micro)
 
 
 def has_namespace_params(
@@ -100,31 +111,12 @@ def get_or_create_namespace(
     return _get_cached_namespace(namespace_impl, namespace_properties_tuple)
 
 
-@lru_cache(maxsize=1)
-def _lance_namespace_kw() -> str:
-    import lance
-
-    params = inspect.signature(lance.dataset).parameters
-    if "namespace_client" in params:
-        return "namespace_client"
-    if "namespace" in params:
-        return "namespace"
-    return ""
-
-
-@lru_cache(maxsize=1)
-def _lance_supports_storage_options_provider() -> bool:
-    import lance
-
-    params = inspect.signature(lance.dataset).parameters
-    return "storage_options_provider" in params
-
-
-def create_storage_options_provider(
+def _create_storage_options_provider(
     namespace_impl: Optional[str],
     namespace_properties: Optional[dict[str, str]],
     table_id: Optional[list[str]],
 ):
+    """Create a LanceNamespaceStorageOptionsProvider (pylance 4.x only)."""
     if not has_namespace_params(namespace_impl, table_id):
         return None
 
@@ -147,10 +139,9 @@ def get_namespace_kwargs(
 ) -> dict[str, Any]:
     """Return kwargs for pylance namespace / auth integration.
 
-    pylance 4.0.0 uses: `namespace`, `table_id`, `storage_options_provider`.
-    Newer pylance versions may use `namespace_client` instead of `namespace`.
-
-    This helper hides those naming differences and keeps call sites simple.
+    Handles API differences between pylance versions:
+    - pylance 4.x: ``namespace``, ``table_id``, ``storage_options_provider``
+    - pylance 5.0+: ``namespace_client``, ``table_id``
     """
     if not has_namespace_params(namespace_impl, table_id):
         return {}
@@ -159,14 +150,13 @@ def get_namespace_kwargs(
     if namespace is None:
         return {}
 
-    kwargs: dict[str, Any] = {}
-    namespace_kw = _lance_namespace_kw()
-    if namespace_kw:
-        kwargs[namespace_kw] = namespace
-    kwargs["table_id"] = table_id
+    kwargs: dict[str, Any] = {"table_id": table_id}
 
-    if _lance_supports_storage_options_provider():
-        provider = create_storage_options_provider(
+    if _pylance_version() >= _PYLANCE_5:
+        kwargs["namespace_client"] = namespace
+    else:
+        kwargs["namespace"] = namespace
+        provider = _create_storage_options_provider(
             namespace_impl, namespace_properties, table_id
         )
         if provider is not None:
@@ -180,15 +170,24 @@ def get_write_fragments_kwargs(
     namespace_properties: Optional[dict[str, str]],
     table_id: Optional[list[str]],
 ) -> dict[str, Any]:
-    """Return kwargs for `lance.fragment.write_fragments`.
+    """Return kwargs for ``lance.fragment.write_fragments``.
 
-    pylance 4.0.0 supports `storage_options_provider` on write_fragments, but not
-    `namespace` / `table_id`.
+    Handles API differences between pylance versions:
+    - pylance 4.x: ``storage_options_provider``
+    - pylance 5.0+: ``namespace_client``, ``table_id``
     """
-    provider = create_storage_options_provider(namespace_impl, namespace_properties, table_id)
-    if provider is None:
+    if not has_namespace_params(namespace_impl, table_id):
         return {}
 
+    if _pylance_version() >= _PYLANCE_5:
+        namespace = get_or_create_namespace(namespace_impl, namespace_properties)
+        if namespace is None:
+            return {}
+        return {"namespace_client": namespace, "table_id": table_id}
+
+    provider = _create_storage_options_provider(namespace_impl, namespace_properties, table_id)
+    if provider is None:
+        return {}
     return {"storage_options_provider": provider}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "ray[data]>=2.41.0",
     "pylance>=4.0.0",
     "lance-namespace",
+    "packaging",
     "pyarrow>=17.0.0",
     "pytest>=8.4.0",
     "pytest-cov>=5.0.0",


### PR DESCRIPTION
This PR fixes forward compatibility issues in lance-ray's namespace API wiring that will break when pylance 5.0 is released.

Pylance 5.0 renames the `namespace` parameter to `namespace_client` and removes `storage_options_provider` / `LanceNamespaceStorageOptionsProvider` across `lance.dataset()`, `LanceDataset()`, `LanceDataset.commit()`, and `write_fragments()`. While 5.0 has not been released yet, these API changes are already present on the main branch, and addressing them now avoids a hard breakage on upgrade.

### Changes

- **`datasource.py`**: `LanceDatasource.lance_dataset` was the only call site that hardcoded `dataset_options["namespace"]` instead of going through the adaptation layer. Switched to `get_namespace_kwargs()`.
- **`utils.py`**: Replaced scattered `inspect.signature` probes with a single `_pylance_version()` check. All version-dependent logic now branches on
 `>= (5, 0, 0)` in one place.
- **`utils.py`**: `get_write_fragments_kwargs()` previously only returned `storage_options_provider`, which silently becomes a no-op in 5.0. Added the `namespace_client` + `table_id` path for 5.0+.
- **`pyproject.toml`**: Added `packaging` as an explicit dependency.

### Why now

The original commit  #3607  correctly adapted most call sites for pylance 4.0, but left two gaps that would cause `TypeError` or silent auth failure on 5.0. Fixing them while the API delta is clear is cheaper than debugging production failures after the upgrade