### PR TITLE
chore: update pylance dependency to v7.0.0b13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=7.0.0b7",
+    "pylance>=7.0.0b13",
     "lance-namespace",
     "packaging",
     "pyarrow>=17.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -387,7 +387,7 @@ requires-dist = [
     { name = "more-itertools", marker = "python_full_version < '3.12'", specifier = ">=2.6.0" },
     { name = "packaging" },
     { name = "pyarrow", specifier = ">=17.0.0" },
-    { name = "pylance", specifier = ">=7.0.0b7" },
+    { name = "pylance", specifier = ">=7.0.0b13" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
@@ -1024,7 +1024,7 @@ wheels = [
 
 [[package]]
 name = "pylance"
-version = "7.0.0b7"
+version = "7.0.0b13"
 source = { registry = "https://pypi.fury.io/lance-format" }
 dependencies = [
     { name = "lance-namespace" },
@@ -1033,12 +1033,12 @@ dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://pypi.fury.io/lance-format/-/ver_1zsVV4/pylance-7.0.0b7-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:66f2ba7969c0fad259f5d13842e89d664956c1415eed644d6956af333e848a62" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1TtYis/pylance-7.0.0b7-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:029ac2359cccbac62345392c78f5aae6596eda4a3398fbf8bef5aad708591d14" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_uZkce/pylance-7.0.0b7-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a53841757573d7c63238d79df94236eb6e46d9508d2690d98ce983e5d04f8c7a" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_3iSeD/pylance-7.0.0b7-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:34c67a0102d47f870d4b795087622c16087aa1928c1925b1acdeb61206f4663a" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_BpURn/pylance-7.0.0b7-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ac70f0248239b50ae718e38e69c1418899a1a7575e7b911beac91eeb60b174ec" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_jVZS2/pylance-7.0.0b7-cp39-abi3-win_amd64.whl", hash = "sha256:0f1caea57ea998f6e59dcb2684a08e4b06f993ecc77c8d0f032a4a43a82ed085" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1ipIp/pylance-7.0.0b13-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:8d9ff9a51f354410d39960596503f6bf1e8577448ef1736b1e7ec70a220a64be" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_djBen/pylance-7.0.0b13-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f19ca2a756c5a0d64ff94fc85f4facdc56eef41ea64ce36f43e432b6801623a" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_YWxjc/pylance-7.0.0b13-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7354ef3e070d1228ebf131c62db6df98d4103ca9110374182e916bd6c6f252b3" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_KJV5w/pylance-7.0.0b13-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9daf8d63b8b52abd7fc343e5238600a404b3d0542627f6572253c35433469309" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1wfqPr/pylance-7.0.0b13-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:02198628ec52b1f8dfc8835858f13ed3195a74b724a6406d6d7c0f04e91b1265" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_dpKLc/pylance-7.0.0b13-cp39-abi3-win_amd64.whl", hash = "sha256:2d5027cfe06c5e5620f079c21034c19023c05e016f51f409a03d63136ae42d99" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump the `pylance` dependency from `>=7.0.0b7` to `>=7.0.0b13` using PEP 440 beta version format.
- Refresh `uv.lock` with the resolved Pylance 7.0.0b13 artifacts.

## Verification
- `make lock`
- `make lint`

Triggered by tag: refs/tags/v7.0.0-beta.13
