### PR TITLE
chore: update pylance dependency to v7.0.0b17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=7.0.0b7",
+    "pylance>=7.0.0b17",
     "lance-namespace",
     "packaging",
     "pyarrow>=17.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -387,7 +387,7 @@ requires-dist = [
     { name = "more-itertools", marker = "python_full_version < '3.12'", specifier = ">=2.6.0" },
     { name = "packaging" },
     { name = "pyarrow", specifier = ">=17.0.0" },
-    { name = "pylance", specifier = ">=7.0.0b7" },
+    { name = "pylance", specifier = ">=7.0.0b17" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
@@ -1024,7 +1024,7 @@ wheels = [
 
 [[package]]
 name = "pylance"
-version = "7.0.0b7"
+version = "7.0.0b17"
 source = { registry = "https://pypi.fury.io/lance-format" }
 dependencies = [
     { name = "lance-namespace" },
@@ -1033,12 +1033,12 @@ dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://pypi.fury.io/lance-format/-/ver_1zsVV4/pylance-7.0.0b7-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:66f2ba7969c0fad259f5d13842e89d664956c1415eed644d6956af333e848a62" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1TtYis/pylance-7.0.0b7-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:029ac2359cccbac62345392c78f5aae6596eda4a3398fbf8bef5aad708591d14" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_uZkce/pylance-7.0.0b7-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a53841757573d7c63238d79df94236eb6e46d9508d2690d98ce983e5d04f8c7a" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_3iSeD/pylance-7.0.0b7-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:34c67a0102d47f870d4b795087622c16087aa1928c1925b1acdeb61206f4663a" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_BpURn/pylance-7.0.0b7-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ac70f0248239b50ae718e38e69c1418899a1a7575e7b911beac91eeb60b174ec" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_jVZS2/pylance-7.0.0b7-cp39-abi3-win_amd64.whl", hash = "sha256:0f1caea57ea998f6e59dcb2684a08e4b06f993ecc77c8d0f032a4a43a82ed085" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1uffpt/pylance-7.0.0b17-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7912c1c928d342fd1815813770f43413a6aa3c13747b7fc31857f926d155993c" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1pbD0J/pylance-7.0.0b17-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08a8a282dc63cae584f4fee140aca93a4bb688a47b7d8a10a85e2056030dabf1" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_18eJLo/pylance-7.0.0b17-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24e0ea6115f56d62beef7277051a432b8f9f46c7a82897b96b43be231001c77b" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_9ghKD/pylance-7.0.0b17-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:95e9245126f7261e361a35775ff902413fba208e503a9dcf48d266f65810ab1d" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1gnZgV/pylance-7.0.0b17-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ece2995ba7ee626b5dd2928bb37db4d2a0baccfe4dbd0372e714cbf275be6483" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1FF3kZ/pylance-7.0.0b17-cp39-abi3-win_amd64.whl", hash = "sha256:d83d9126fa810a65d724673186d4033c511239fbd8cec313ba95e5366fae64f8" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump the `pylance` dependency from `>=7.0.0b7` to `>=7.0.0b17` in `pyproject.toml`.
- Refresh `uv.lock` with the resolved Pylance 7.0.0b17 wheels and hashes.

## Verification
- `make lock`
- `make build` to install the `dev` extra required for `ruff`
- `make lint`

Triggered by tag: refs/tags/v7.0.0-beta.17
