### PR TITLE
fix: join Ray pools after closing

### DIFF
--- a/lance_ray/compaction.py
+++ b/lance_ray/compaction.py
@@ -185,6 +185,7 @@ def compact_files(
         raise RuntimeError(f"Failed to complete distributed compaction: {e}") from e
     finally:
         pool.close()
+        pool.join()
 
     # Check for failures
     failed_results = [r for r in results if r["status"] == "error"]

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -152,6 +152,7 @@ def _map_async_with_pool(
         raise RuntimeError(f"{error_prefix}: {exc}") from exc
     finally:
         pool.close()
+        pool.join()
 
     return results
 

--- a/lance_ray/io.py
+++ b/lance_ray/io.py
@@ -551,6 +551,7 @@ def add_columns(
         raise RuntimeError(f"Failed to add columns: {exc}") from exc
     finally:
         pool.close()
+        pool.join()
 
     commit_messages = []
     new_schema = None

--- a/tests/test_vector_index_options.py
+++ b/tests/test_vector_index_options.py
@@ -144,6 +144,53 @@ class _FakeDataset:
         return self
 
 
+def test_map_async_with_pool_closes_and_joins_pool(monkeypatch):
+    """The Ray Pool should be joined after close so actors finish cleanup."""
+
+    events = []
+
+    class FakeAsyncResult:
+        def get(self):
+            events.append("get")
+            return [{"status": "success"}]
+
+    class FakePool:
+        def __init__(self, processes, ray_remote_args):
+            events.append(("init", processes, ray_remote_args))
+
+        def map_async(self, fragment_handler, fragment_batches, chunksize):
+            events.append(("map_async", fragment_batches, chunksize))
+            return FakeAsyncResult()
+
+        def close(self):
+            events.append("close")
+
+        def join(self):
+            events.append("join")
+
+    def create_fragment_handler():
+        events.append("create_handler")
+        return lambda fragment_ids: {"status": "success", "fragment_ids": fragment_ids}
+
+    monkeypatch.setattr(index_mod, "Pool", FakePool)
+
+    assert index_mod._map_async_with_pool(
+        create_fragment_handler=create_fragment_handler,
+        fragment_batches=[[0, 1]],
+        num_workers=2,
+        ray_remote_args={"num_cpus": 1},
+        error_prefix="failed",
+    ) == [{"status": "success"}]
+    assert events == [
+        ("init", 2, {"num_cpus": 1}),
+        "create_handler",
+        ("map_async", [[0, 1]], 1),
+        "get",
+        "close",
+        "join",
+    ]
+
+
 def test_create_index_uses_sample_rate_for_global_training(monkeypatch):
     """The public sample_rate option should drive both IVF and PQ training."""
 


### PR DESCRIPTION
## Summary

- Call `pool.join()` after `pool.close()` in the Ray Pool cleanup paths for distributed indexing, `add_columns`, and compaction.
- Add a unit test covering the shared index Pool helper cleanup order.

## Why

`ray.util.multiprocessing.Pool` follows the multiprocessing-style lifecycle: `close()` prevents new work and lets outstanding actor work finish, but it does not wait for the Pool actors to exit. `join()` is the call that waits for actors in a closed Pool to stop.

These code paths already wait for `map_async(...).get()` before returning results, so this does not change result collection semantics. It makes worker actor cleanup deterministic after successful and failed runs, reducing the chance of transient Ray actor/resource leftovers across repeated operations or tests.

## Validation

- `python -m py_compile lance_ray/index.py lance_ray/io.py lance_ray/compaction.py tests/test_vector_index_options.py`
- `python -m pytest tests/test_vector_index_options.py`
- `uv run --no-sync ruff check lance_ray/index.py tests/test_vector_index_options.py`
- `git diff --check`