### PR TITLE
chore: log Ray Pool run batches

### DIFF
--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -141,7 +141,7 @@ def _map_async_with_pool(
     """
     pool = Pool(processes=num_workers, ray_remote_args=ray_remote_args)
     try:
-        fragment_handler = create_fragment_handler()
+        fragment_handler = _with_pool_run_batch_logging(create_fragment_handler())
         rst_futures = pool.map_async(
             fragment_handler,
             fragment_batches,
@@ -154,6 +154,28 @@ def _map_async_with_pool(
         pool.close()
 
     return results
+
+
+def _format_fragment_batch_for_log(fragment_batch: list[int]) -> str:
+    preview = fragment_batch[:10]
+    suffix = "..." if len(fragment_batch) > len(preview) else ""
+    return f"size={len(fragment_batch)}, fragment_ids={preview}{suffix}"
+
+
+def _with_pool_run_batch_logging(fragment_handler: Any) -> Any:
+    def logged_fragment_handler(fragment_batch: list[int]) -> dict[str, Any]:
+        batch_summary = _format_fragment_batch_for_log(fragment_batch)
+        logger.info("Starting Ray Pool run_batch for %s", batch_summary)
+        result = fragment_handler(fragment_batch)
+        status = result.get("status") if isinstance(result, dict) else None
+        logger.info(
+            "Finished Ray Pool run_batch for %s with status=%s",
+            batch_summary,
+            status,
+        )
+        return result
+
+    return logged_fragment_handler
 
 
 def _is_ray_object_ref(value: Any) -> bool:

--- a/tests/test_vector_index_options.py
+++ b/tests/test_vector_index_options.py
@@ -1,6 +1,7 @@
 """Tests for distributed vector index option handling."""
 
 import importlib.util
+import logging
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -142,6 +143,64 @@ class _FakeDataset:
     def commit_existing_index_segments(self, **kwargs):
         self.commit_kwargs = kwargs
         return self
+
+
+def test_map_async_with_pool_logs_run_batch(monkeypatch, caplog):
+    """The Ray Pool helper should log each run_batch business batch."""
+
+    events = []
+
+    class FakeAsyncResult:
+        def __init__(self, result):
+            self.result = result
+
+        def get(self):
+            events.append("get")
+            return [self.result]
+
+    class FakePool:
+        def __init__(self, processes, ray_remote_args):
+            events.append(("init", processes, ray_remote_args))
+
+        def map_async(self, fragment_handler, fragment_batches, chunksize):
+            events.append(("map_async", fragment_batches, chunksize))
+            return FakeAsyncResult(fragment_handler(fragment_batches[0]))
+
+        def close(self):
+            events.append("close")
+
+    def create_fragment_handler():
+        events.append("create_handler")
+        return lambda fragment_ids: {"status": "success", "fragment_ids": fragment_ids}
+
+    monkeypatch.setattr(index_mod, "Pool", FakePool)
+    caplog.set_level(logging.INFO, logger=index_mod.logger.name)
+
+    assert index_mod._map_async_with_pool(
+        create_fragment_handler=create_fragment_handler,
+        fragment_batches=[[0, 1]],
+        num_workers=2,
+        ray_remote_args={"num_cpus": 1},
+        error_prefix="failed",
+    ) == [{"status": "success", "fragment_ids": [0, 1]}]
+    assert events == [
+        ("init", 2, {"num_cpus": 1}),
+        "create_handler",
+        ("map_async", [[0, 1]], 1),
+        "get",
+        "close",
+    ]
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        "Starting Ray Pool run_batch for size=2, fragment_ids=[0, 1]"
+        in message
+        for message in messages
+    )
+    assert any(
+        "Finished Ray Pool run_batch for size=2, fragment_ids=[0, 1] with status=success"
+        in message
+        for message in messages
+    )
 
 
 def test_create_index_uses_sample_rate_for_global_training(monkeypatch):


### PR DESCRIPTION
## Summary

- Add info-level logs before and after each index Ray Pool `run_batch` business batch.
- Include batch size, a bounded fragment ID preview, and result status in the log messages.
- Add a unit test that exercises the shared index Pool helper and verifies the run-batch log messages.

## Why

The index helper submits `fragment_batches` to `ray.util.multiprocessing.Pool.map_async(..., chunksize=1)`. In Ray Pool, each submitted chunk is executed by `PoolActor.run_batch`. With `chunksize=1`, each `run_batch` contains one balanced fragment batch.

For large vector index builds, these batches can be memory-heavy or long-running. Bracketing each business batch with info-level logs makes it easier to identify which fragment batch is starting, which one completed, and what status it returned, without logging an unbounded list of fragment IDs.

## Validation

- `python -m py_compile lance_ray/index.py tests/test_vector_index_options.py`
- `python -m pytest tests/test_vector_index_options.py`
- `uv run --no-sync ruff check lance_ray/index.py tests/test_vector_index_options.py`
- `git diff --check`