### PR TITLE
chore: update pylance dependency to v7.0.0b17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=7.0.0b7",
+    "pylance>=7.0.0b17",
     "lance-namespace",
     "packaging",
     "pyarrow>=17.0.0",


### PR DESCRIPTION
## Summary
- Update the `pylance` dependency constraint from `>=7.0.0b7` to `>=7.0.0b17` in PEP 440 format.
- Triggering tag: https://github.com/lance-format/lance/releases/tag/v7.0.0-beta.17 (`refs/tags/v7.0.0-beta.17`).

## Verification
- `make lock` was attempted, but `uv` could not resolve `pylance>=7.0.0b17` because the configured package indexes currently expose `pylance` only up to `7.0.0b16`.
- `make lint` was attempted and failed at its `lock` prerequisite for the same resolver issue, so Ruff checks did not run.
- Confirmed with `python -m pip index versions pylance --extra-index-url https://pypi.fury.io/lance-format --pre` that the latest available pre-release is currently `7.0.0b16`.
