### PR TITLE
chore: update pylance dependency to v7.0.0b16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=7.0.0b7",
+    "pylance>=7.0.0b16",
     "lance-namespace",
     "packaging",
     "pyarrow>=17.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -387,7 +387,7 @@ requires-dist = [
     { name = "more-itertools", marker = "python_full_version < '3.12'", specifier = ">=2.6.0" },
     { name = "packaging" },
     { name = "pyarrow", specifier = ">=17.0.0" },
-    { name = "pylance", specifier = ">=7.0.0b7" },
+    { name = "pylance", specifier = ">=7.0.0b16" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
@@ -1024,7 +1024,7 @@ wheels = [
 
 [[package]]
 name = "pylance"
-version = "7.0.0b7"
+version = "7.0.0b16"
 source = { registry = "https://pypi.fury.io/lance-format" }
 dependencies = [
     { name = "lance-namespace" },
@@ -1033,12 +1033,11 @@ dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://pypi.fury.io/lance-format/-/ver_1zsVV4/pylance-7.0.0b7-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:66f2ba7969c0fad259f5d13842e89d664956c1415eed644d6956af333e848a62" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1TtYis/pylance-7.0.0b7-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:029ac2359cccbac62345392c78f5aae6596eda4a3398fbf8bef5aad708591d14" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_uZkce/pylance-7.0.0b7-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a53841757573d7c63238d79df94236eb6e46d9508d2690d98ce983e5d04f8c7a" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_3iSeD/pylance-7.0.0b7-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:34c67a0102d47f870d4b795087622c16087aa1928c1925b1acdeb61206f4663a" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_BpURn/pylance-7.0.0b7-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ac70f0248239b50ae718e38e69c1418899a1a7575e7b911beac91eeb60b174ec" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_jVZS2/pylance-7.0.0b7-cp39-abi3-win_amd64.whl", hash = "sha256:0f1caea57ea998f6e59dcb2684a08e4b06f993ecc77c8d0f032a4a43a82ed085" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1a89T9/pylance-7.0.0b16-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:6dedc54ba0b5b04e635bf8985f5ed24c3377d98fae4b9e32967c730d629eb849" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_Z4zzZ/pylance-7.0.0b16-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c942f95338349ab0560c329fcf6a1798fd134e18e3d0ad1b6f42ed632db58939" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_JvIEx/pylance-7.0.0b16-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ea03ea3dd4ca844bae67828d829860e80154c023c4fe92c16410916839111e07" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1x4mtg/pylance-7.0.0b16-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a653eb8e00fd86844683e0a585fdf0a01e1ed8ed817ace1ba73b77b8a35743db" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1jcPgE/pylance-7.0.0b16-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:5185f1a2632627b2d4abfc9f50e7e7ef78b0bcb3b4e4c0da7a7b822e1231c738" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Update the `pylance` dependency from `>=7.0.0b7` to `>=7.0.0b16` using PEP 440 beta version format.
- Refresh `uv.lock` with `make lock` so the locked package resolves to `pylance` 7.0.0b16.

## Verification
- `make lock`
- `make build` to install the repository's dev/docs extras needed by the Makefile lint target
- `make lint`

Triggering tag: [refs/tags/v7.0.0-beta.16](https://github.com/lance-format/lance/releases/tag/v7.0.0-beta.16)
