### PR TITLE
feat: add vector index sample rate option

### DIFF
--- a/docs/src/distributed-indexing.md
+++ b/docs/src/distributed-indexing.md
@@ -105,6 +105,7 @@ def create_index(
     metric: str = "l2",
     num_partitions: Optional[int] = None,
     num_sub_vectors: Optional[int] = None,
+    sample_rate: int = 256,
     ivf_centroids: Optional["pyarrow.Array"] = None,
     pq_codebook: Optional["pyarrow.Array"] = None,
     **kwargs: Any,
@@ -129,9 +130,10 @@ def create_index(
 | `metric` | `str`, optional | Distance metric to use (e.g., `"l2"`, `"cosine"`, `"dot"`, `"hamming"`), default is `"l2"` |
 | `num_partitions` | `int`, optional | Number of IVF partitions |
 | `num_sub_vectors` | `int`, optional | Number of PQ sub-vectors |
+| `sample_rate` | `int`, optional | Number of rows sampled per IVF partition and PQ centroid, default is 256 |
 | `ivf_centroids` | `pyarrow.Array`, optional | Pre-computed IVF centroids (advanced) |
 | `pq_codebook` | `pyarrow.Array`, optional | Pre-computed PQ codebook for PQ-based indices (advanced) |
-| `**kwargs` | `Any` | Additional arguments to pass (e.g., `sample_rate`) |
+| `**kwargs` | `Any` | Additional arguments to pass through to Lance index creation |
 
 #### Return Value
 
@@ -240,6 +242,7 @@ updated_dataset = lr.create_index(
     num_workers=4,
     num_partitions=256,
     num_sub_vectors=16,
+    sample_rate=64,
     metric="l2"
 )
 

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -749,6 +749,7 @@ def create_index(
     metric: str = "l2",
     num_partitions: Optional[int] = None,
     num_sub_vectors: Optional[int] = None,
+    sample_rate: int = 256,
     ivf_centroids: Optional[
         pa.Array | pa.FixedSizeListArray | pa.FixedShapeTensorArray
     ] = None,
@@ -774,9 +775,10 @@ def create_index(
         metric: Distance metric to use (default: "l2")
         num_partitions: Number of IVF partitions (optional)
         num_sub_vectors: Number of PQ sub-vectors (optional)
+        sample_rate: Number of rows sampled per IVF partition and PQ centroid (default: 256)
         ivf_centroids: Pre-computed IVF centroids (optional)
         pq_codebook: Pre-computed PQ codebook (optional)
-        **kwargs: Additional arguments to pass to create_index and train_pq (e.g., sample_rate)
+        **kwargs: Additional arguments to pass to create_index
 
     Returns:
         Updated Lance dataset with the index created
@@ -888,14 +890,17 @@ def create_index(
 
     requested_num_partitions = num_partitions
     logger.info(
-        "Training IVF with requested_num_partitions=%s, num_rows=%d, dimension=%d",
+        "Training IVF with requested_num_partitions=%s, num_rows=%d, "
+        "dimension=%d, sample_rate=%d",
         requested_num_partitions,
         num_rows,
         dimension,
+        sample_rate,
     )
     ivf_model = builder.train_ivf(
         num_partitions=requested_num_partitions,
         distance_type=metric_lower,
+        sample_rate=sample_rate,
     )
     ivf_centroids_artifact = ivf_model.centroids
     num_partitions = ivf_model.num_partitions
@@ -909,12 +914,12 @@ def create_index(
         logger.info(
             "Training PQ codebook: requested_num_sub_vectors=%s, sample_rate=%d",
             requested_num_sub_vectors,
-            kwargs.get("sample_rate", 256),
+            sample_rate,
         )
         pq_model = builder.train_pq(
             ivf_model,
             num_subvectors=requested_num_sub_vectors,
-            sample_rate=kwargs.get("sample_rate", 256),
+            sample_rate=sample_rate,
         )
         pq_codebook_artifact = pq_model.codebook
         num_sub_vectors = pq_model.num_subvectors

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -778,7 +778,7 @@ def create_index(
         sample_rate: Number of rows sampled per IVF partition and PQ centroid (default: 256)
         ivf_centroids: Pre-computed IVF centroids (optional)
         pq_codebook: Pre-computed PQ codebook (optional)
-        **kwargs: Additional arguments to pass to create_index
+        **kwargs: Additional arguments to pass to the fragment index build entrypoint
 
     Returns:
         Updated Lance dataset with the index created
@@ -791,6 +791,9 @@ def create_index(
 
     if num_workers <= 0:
         raise ValueError(f"num_workers must be positive, got {num_workers}")
+
+    if sample_rate <= 0:
+        raise ValueError(f"sample_rate must be positive, got {sample_rate}")
 
     index_type_name = _normalize_index_type(index_type)
     metric_lower = _validate_metric(metric)

--- a/tests/test_vector_index_options.py
+++ b/tests/test_vector_index_options.py
@@ -5,6 +5,8 @@ import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
+import pytest
+
 
 def _load_index_module_with_stubs():
     """Load lance_ray.index when the native pylance extension is unavailable."""
@@ -163,3 +165,17 @@ def test_create_index_uses_sample_rate_for_global_training(monkeypatch):
     assert captured["fragment_handler_kwargs"]["ivf_centroids"] == "ivf_centroids"
     assert captured["fragment_handler_kwargs"]["pq_codebook"] == "pq_codebook"
     assert "sample_rate" not in captured["fragment_handler_kwargs"]
+
+
+def test_create_index_rejects_non_positive_sample_rate(monkeypatch):
+    """Invalid sample rates should fail before training starts."""
+
+    monkeypatch.setattr(index_mod, "_check_pylance_version", lambda: None)
+
+    with pytest.raises(ValueError, match="sample_rate must be positive, got 0"):
+        index_mod.create_index(
+            uri=_FakeDataset(),
+            column="vector",
+            index_type="IVF_PQ",
+            sample_rate=0,
+        )

--- a/tests/test_vector_index_options.py
+++ b/tests/test_vector_index_options.py
@@ -1,0 +1,165 @@
+"""Tests for distributed vector index option handling."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+def _load_index_module_with_stubs():
+    """Load lance_ray.index when the native pylance extension is unavailable."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    package = ModuleType("lance_ray")
+    package.__path__ = [str(repo_root / "lance_ray")]
+
+    lance = ModuleType("lance")
+    lance.__version__ = "6.0.0"
+
+    lance_dataset = ModuleType("lance.dataset")
+    lance_dataset.Index = type("Index", (), {})
+    lance_dataset.IndexConfig = type("IndexConfig", (), {})
+    lance_dataset.LanceDataset = object
+
+    lance_indices = ModuleType("lance.indices")
+    lance_indices.IndicesBuilder = object
+
+    ray = ModuleType("ray")
+    ray_util = ModuleType("ray.util")
+    ray_multiprocessing = ModuleType("ray.util.multiprocessing")
+    ray_multiprocessing.Pool = object
+
+    sys.modules["lance_ray"] = package
+    sys.modules["lance"] = lance
+    sys.modules["lance.dataset"] = lance_dataset
+    sys.modules["lance.indices"] = lance_indices
+    sys.modules["ray"] = ray
+    sys.modules["ray.util"] = ray_util
+    sys.modules["ray.util.multiprocessing"] = ray_multiprocessing
+
+    spec = importlib.util.spec_from_file_location(
+        "lance_ray.index",
+        repo_root / "lance_ray" / "index.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["lance_ray.index"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+try:
+    from lance_ray import index as index_mod
+except ImportError:  # pragma: no cover - environment dependent
+    index_mod = _load_index_module_with_stubs()
+
+
+class _FakeSchema:
+    def field(self, column):
+        if column != "vector":
+            raise KeyError(column)
+        return SimpleNamespace(name=column)
+
+
+class _FakeFragment:
+    def __init__(self, fragment_id, rows):
+        self.fragment_id = fragment_id
+        self._rows = rows
+
+    def count_rows(self):
+        return self._rows
+
+
+class _FakeSegmentBuilder:
+    def with_index_type(self, index_type):
+        self.index_type = index_type
+        return self
+
+    def with_segments(self, segments):
+        self.segments = segments
+        return self
+
+    def build_all(self):
+        return ["merged_segment"]
+
+
+class _FakeDataset:
+    uri = "memory://fake"
+    schema = _FakeSchema()
+
+    def get_fragments(self):
+        return [_FakeFragment(0, 100), _FakeFragment(1, 100)]
+
+    def count_rows(self):
+        return 200
+
+    def create_index_segment_builder(self):
+        return _FakeSegmentBuilder()
+
+    def commit_existing_index_segments(self, **kwargs):
+        self.commit_kwargs = kwargs
+        return self
+
+
+def test_create_index_uses_sample_rate_for_global_training(monkeypatch):
+    """The public sample_rate option should drive both IVF and PQ training."""
+
+    captured = {}
+    fake_dataset = _FakeDataset()
+
+    class FakeIndicesBuilder:
+        dimension = 16
+
+        def __init__(self, dataset, column):
+            captured["builder_dataset"] = dataset
+            captured["builder_column"] = column
+
+        def train_ivf(self, **kwargs):
+            captured["train_ivf"] = kwargs
+            return SimpleNamespace(centroids="ivf_centroids", num_partitions=4)
+
+        def train_pq(self, ivf_model, **kwargs):
+            captured["train_pq_ivf_model"] = ivf_model
+            captured["train_pq"] = kwargs
+            return SimpleNamespace(codebook="pq_codebook", num_subvectors=4)
+
+    def fake_handle_vector_fragment_index(**kwargs):
+        captured["fragment_handler_kwargs"] = kwargs
+        return lambda fragment_ids: {"status": "success", "fragment_ids": fragment_ids}
+
+    def fake_map_async_with_pool(**kwargs):
+        captured["map_kwargs"] = kwargs
+        return [
+            {
+                "status": "success",
+                "fragment_ids": [0, 1],
+                "segment_index": "segment",
+            }
+        ]
+
+    monkeypatch.setattr(index_mod, "_check_pylance_version", lambda: None)
+    monkeypatch.setattr(index_mod, "IndicesBuilder", FakeIndicesBuilder)
+    monkeypatch.setattr(index_mod, "LanceDataset", lambda *args, **kwargs: fake_dataset)
+    monkeypatch.setattr(
+        index_mod,
+        "_handle_vector_fragment_index",
+        fake_handle_vector_fragment_index,
+    )
+    monkeypatch.setattr(index_mod, "_map_async_with_pool", fake_map_async_with_pool)
+
+    updated_dataset = index_mod.create_index(
+        uri=fake_dataset,
+        column="vector",
+        index_type="IVF_PQ",
+        name="vector_idx",
+        num_workers=2,
+        num_partitions=4,
+        num_sub_vectors=4,
+        sample_rate=8,
+    )
+
+    assert updated_dataset is fake_dataset
+    assert captured["train_ivf"]["sample_rate"] == 8
+    assert captured["train_pq"]["sample_rate"] == 8
+    assert captured["fragment_handler_kwargs"]["ivf_centroids"] == "ivf_centroids"
+    assert captured["fragment_handler_kwargs"]["pq_codebook"] == "pq_codebook"
+    assert "sample_rate" not in captured["fragment_handler_kwargs"]


### PR DESCRIPTION
## Summary
- add an explicit `sample_rate` option to distributed `create_index`
- pass the option through both IVF and PQ global training
- document the option and cover propagation with a unit test

## Background
Before this change, users could already pass `sample_rate` through `**kwargs`, for example `lr.create_index(..., sample_rate=64)`. However, lance-ray only read that value for PQ training via `builder.train_pq(..., sample_rate=kwargs.get("sample_rate", 256))`. The IVF training step still called `builder.train_ivf(...)` without forwarding `sample_rate`, so IVF used Lance's default sample rate of 256.

That meant `sample_rate` did not affect IVF-only index types such as `IVF_FLAT` and `IVF_SQ`, and `IVF_PQ` could use different sample rates for IVF and PQ training.

This PR keeps the user-facing call unchanged: existing calls that pass `sample_rate=...` still work, but the value now consistently controls both IVF and PQ global training.

## Test
- `uv run --no-sync ruff check lance_ray/index.py tests/test_vector_index_options.py`
- `uv run --no-sync pytest tests/test_vector_index_options.py`