### PR TITLE
feat: add index dataset block size option

### DIFF
--- a/docs/src/distributed-indexing.md
+++ b/docs/src/distributed-indexing.md
@@ -66,7 +66,7 @@ def create_scalar_index(
 | `index_uuid` | `str`, optional | Optional fragment UUID for distributed indexing |
 | `num_workers` | `int`, optional | Number of Ray worker nodes to use, default is 4 |
 | `storage_options` | `Dict[str, str]`, optional | Storage options for the dataset |
-| `block_size` | `int`, optional | Block size to use when loading the dataset |
+| `block_size` | `int`, optional | Block size in bytes to use when loading the dataset |
 | `namespace_impl` | `str`, optional | The namespace implementation type (e.g., `"rest"`, `"dir"`) |
 | `namespace_properties` | `Dict[str, str]`, optional | Properties for connecting to the namespace |
 | `ray_remote_args` | `Dict[str, Any]`, optional | Ray task options (e.g., `num_cpus`, `resources`) |
@@ -126,7 +126,7 @@ def create_index(
 | `replace` | `bool`, optional | Whether to replace existing index, default is `True` |
 | `num_workers` | `int`, optional | Number of Ray workers to use, default is 4 |
 | `storage_options` | `Dict[str, str]`, optional | Storage options for the dataset. These are merged with the storage options returned by the namespace (if any). |
-| `block_size` | `int`, optional | Block size to use when loading the dataset |
+| `block_size` | `int`, optional | Block size in bytes to use when loading the dataset |
 | `namespace_impl` | `str`, optional | The namespace implementation type (e.g., `"rest"`, `"dir"`) |
 | `namespace_properties` | `Dict[str, str]`, optional | Properties for connecting to the namespace |
 | `table_id` | `list[str]`, optional | The table identifier as a list of strings. Must be provided together with `namespace_impl`. |

--- a/docs/src/distributed-indexing.md
+++ b/docs/src/distributed-indexing.md
@@ -42,6 +42,7 @@ def create_scalar_index(
     index_uuid: Optional[str] = None,
     num_workers: int = 4,
     storage_options: Optional[dict[str, str]] = None,
+    block_size: Optional[int] = None,
     namespace_impl: Optional[str] = None,
     namespace_properties: Optional[dict[str, str]] = None,
     ray_remote_args: Optional[dict[str, Any]] = None,
@@ -65,6 +66,7 @@ def create_scalar_index(
 | `index_uuid` | `str`, optional | Optional fragment UUID for distributed indexing |
 | `num_workers` | `int`, optional | Number of Ray worker nodes to use, default is 4 |
 | `storage_options` | `Dict[str, str]`, optional | Storage options for the dataset |
+| `block_size` | `int`, optional | Block size to use when loading the dataset |
 | `namespace_impl` | `str`, optional | The namespace implementation type (e.g., `"rest"`, `"dir"`) |
 | `namespace_properties` | `Dict[str, str]`, optional | Properties for connecting to the namespace |
 | `ray_remote_args` | `Dict[str, Any]`, optional | Ray task options (e.g., `num_cpus`, `resources`) |
@@ -98,6 +100,7 @@ def create_index(
     replace: bool = True,
     num_workers: int = 4,
     storage_options: Optional[dict[str, str]] = None,
+    block_size: Optional[int] = None,
     namespace_impl: Optional[str] = None,
     namespace_properties: Optional[dict[str, str]] = None,
     table_id: Optional[list[str]] = None,
@@ -123,6 +126,7 @@ def create_index(
 | `replace` | `bool`, optional | Whether to replace existing index, default is `True` |
 | `num_workers` | `int`, optional | Number of Ray workers to use, default is 4 |
 | `storage_options` | `Dict[str, str]`, optional | Storage options for the dataset. These are merged with the storage options returned by the namespace (if any). |
+| `block_size` | `int`, optional | Block size to use when loading the dataset |
 | `namespace_impl` | `str`, optional | The namespace implementation type (e.g., `"rest"`, `"dir"`) |
 | `namespace_properties` | `Dict[str, str]`, optional | Properties for connecting to the namespace |
 | `table_id` | `list[str]`, optional | The table identifier as a list of strings. Must be provided together with `namespace_impl`. |

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -291,7 +291,7 @@ def create_scalar_index(
         index_uuid: Optional fragment UUID for distributed indexing.
         num_workers: Number of Ray workers to use (keyword-only).
         storage_options: Storage options for the dataset (keyword-only).
-        block_size: Block size to use when loading the dataset (keyword-only).
+        block_size: Block size in bytes to use when loading the dataset (keyword-only).
         namespace_impl: The namespace implementation type (e.g., "rest", "dir").
             Used together with table_id for resolving the dataset location and
             credentials vending in distributed workers.
@@ -791,7 +791,7 @@ def create_index(
         replace: Whether to replace existing index with the same name (default: True)
         num_workers: Number of Ray workers to use (keyword-only)
         storage_options: Storage options for the dataset (keyword-only)
-        block_size: Block size to use when loading the dataset (keyword-only)
+        block_size: Block size in bytes to use when loading the dataset (keyword-only)
         ray_remote_args: Options for Ray tasks (keyword-only)
         metric: Distance metric to use (default: "l2")
         num_partitions: Number of IVF partitions (optional)

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -21,6 +21,20 @@ from .utils import (
 logger = logging.getLogger(__name__)
 
 
+def _dataset_load_kwargs(
+    storage_options: Optional[dict[str, Any]],
+    namespace_kwargs: dict[str, Any],
+    block_size: Optional[int],
+) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "storage_options": storage_options,
+        **namespace_kwargs,
+    }
+    if block_size is not None:
+        kwargs["block_size"] = block_size
+    return kwargs
+
+
 def _distribute_fragments_balanced(
     fragments: list[Any], num_workers: int, logger: logging.Logger
 ) -> list[list[int]]:
@@ -140,6 +154,7 @@ def _handle_fragment_index(
     replace: bool,
     train: bool,
     storage_options: Optional[dict[str, str]] = None,
+    block_size: Optional[int] = None,
     namespace_impl: Optional[str] = None,
     namespace_properties: Optional[dict[str, str]] = None,
     table_id: Optional[list[str]] = None,
@@ -167,8 +182,7 @@ def _handle_fragment_index(
             # Load dataset
             dataset = LanceDataset(
                 dataset_uri,
-                storage_options=storage_options,
-                **namespace_kwargs,
+                **_dataset_load_kwargs(storage_options, namespace_kwargs, block_size),
             )
 
             available_fragments = {f.fragment_id for f in dataset.get_fragments()}
@@ -254,6 +268,7 @@ def create_scalar_index(
     index_uuid: Optional[str] = None,
     num_workers: int = 4,
     storage_options: Optional[dict[str, str]] = None,
+    block_size: Optional[int] = None,
     namespace_impl: Optional[str] = None,
     namespace_properties: Optional[dict[str, str]] = None,
     ray_remote_args: Optional[dict[str, Any]] = None,
@@ -276,6 +291,7 @@ def create_scalar_index(
         index_uuid: Optional fragment UUID for distributed indexing.
         num_workers: Number of Ray workers to use (keyword-only).
         storage_options: Storage options for the dataset (keyword-only).
+        block_size: Block size to use when loading the dataset (keyword-only).
         namespace_impl: The namespace implementation type (e.g., "rest", "dir").
             Used together with table_id for resolving the dataset location and
             credentials vending in distributed workers.
@@ -325,6 +341,9 @@ def create_scalar_index(
 
     if num_workers <= 0:
         raise ValueError(f"num_workers must be positive, got {num_workers}")
+
+    if block_size is not None and block_size <= 0:
+        raise ValueError(f"block_size must be positive, got {block_size}")
 
     if isinstance(index_type, str):
         valid_index_types = [
@@ -376,8 +395,7 @@ def create_scalar_index(
     # Load dataset
     dataset = LanceDataset(
         uri,
-        storage_options=merged_storage_options,
-        **namespace_kwargs,
+        **_dataset_load_kwargs(merged_storage_options, namespace_kwargs, block_size),
     )
 
     try:
@@ -431,8 +449,9 @@ def create_scalar_index(
             dataset.drop_index(name)
             dataset = LanceDataset(
                 uri,
-                storage_options=merged_storage_options,
-                **namespace_kwargs,
+                **_dataset_load_kwargs(
+                    merged_storage_options, namespace_kwargs, block_size
+                ),
             )
 
     else:
@@ -480,6 +499,7 @@ def create_scalar_index(
         replace=False,
         train=train,
         storage_options=merged_storage_options,
+        block_size=block_size,
         namespace_impl=namespace_impl,
         namespace_properties=namespace_properties,
         table_id=table_id,
@@ -508,8 +528,7 @@ def create_scalar_index(
     # Reload dataset to get the latest state after fragment index creation
     dataset = LanceDataset(
         uri,
-        storage_options=merged_storage_options,
-        **namespace_kwargs,
+        **_dataset_load_kwargs(merged_storage_options, namespace_kwargs, block_size),
     )
 
     logger.info("Phase 2: Merging index metadata for index ID: %s", index_id)
@@ -655,6 +674,7 @@ def _handle_vector_fragment_index(
     ivf_centroids: pa.Array | pa.FixedSizeListArray | pa.FixedShapeTensorArray | None,
     pq_codebook: pa.Array | pa.FixedSizeListArray | pa.FixedShapeTensorArray | None,
     storage_options: Optional[dict[str, str]] = None,
+    block_size: Optional[int] = None,
     namespace_impl: Optional[str] = None,
     namespace_properties: Optional[dict[str, str]] = None,
     table_id: Optional[list[str]] = None,
@@ -676,8 +696,7 @@ def _handle_vector_fragment_index(
             )
             dataset = LanceDataset(
                 dataset_uri,
-                storage_options=storage_options,
-                **namespace_kwargs,
+                **_dataset_load_kwargs(storage_options, namespace_kwargs, block_size),
             )
             available_fragments = {f.fragment_id for f in dataset.get_fragments()}
             invalid_fragments = set(fragment_ids) - available_fragments
@@ -742,6 +761,7 @@ def create_index(
     replace: bool = True,
     num_workers: int = 4,
     storage_options: Optional[dict[str, str]] = None,
+    block_size: Optional[int] = None,
     namespace_impl: Optional[str] = None,
     namespace_properties: Optional[dict[str, str]] = None,
     table_id: Optional[list[str]] = None,
@@ -771,6 +791,7 @@ def create_index(
         replace: Whether to replace existing index with the same name (default: True)
         num_workers: Number of Ray workers to use (keyword-only)
         storage_options: Storage options for the dataset (keyword-only)
+        block_size: Block size to use when loading the dataset (keyword-only)
         ray_remote_args: Options for Ray tasks (keyword-only)
         metric: Distance metric to use (default: "l2")
         num_partitions: Number of IVF partitions (optional)
@@ -794,6 +815,9 @@ def create_index(
 
     if sample_rate <= 0:
         raise ValueError(f"sample_rate must be positive, got {sample_rate}")
+
+    if block_size is not None and block_size <= 0:
+        raise ValueError(f"block_size must be positive, got {block_size}")
 
     index_type_name = _normalize_index_type(index_type)
     metric_lower = _validate_metric(metric)
@@ -827,8 +851,9 @@ def create_index(
         )
         dataset_obj = LanceDataset(
             dataset_uri,
-            storage_options=merged_storage_options,
-            **namespace_kwargs,
+            **_dataset_load_kwargs(
+                merged_storage_options, namespace_kwargs, block_size
+            ),
         )
     else:
         # LanceDataset object passed directly
@@ -963,6 +988,7 @@ def create_index(
         ivf_centroids=ivf_centroids_artifact,
         pq_codebook=pq_codebook_artifact,
         storage_options=merged_storage_options,
+        block_size=block_size,
         namespace_impl=namespace_impl,
         namespace_properties=namespace_properties,
         table_id=table_id,
@@ -984,8 +1010,7 @@ def create_index(
 
     dataset_obj = LanceDataset(
         dataset_uri,
-        storage_options=merged_storage_options,
-        **namespace_kwargs,
+        **_dataset_load_kwargs(merged_storage_options, namespace_kwargs, block_size),
     )
 
     logger.info(

--- a/tests/test_vector_index_options.py
+++ b/tests/test_vector_index_options.py
@@ -55,11 +55,40 @@ except ImportError:  # pragma: no cover - environment dependent
     index_mod = _load_index_module_with_stubs()
 
 
+class _FakeField:
+    def __init__(self, name, field_type=None):
+        self.name = name
+        self.type = field_type or index_mod.pa.float32()
+
+
+class _FakeLanceField:
+    def id(self):
+        return 7
+
+
+class _FakeLanceSchema:
+    def field(self, column):
+        if column != "value":
+            raise KeyError(column)
+        return _FakeLanceField()
+
+
 class _FakeSchema:
     def field(self, column):
-        if column != "vector":
+        if column == "vector":
+            return _FakeField(column)
+        if column == "value":
+            return _FakeField(column, index_mod.pa.int64())
+        else:
             raise KeyError(column)
-        return SimpleNamespace(name=column)
+
+    def __iter__(self):
+        return iter(
+            [
+                _FakeField("vector"),
+                _FakeField("value", index_mod.pa.int64()),
+            ]
+        )
 
 
 class _FakeFragment:
@@ -87,6 +116,8 @@ class _FakeSegmentBuilder:
 class _FakeDataset:
     uri = "memory://fake"
     schema = _FakeSchema()
+    lance_schema = _FakeLanceSchema()
+    version = 1
 
     def get_fragments(self):
         return [_FakeFragment(0, 100), _FakeFragment(1, 100)]
@@ -94,8 +125,18 @@ class _FakeDataset:
     def count_rows(self):
         return 200
 
+    def list_indices(self):
+        return []
+
+    def create_scalar_index(self, **kwargs):
+        self.scalar_index_kwargs = kwargs
+
     def create_index_segment_builder(self):
         return _FakeSegmentBuilder()
+
+    def create_index_uncommitted(self, **kwargs):
+        self.vector_index_kwargs = kwargs
+        return "segment"
 
     def commit_existing_index_segments(self, **kwargs):
         self.commit_kwargs = kwargs
@@ -179,3 +220,174 @@ def test_create_index_rejects_non_positive_sample_rate(monkeypatch):
             index_type="IVF_PQ",
             sample_rate=0,
         )
+
+
+def test_create_scalar_index_passes_block_size_to_loads_and_handler(monkeypatch):
+    """The scalar index path should use block_size whenever it loads a dataset."""
+
+    captured = {"loads": []}
+    fake_dataset = _FakeDataset()
+
+    def fake_lance_dataset(*args, **kwargs):
+        captured["loads"].append(kwargs)
+        return fake_dataset
+
+    def fake_handle_fragment_index(**kwargs):
+        captured["fragment_handler_kwargs"] = kwargs
+        return lambda fragment_ids: {
+            "status": "success",
+            "fragment_ids": fragment_ids,
+            "fields": [7],
+        }
+
+    def fake_map_async_with_pool(**kwargs):
+        captured["map_kwargs"] = kwargs
+        return [
+            {
+                "status": "success",
+                "fragment_ids": [0, 1],
+                "fields": [7],
+            }
+        ]
+
+    monkeypatch.setattr(index_mod, "LanceDataset", fake_lance_dataset)
+    monkeypatch.setattr(
+        index_mod,
+        "_handle_fragment_index",
+        fake_handle_fragment_index,
+    )
+    monkeypatch.setattr(index_mod, "_map_async_with_pool", fake_map_async_with_pool)
+    monkeypatch.setattr(index_mod, "merge_index_metadata_compat", lambda *a, **k: None)
+    monkeypatch.setattr(index_mod, "Index", SimpleNamespace)
+    monkeypatch.setattr(
+        index_mod.lance,
+        "LanceDataset",
+        SimpleNamespace(commit=lambda *args, **kwargs: fake_dataset),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        index_mod.lance,
+        "LanceOperation",
+        SimpleNamespace(CreateIndex=SimpleNamespace),
+        raising=False,
+    )
+
+    updated_dataset = index_mod.create_scalar_index(
+        uri="memory://fake",
+        column="value",
+        index_type="BTREE",
+        num_workers=2,
+        block_size=4096,
+    )
+
+    assert updated_dataset is fake_dataset
+    assert [load["block_size"] for load in captured["loads"]] == [4096, 4096]
+    assert captured["fragment_handler_kwargs"]["block_size"] == 4096
+
+
+def test_create_index_passes_block_size_to_loads_and_handler(monkeypatch):
+    """The vector index path should use block_size for driver and worker loads."""
+
+    captured = {"loads": []}
+    fake_dataset = _FakeDataset()
+
+    class FakeIndicesBuilder:
+        dimension = 16
+
+        def __init__(self, dataset, column):
+            captured["builder_dataset"] = dataset
+            captured["builder_column"] = column
+
+        def train_ivf(self, **kwargs):
+            captured["train_ivf"] = kwargs
+            return SimpleNamespace(centroids="ivf_centroids", num_partitions=4)
+
+        def train_pq(self, ivf_model, **kwargs):
+            captured["train_pq_ivf_model"] = ivf_model
+            captured["train_pq"] = kwargs
+            return SimpleNamespace(codebook="pq_codebook", num_subvectors=4)
+
+    def fake_lance_dataset(*args, **kwargs):
+        captured["loads"].append(kwargs)
+        return fake_dataset
+
+    def fake_handle_vector_fragment_index(**kwargs):
+        captured["fragment_handler_kwargs"] = kwargs
+        return lambda fragment_ids: {"status": "success", "fragment_ids": fragment_ids}
+
+    def fake_map_async_with_pool(**kwargs):
+        captured["map_kwargs"] = kwargs
+        return [
+            {
+                "status": "success",
+                "fragment_ids": [0, 1],
+                "segment_index": "segment",
+            }
+        ]
+
+    monkeypatch.setattr(index_mod, "_check_pylance_version", lambda: None)
+    monkeypatch.setattr(index_mod, "IndicesBuilder", FakeIndicesBuilder)
+    monkeypatch.setattr(index_mod, "LanceDataset", fake_lance_dataset)
+    monkeypatch.setattr(
+        index_mod,
+        "_handle_vector_fragment_index",
+        fake_handle_vector_fragment_index,
+    )
+    monkeypatch.setattr(index_mod, "_map_async_with_pool", fake_map_async_with_pool)
+
+    updated_dataset = index_mod.create_index(
+        uri="memory://fake",
+        column="vector",
+        index_type="IVF_PQ",
+        name="vector_idx",
+        num_workers=2,
+        num_partitions=4,
+        num_sub_vectors=4,
+        block_size=8192,
+    )
+
+    assert updated_dataset is fake_dataset
+    assert [load["block_size"] for load in captured["loads"]] == [8192, 8192]
+    assert captured["fragment_handler_kwargs"]["block_size"] == 8192
+
+
+def test_fragment_handlers_pass_block_size_to_dataset_load(monkeypatch):
+    """Worker-side scalar and vector handlers should load datasets with block_size."""
+
+    captured = {"loads": []}
+    fake_dataset = _FakeDataset()
+
+    def fake_lance_dataset(*args, **kwargs):
+        captured["loads"].append(kwargs)
+        return fake_dataset
+
+    monkeypatch.setattr(index_mod, "LanceDataset", fake_lance_dataset)
+
+    scalar_handler = index_mod._handle_fragment_index(
+        dataset_uri="memory://fake",
+        column="value",
+        index_type="BTREE",
+        name="value_idx",
+        index_uuid="scalar-index",
+        replace=False,
+        train=True,
+        block_size=4096,
+    )
+    vector_handler = index_mod._handle_vector_fragment_index(
+        dataset_uri="memory://fake",
+        column="vector",
+        index_type="IVF_PQ",
+        name="vector_idx",
+        index_uuid="vector-index",
+        replace=False,
+        metric="l2",
+        num_partitions=4,
+        num_sub_vectors=4,
+        ivf_centroids="ivf_centroids",
+        pq_codebook="pq_codebook",
+        block_size=8192,
+    )
+
+    assert scalar_handler([0])["status"] == "success"
+    assert vector_handler([0])["status"] == "success"
+    assert [load["block_size"] for load in captured["loads"]] == [4096, 8192]


### PR DESCRIPTION
## Summary
- add a `block_size` option to distributed scalar and vector index APIs
- pass it to every `LanceDataset(...)` load used by driver reloads and worker fragment handlers
- document the option and cover scalar/vector load propagation with unit tests

## Background
Large remote datasets can need a larger read block size when Lance loads the dataset during distributed index creation. This exposes one high-priority dataset load option directly on both `create_scalar_index` and `create_index`.

There are other `LanceDataset` loading options we could expose in the future. For now this PR intentionally keeps the public surface small and adds `block_size` first because it is the immediate performance tuning knob needed for large-scale indexing. We can extend the interface later when concrete scenarios require additional parameters.

## Test
- `python -m py_compile lance_ray/index.py tests/test_vector_index_options.py`
- `uv run --no-sync ruff check lance_ray/index.py tests/test_vector_index_options.py`
- `uv run --no-sync pytest tests/test_vector_index_options.py`


## Use case

Before changes, use default block_size=64KB.  The "sample data" procedure in `train_ivf` took 20 minutes.
After changes, we use block_size=256KB. The "sample data" procedure in `train_ivf` took 3 minutes.
