### PR TITLE
chore: update pylance dependency to v7.0.0b10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=7.0.0b7",
+    "pylance>=7.0.0b10",
     "lance-namespace",
     "packaging",
     "pyarrow>=17.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -387,7 +387,7 @@ requires-dist = [
     { name = "more-itertools", marker = "python_full_version < '3.12'", specifier = ">=2.6.0" },
     { name = "packaging" },
     { name = "pyarrow", specifier = ">=17.0.0" },
-    { name = "pylance", specifier = ">=7.0.0b7" },
+    { name = "pylance", specifier = ">=7.0.0b10" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
@@ -1024,7 +1024,7 @@ wheels = [
 
 [[package]]
 name = "pylance"
-version = "7.0.0b7"
+version = "7.0.0b10"
 source = { registry = "https://pypi.fury.io/lance-format" }
 dependencies = [
     { name = "lance-namespace" },
@@ -1033,12 +1033,12 @@ dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://pypi.fury.io/lance-format/-/ver_1zsVV4/pylance-7.0.0b7-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:66f2ba7969c0fad259f5d13842e89d664956c1415eed644d6956af333e848a62" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1TtYis/pylance-7.0.0b7-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:029ac2359cccbac62345392c78f5aae6596eda4a3398fbf8bef5aad708591d14" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_uZkce/pylance-7.0.0b7-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a53841757573d7c63238d79df94236eb6e46d9508d2690d98ce983e5d04f8c7a" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_3iSeD/pylance-7.0.0b7-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:34c67a0102d47f870d4b795087622c16087aa1928c1925b1acdeb61206f4663a" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_BpURn/pylance-7.0.0b7-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ac70f0248239b50ae718e38e69c1418899a1a7575e7b911beac91eeb60b174ec" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_jVZS2/pylance-7.0.0b7-cp39-abi3-win_amd64.whl", hash = "sha256:0f1caea57ea998f6e59dcb2684a08e4b06f993ecc77c8d0f032a4a43a82ed085" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_sHR0B/pylance-7.0.0b10-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:f0418906029460f84d50d57cb8216afeff5aeccb99de50ed2d7619ba8b99f5e1" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_10HDTS/pylance-7.0.0b10-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ac70947ae323af56d2227a48c7dcb080137fb1b5ce6d29fb91f60cfcc7861f2b" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_23iRxo/pylance-7.0.0b10-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4f4868f15afbced9c08a3d38b4cce70d1fb628129e3a4f15c7679ef564ed1df" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1vSxHh/pylance-7.0.0b10-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:42dbc2d1f0c3ec19d624f244604efffcab4f769bef4cb868c96eb1995b38bb96" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_22Etj7/pylance-7.0.0b10-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1e332214a008fcf0df063a5f4431af1f22c5fbfdcabe82ee29baa83496acf1a4" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_fjDRm/pylance-7.0.0b10-cp39-abi3-win_amd64.whl", hash = "sha256:6af01925e5e2f89a2921b6e2095aff505819377dcd455bb651752e6609bebfb9" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Update the `pylance` dependency requirement to `pylance>=7.0.0b10` using PEP 440 beta format.
- Refresh `uv.lock` with `make lock` so the locked Pylance package moves from `7.0.0b7` to `7.0.0b10`.

## Verification
- `make lint`

Triggering tag: https://github.com/lance-format/lance/releases/tag/v7.0.0-beta.10 (`refs/tags/v7.0.0-beta.10`)
