### PR TITLE
chore: update pylance dependency to v7.0.0b15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=7.0.0b7",
+    "pylance>=7.0.0b15",
     "lance-namespace",
     "packaging",
     "pyarrow>=17.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -387,7 +387,7 @@ requires-dist = [
     { name = "more-itertools", marker = "python_full_version < '3.12'", specifier = ">=2.6.0" },
     { name = "packaging" },
     { name = "pyarrow", specifier = ">=17.0.0" },
-    { name = "pylance", specifier = ">=7.0.0b7" },
+    { name = "pylance", specifier = ">=7.0.0b15" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
@@ -1024,7 +1024,7 @@ wheels = [
 
 [[package]]
 name = "pylance"
-version = "7.0.0b7"
+version = "7.0.0b15"
 source = { registry = "https://pypi.fury.io/lance-format" }
 dependencies = [
     { name = "lance-namespace" },
@@ -1033,12 +1033,12 @@ dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://pypi.fury.io/lance-format/-/ver_1zsVV4/pylance-7.0.0b7-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:66f2ba7969c0fad259f5d13842e89d664956c1415eed644d6956af333e848a62" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1TtYis/pylance-7.0.0b7-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:029ac2359cccbac62345392c78f5aae6596eda4a3398fbf8bef5aad708591d14" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_uZkce/pylance-7.0.0b7-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a53841757573d7c63238d79df94236eb6e46d9508d2690d98ce983e5d04f8c7a" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_3iSeD/pylance-7.0.0b7-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:34c67a0102d47f870d4b795087622c16087aa1928c1925b1acdeb61206f4663a" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_BpURn/pylance-7.0.0b7-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ac70f0248239b50ae718e38e69c1418899a1a7575e7b911beac91eeb60b174ec" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_jVZS2/pylance-7.0.0b7-cp39-abi3-win_amd64.whl", hash = "sha256:0f1caea57ea998f6e59dcb2684a08e4b06f993ecc77c8d0f032a4a43a82ed085" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_M087o/pylance-7.0.0b15-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:4702fc4d3319be434a4a882ef90c6f1c576ca66c8fe7bbb9b64cee45231d68d2" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_v2VGn/pylance-7.0.0b15-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f0d31d923b92a0ca81bd9eef6aa3e625a9128ee48d4eab6112daf9546e383d94" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_h5hm6/pylance-7.0.0b15-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:29670a02637237072b834217a1aad849c61f9ec4fafb23a69a200056d14ce1a6" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_2iY3QM/pylance-7.0.0b15-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0ac41228772f58ffe14371c27416174d23cb127586daeb2dd8d979cc25f1c61a" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_2gONzR/pylance-7.0.0b15-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:132497fceee2003e65f69d19cd47ff5b35891b70c11091d53f81f0d6e1bcfb1c" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1keB40/pylance-7.0.0b15-cp39-abi3-win_amd64.whl", hash = "sha256:77bca5797d5c6c3e2794a91ddbf00c7764ef6b4b83cebd1b6adb935c039f5575" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump the `pylance` dependency from `>=7.0.0b7` to `>=7.0.0b15` using PEP 440 format.
- Regenerate `uv.lock` with the updated Pylance wheel hashes.

## Verification
- `make lock`
- `make lint`

Triggered by tag: [refs/tags/v7.0.0-beta.15](https://github.com/lance-format/lance/releases/tag/v7.0.0-beta.15)
