### PR TITLE
perf: share IVF centroids and PQ codebook across Ray tasks

### DIFF
--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -3,10 +3,12 @@
 
 import logging
 import uuid
-from typing import Any, Literal, Optional, Union
+from collections.abc import Callable
+from typing import Any, Literal, Optional, TypeAlias, Union
 
 import lance
 import pyarrow as pa
+import ray
 from lance.dataset import Index, IndexConfig, LanceDataset
 from lance.indices import IndicesBuilder
 from packaging import version
@@ -19,6 +21,15 @@ from .utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+_VectorIndexArtifact: TypeAlias = (
+    pa.Array | pa.FixedSizeListArray | pa.FixedShapeTensorArray | None
+)
+_VectorIndexArtifactRef: TypeAlias = _VectorIndexArtifact | ray.ObjectRef
+_VectorIndexArtifactRefs: TypeAlias = tuple[
+    _VectorIndexArtifactRef, _VectorIndexArtifactRef
+]
 
 
 def _dataset_load_kwargs(
@@ -115,7 +126,7 @@ def _distribute_fragments_balanced(
 
 
 def _map_async_with_pool(
-    fragment_handler: Any,
+    create_fragment_handler: Callable[[], Any],
     fragment_batches: list[list[int]],
     *,
     num_workers: int,
@@ -129,13 +140,13 @@ def _map_async_with_pool(
     the same implementation.
     """
     pool = Pool(processes=num_workers, ray_remote_args=ray_remote_args)
-    rst_futures = pool.map_async(
-        fragment_handler,
-        fragment_batches,
-        chunksize=1,
-    )
-
     try:
+        fragment_handler = create_fragment_handler()
+        rst_futures = pool.map_async(
+            fragment_handler,
+            fragment_batches,
+            chunksize=1,
+        )
         results = rst_futures.get()
     except Exception as exc:  # pragma: no cover - exercised via integration tests
         raise RuntimeError(f"{error_prefix}: {exc}") from exc
@@ -143,6 +154,33 @@ def _map_async_with_pool(
         pool.close()
 
     return results
+
+
+def _is_ray_object_ref(value: Any) -> bool:
+    object_ref_type = getattr(ray, "ObjectRef", None)
+    return object_ref_type is not None and isinstance(value, object_ref_type)
+
+
+def _ray_put_index_artifact(value: Any) -> _VectorIndexArtifactRef:
+    if value is None or _is_ray_object_ref(value):
+        return value
+    return ray.put(value)
+
+
+def _ray_get_index_artifact(value: Any) -> _VectorIndexArtifact:
+    if _is_ray_object_ref(value):
+        return ray.get(value)
+    return value
+
+
+def _put_vector_index_artifacts_in_object_store(
+    ivf_centroids: pa.Array | pa.FixedSizeListArray | pa.FixedShapeTensorArray | None,
+    pq_codebook: pa.Array | pa.FixedSizeListArray | pa.FixedShapeTensorArray | None,
+) -> _VectorIndexArtifactRefs:
+    return (
+        _ray_put_index_artifact(ivf_centroids),
+        _ray_put_index_artifact(pq_codebook),
+    )
 
 
 def _handle_fragment_index(
@@ -490,21 +528,22 @@ def create_scalar_index(
 
     fragment_batches = _distribute_fragments_balanced(fragments, num_workers, logger)
 
-    fragment_handler = _handle_fragment_index(
-        dataset_uri=uri,
-        column=column,
-        index_type=index_type,
-        name=name,
-        index_uuid=index_id,
-        replace=False,
-        train=train,
-        storage_options=merged_storage_options,
-        block_size=block_size,
-        namespace_impl=namespace_impl,
-        namespace_properties=namespace_properties,
-        table_id=table_id,
-        **kwargs,
-    )
+    def create_fragment_handler() -> Any:
+        return _handle_fragment_index(
+            dataset_uri=uri,
+            column=column,
+            index_type=index_type,
+            name=name,
+            index_uuid=index_id,
+            replace=False,
+            train=train,
+            storage_options=merged_storage_options,
+            block_size=block_size,
+            namespace_impl=namespace_impl,
+            namespace_properties=namespace_properties,
+            table_id=table_id,
+            **kwargs,
+        )
 
     logger.info(
         "Phase 1: Distributing scalar index build across %d workers for %d fragments",
@@ -513,7 +552,7 @@ def create_scalar_index(
     )
 
     results = _map_async_with_pool(
-        fragment_handler=fragment_handler,
+        create_fragment_handler=create_fragment_handler,
         fragment_batches=fragment_batches,
         num_workers=num_workers,
         ray_remote_args=ray_remote_args,
@@ -709,6 +748,9 @@ def _handle_vector_fragment_index(
                 fragment_ids,
             )
 
+            resolved_ivf_centroids = _ray_get_index_artifact(ivf_centroids)
+            resolved_pq_codebook = _ray_get_index_artifact(pq_codebook)
+
             segment_index = dataset.create_index_uncommitted(
                 column=column,
                 index_type=index_type,
@@ -716,8 +758,8 @@ def _handle_vector_fragment_index(
                 metric=metric,
                 replace=replace,
                 num_partitions=num_partitions,
-                ivf_centroids=ivf_centroids,
-                pq_codebook=pq_codebook,
+                ivf_centroids=resolved_ivf_centroids,
+                pq_codebook=resolved_pq_codebook,
                 num_sub_vectors=num_sub_vectors,
                 storage_options=storage_options,
                 train=True,
@@ -975,28 +1017,35 @@ def create_index(
         len(fragment_ids_to_use),
     )
 
-    fragment_handler = _handle_vector_fragment_index(
-        dataset_uri=dataset_uri,
-        column=column,
-        index_type=index_type_name,
-        name=name,
-        index_uuid=index_id,
-        replace=replace,
-        metric=metric_lower,
-        num_partitions=num_partitions,
-        num_sub_vectors=num_sub_vectors,
-        ivf_centroids=ivf_centroids_artifact,
-        pq_codebook=pq_codebook_artifact,
-        storage_options=merged_storage_options,
-        block_size=block_size,
-        namespace_impl=namespace_impl,
-        namespace_properties=namespace_properties,
-        table_id=table_id,
-        **kwargs,
-    )
+    def create_fragment_handler() -> Any:
+        shared_ivf_centroids, shared_pq_codebook = (
+            _put_vector_index_artifacts_in_object_store(
+                ivf_centroids_artifact,
+                pq_codebook_artifact,
+            )
+        )
+        return _handle_vector_fragment_index(
+            dataset_uri=dataset_uri,
+            column=column,
+            index_type=index_type_name,
+            name=name,
+            index_uuid=index_id,
+            replace=replace,
+            metric=metric_lower,
+            num_partitions=num_partitions,
+            num_sub_vectors=num_sub_vectors,
+            ivf_centroids=shared_ivf_centroids,
+            pq_codebook=shared_pq_codebook,
+            storage_options=merged_storage_options,
+            block_size=block_size,
+            namespace_impl=namespace_impl,
+            namespace_properties=namespace_properties,
+            table_id=table_id,
+            **kwargs,
+        )
 
     results = _map_async_with_pool(
-        fragment_handler=fragment_handler,
+        create_fragment_handler=create_fragment_handler,
         fragment_batches=fragment_batches,
         num_workers=num_workers,
         ray_remote_args=ray_remote_args,

--- a/tests/test_vector_index_options.py
+++ b/tests/test_vector_index_options.py
@@ -27,6 +27,7 @@ def _load_index_module_with_stubs():
     lance_indices.IndicesBuilder = object
 
     ray = ModuleType("ray")
+    ray.ObjectRef = type("ObjectRef", (), {})
     ray_util = ModuleType("ray.util")
     ray_multiprocessing = ModuleType("ray.util.multiprocessing")
     ray_multiprocessing.Pool = object
@@ -169,8 +170,13 @@ def test_create_index_uses_sample_rate_for_global_training(monkeypatch):
         captured["fragment_handler_kwargs"] = kwargs
         return lambda fragment_ids: {"status": "success", "fragment_ids": fragment_ids}
 
+    def fake_put_vector_index_artifacts(ivf_centroids, pq_codebook):
+        captured["put_artifacts"] = (ivf_centroids, pq_codebook)
+        return "ivf_ref", "pq_ref"
+
     def fake_map_async_with_pool(**kwargs):
         captured["map_kwargs"] = kwargs
+        kwargs["create_fragment_handler"]()
         return [
             {
                 "status": "success",
@@ -186,6 +192,11 @@ def test_create_index_uses_sample_rate_for_global_training(monkeypatch):
         index_mod,
         "_handle_vector_fragment_index",
         fake_handle_vector_fragment_index,
+    )
+    monkeypatch.setattr(
+        index_mod,
+        "_put_vector_index_artifacts_in_object_store",
+        fake_put_vector_index_artifacts,
     )
     monkeypatch.setattr(index_mod, "_map_async_with_pool", fake_map_async_with_pool)
 
@@ -203,8 +214,9 @@ def test_create_index_uses_sample_rate_for_global_training(monkeypatch):
     assert updated_dataset is fake_dataset
     assert captured["train_ivf"]["sample_rate"] == 8
     assert captured["train_pq"]["sample_rate"] == 8
-    assert captured["fragment_handler_kwargs"]["ivf_centroids"] == "ivf_centroids"
-    assert captured["fragment_handler_kwargs"]["pq_codebook"] == "pq_codebook"
+    assert captured["put_artifacts"] == ("ivf_centroids", "pq_codebook")
+    assert captured["fragment_handler_kwargs"]["ivf_centroids"] == "ivf_ref"
+    assert captured["fragment_handler_kwargs"]["pq_codebook"] == "pq_ref"
     assert "sample_rate" not in captured["fragment_handler_kwargs"]
 
 
@@ -242,6 +254,7 @@ def test_create_scalar_index_passes_block_size_to_loads_and_handler(monkeypatch)
 
     def fake_map_async_with_pool(**kwargs):
         captured["map_kwargs"] = kwargs
+        kwargs["create_fragment_handler"]()
         return [
             {
                 "status": "success",
@@ -315,8 +328,13 @@ def test_create_index_passes_block_size_to_loads_and_handler(monkeypatch):
         captured["fragment_handler_kwargs"] = kwargs
         return lambda fragment_ids: {"status": "success", "fragment_ids": fragment_ids}
 
+    def fake_put_vector_index_artifacts(ivf_centroids, pq_codebook):
+        captured["put_artifacts"] = (ivf_centroids, pq_codebook)
+        return "ivf_ref", "pq_ref"
+
     def fake_map_async_with_pool(**kwargs):
         captured["map_kwargs"] = kwargs
+        kwargs["create_fragment_handler"]()
         return [
             {
                 "status": "success",
@@ -332,6 +350,11 @@ def test_create_index_passes_block_size_to_loads_and_handler(monkeypatch):
         index_mod,
         "_handle_vector_fragment_index",
         fake_handle_vector_fragment_index,
+    )
+    monkeypatch.setattr(
+        index_mod,
+        "_put_vector_index_artifacts_in_object_store",
+        fake_put_vector_index_artifacts,
     )
     monkeypatch.setattr(index_mod, "_map_async_with_pool", fake_map_async_with_pool)
 
@@ -349,6 +372,7 @@ def test_create_index_passes_block_size_to_loads_and_handler(monkeypatch):
     assert updated_dataset is fake_dataset
     assert [load["block_size"] for load in captured["loads"]] == [8192, 8192]
     assert captured["fragment_handler_kwargs"]["block_size"] == 8192
+    assert captured["put_artifacts"] == ("ivf_centroids", "pq_codebook")
 
 
 def test_fragment_handlers_pass_block_size_to_dataset_load(monkeypatch):
@@ -391,3 +415,43 @@ def test_fragment_handlers_pass_block_size_to_dataset_load(monkeypatch):
     assert scalar_handler([0])["status"] == "success"
     assert vector_handler([0])["status"] == "success"
     assert [load["block_size"] for load in captured["loads"]] == [4096, 8192]
+
+
+def test_vector_fragment_handler_resolves_shared_artifact_refs(monkeypatch):
+    """Workers should dereference shared training artifacts before Lance calls."""
+
+    class FakeObjectRef:
+        def __init__(self, value):
+            self.value = value
+
+    fake_dataset = _FakeDataset()
+    captured = {"gets": []}
+
+    def fake_get(ref):
+        captured["gets"].append(ref)
+        return ref.value
+
+    monkeypatch.setattr(index_mod.ray, "ObjectRef", FakeObjectRef, raising=False)
+    monkeypatch.setattr(index_mod.ray, "get", fake_get, raising=False)
+    monkeypatch.setattr(index_mod, "LanceDataset", lambda *args, **kwargs: fake_dataset)
+
+    ivf_ref = FakeObjectRef("ivf_centroids")
+    pq_ref = FakeObjectRef("pq_codebook")
+    vector_handler = index_mod._handle_vector_fragment_index(
+        dataset_uri="memory://fake",
+        column="vector",
+        index_type="IVF_PQ",
+        name="vector_idx",
+        index_uuid="vector-index",
+        replace=False,
+        metric="l2",
+        num_partitions=4,
+        num_sub_vectors=4,
+        ivf_centroids=ivf_ref,
+        pq_codebook=pq_ref,
+    )
+
+    assert vector_handler([0])["status"] == "success"
+    assert captured["gets"] == [ivf_ref, pq_ref]
+    assert fake_dataset.vector_index_kwargs["ivf_centroids"] == "ivf_centroids"
+    assert fake_dataset.vector_index_kwargs["pq_codebook"] == "pq_codebook"


### PR DESCRIPTION
## Summary

- Put IVF centroids and PQ codebooks into Ray's object store before submitting vector index fragment tasks.
- Pass small ObjectRefs through the Ray Pool task closure and dereference them inside workers before calling Lance.
- Add tests covering the shared-artifact path and worker-side dereferencing.

## Why

The vector index build path captured the same trained IVF/PQ artifacts in the fragment handler closure. Ray Pool then submitted that closure to each worker task, causing repeated serialization of the same potentially large Arrow objects. Sharing the artifacts through Ray's object store avoids that driver-side duplication and lets Ray manage reuse by ObjectRef.

## Validation

- `python -m py_compile lance_ray/index.py tests/test_vector_index_options.py`
- `python -m pytest tests/test_vector_index_options.py`
- `uv run --no-sync ruff check lance_ray/index.py tests/test_vector_index_options.py`
- `git diff --check`