### PR TITLE
chore: update pylance dependency to v6.0.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=4.0.0",
+    "pylance>=6.0.0rc1",
     "lance-namespace",
     "packaging",
     "pyarrow>=17.0.0",


### PR DESCRIPTION
## Summary
- Update the Pylance dependency requirement from `pylance>=4.0.0` to `pylance>=6.0.0rc1`.
- Triggering tag: [refs/tags/v6.0.0-rc.1](https://github.com/lance-format/lance/releases/tag/v6.0.0-rc.1)

## Verification
- `make lock` was attempted, but `uv lock` could not resolve `pylance>=6.0.0rc1` because the configured package indexes currently expose Pylance only up to `6.0.0b7`.
- `make lint` was attempted, but it depends on `make lock` and stopped at the same resolver failure before ruff ran.
