### PR TITLE
chore: update pylance dependency to v7.0.0b8

### DIFF
--- a/lance_ray/datasource.py
+++ b/lance_ray/datasource.py
@@ -183,7 +183,17 @@ class LanceDatasource(Datasource):
                 )
 
             read_task = ReadTask(
-                lambda fids=fragment_ids, uri=dataset_uri, version=dataset_version, storage_options=dataset_storage_options, manifest=serialized_manifest, ns_impl=namespace_impl, ns_props=namespace_properties, tbl_id=table_id, base_params=base_store_params, scanner_options=self._scanner_options, retry_params=self._retry_params: (
+                lambda fids=fragment_ids,
+                uri=dataset_uri,
+                version=dataset_version,
+                storage_options=dataset_storage_options,
+                manifest=serialized_manifest,
+                ns_impl=namespace_impl,
+                ns_props=namespace_properties,
+                tbl_id=table_id,
+                base_params=base_store_params,
+                scanner_options=self._scanner_options,
+                retry_params=self._retry_params: (
                     _read_fragments_with_retry(
                         fids,
                         uri,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=7.0.0b7",
+    "pylance>=7.0.0b8",
     "lance-namespace",
     "packaging",
     "pyarrow>=17.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -387,7 +387,7 @@ requires-dist = [
     { name = "more-itertools", marker = "python_full_version < '3.12'", specifier = ">=2.6.0" },
     { name = "packaging" },
     { name = "pyarrow", specifier = ">=17.0.0" },
-    { name = "pylance", specifier = ">=7.0.0b7" },
+    { name = "pylance", specifier = ">=7.0.0b8" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
@@ -1024,7 +1024,7 @@ wheels = [
 
 [[package]]
 name = "pylance"
-version = "7.0.0b7"
+version = "7.0.0b8"
 source = { registry = "https://pypi.fury.io/lance-format" }
 dependencies = [
     { name = "lance-namespace" },
@@ -1033,12 +1033,12 @@ dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://pypi.fury.io/lance-format/-/ver_1zsVV4/pylance-7.0.0b7-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:66f2ba7969c0fad259f5d13842e89d664956c1415eed644d6956af333e848a62" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1TtYis/pylance-7.0.0b7-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:029ac2359cccbac62345392c78f5aae6596eda4a3398fbf8bef5aad708591d14" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_uZkce/pylance-7.0.0b7-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a53841757573d7c63238d79df94236eb6e46d9508d2690d98ce983e5d04f8c7a" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_3iSeD/pylance-7.0.0b7-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:34c67a0102d47f870d4b795087622c16087aa1928c1925b1acdeb61206f4663a" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_BpURn/pylance-7.0.0b7-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ac70f0248239b50ae718e38e69c1418899a1a7575e7b911beac91eeb60b174ec" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_jVZS2/pylance-7.0.0b7-cp39-abi3-win_amd64.whl", hash = "sha256:0f1caea57ea998f6e59dcb2684a08e4b06f993ecc77c8d0f032a4a43a82ed085" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1gRx5m/pylance-7.0.0b8-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:70f69906b3cea691faef62a5b05265c096f971ad94178bf9ec1b7abfc8da9b02" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_2dzc3J/pylance-7.0.0b8-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7728648c450e487863a70f7fd1a2a8a01f366305ff3a1703c8a582f9c41270ff" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_2eogKV/pylance-7.0.0b8-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:038d908ac38653422a4289642c70fad1aca74808253a6ee44b60b20e643d73f8" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_nptfY/pylance-7.0.0b8-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:304511c835674ba8019910de0f8f241a26e8d8ec2a1419e4831371636c5a019b" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1hfW2y/pylance-7.0.0b8-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0d1dd9338d87cb40f6aab8f4f431ba76088a5a7b4f12724402b6221fc3d15e31" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1PfJZn/pylance-7.0.0b8-cp39-abi3-win_amd64.whl", hash = "sha256:2c35f5b3e48ffe19645b81dd50e5ff0bb61bdde753d0242986f9bd6e421845e0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump the Pylance dependency from `pylance>=7.0.0b7` to `pylance>=7.0.0b8` in `pyproject.toml`.
- Regenerate `uv.lock` with `make lock` so it resolves Pylance 7.0.0b8.
- Apply the formatter change required by `make lint` via `make fix`.

## Verification
- `make lock`
- `make lint` initially found one formatting issue in `lance_ray/datasource.py`.
- `make fix`
- `make lint` passed after formatting.

Triggered by tag: [refs/tags/v7.0.0-beta.8](https://github.com/lance-format/lance/releases/tag/v7.0.0-beta.8)
