### PR TITLE
chore: update pylance dependency to v7.0.0b12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=7.0.0b7",
+    "pylance>=7.0.0b12",
     "lance-namespace",
     "packaging",
     "pyarrow>=17.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -387,7 +387,7 @@ requires-dist = [
     { name = "more-itertools", marker = "python_full_version < '3.12'", specifier = ">=2.6.0" },
     { name = "packaging" },
     { name = "pyarrow", specifier = ">=17.0.0" },
-    { name = "pylance", specifier = ">=7.0.0b7" },
+    { name = "pylance", specifier = ">=7.0.0b12" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
@@ -1024,7 +1024,7 @@ wheels = [
 
 [[package]]
 name = "pylance"
-version = "7.0.0b7"
+version = "7.0.0b12"
 source = { registry = "https://pypi.fury.io/lance-format" }
 dependencies = [
     { name = "lance-namespace" },
@@ -1033,12 +1033,12 @@ dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://pypi.fury.io/lance-format/-/ver_1zsVV4/pylance-7.0.0b7-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:66f2ba7969c0fad259f5d13842e89d664956c1415eed644d6956af333e848a62" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1TtYis/pylance-7.0.0b7-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:029ac2359cccbac62345392c78f5aae6596eda4a3398fbf8bef5aad708591d14" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_uZkce/pylance-7.0.0b7-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a53841757573d7c63238d79df94236eb6e46d9508d2690d98ce983e5d04f8c7a" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_3iSeD/pylance-7.0.0b7-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:34c67a0102d47f870d4b795087622c16087aa1928c1925b1acdeb61206f4663a" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_BpURn/pylance-7.0.0b7-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ac70f0248239b50ae718e38e69c1418899a1a7575e7b911beac91eeb60b174ec" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_jVZS2/pylance-7.0.0b7-cp39-abi3-win_amd64.whl", hash = "sha256:0f1caea57ea998f6e59dcb2684a08e4b06f993ecc77c8d0f032a4a43a82ed085" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_hMCVk/pylance-7.0.0b12-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:37dbb8256c7ebe432a2250046cd0bf79e8c27013110bc930722730ae82e8d0c3" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_Pe2YB/pylance-7.0.0b12-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d077b5710efbed181402724c46adc6add7e5c06f108f820e757f04a75276fba" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1Smykz/pylance-7.0.0b12-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b02e257c8392c5bc43b53a6dc312b1ffba108845e9e834ef19ef8485b263dcae" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1knRCM/pylance-7.0.0b12-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:11bc9fe752ad3b999380b70419b9ac65320e78bc7a18968e2977aa60399926aa" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_6J2CG/pylance-7.0.0b12-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b6b19b712e8cc06b32c05f337b64ecc7ea53dc956fd71155bbf5c3bb9a87923c" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_E9Dfj/pylance-7.0.0b12-cp39-abi3-win_amd64.whl", hash = "sha256:197a9daf420fd9bafc6b1be31cdad010da81645da1b4ee7e6cdd6b0a30fea2de" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Update the Pylance dependency lower bound to `pylance>=7.0.0b12`.
- Refresh `uv.lock` so it resolves Pylance `7.0.0b12`.

## Verification
- `make lock`
- `make lint` (after installing the project dev extra so `ruff` is available in the fresh runner environment)

Triggering tag: `refs/tags/v7.0.0-beta.12`
