### PR TITLE
feat: support `target_bases` parameter in write_lance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ help:
 	@echo "  lint   Run linter and format checker (ruff check + ruff format --check)"
 	@echo "  fix    Auto-fix lint issues and format code (ruff check --fix + ruff format)"
 	@echo "  lock   Update uv.lock lockfile"
-	@echo "  build  Install the project with dev and docs dependencies"
+	@echo "  build       Install the project with dev and docs dependencies"
+	@echo "  build-whl   Build wheel package into dist/ (for dev & test)"
+	@echo "  clean       Remove build artifacts and caches"
 	@echo "  test   Run pytest with verbose output"
 
 .PHONY: lint
@@ -27,6 +29,18 @@ lock:
 .PHONY: build
 build: lock
 	uv pip install ".[dev,docs]"
+
+.PHONY: build-whl
+build-whl:
+	uv build --wheel --no-cache
+
+.PHONY: clean
+clean:
+	rm -rf build/ dist/ *.egg-info/
+	find . -type d -name __pycache__ -exec rm -rf {} +
+	find . -type d -name .pytest_cache -exec rm -rf {} +
+	find . -type d -name .ruff_cache -exec rm -rf {} +
+	rm -f .coverage
 
 .PHONY: test
 test: lock

--- a/docs/src/write.md
+++ b/docs/src/write.md
@@ -11,6 +11,7 @@ write_lance(
     table_id=None, 
     schema=None, 
     mode="create", 
+    target_bases=None,
     **kwargs)
 ```
 
@@ -24,6 +25,7 @@ Write a Ray Dataset to Lance format.
 - `table_id`: Table identifier as list of strings (requires namespace)
 - `schema`: Optional PyArrow schema
 - `mode`: Write mode - "create", "append", or "overwrite"
+- `target_bases`: Optional list of registered base names or base path URIs where new data files should be written. In `create` mode, entries must match `initial_bases`; in `append` and `overwrite` modes, entries must match bases already registered in the dataset manifest
 - `min_rows_per_file`: Minimum rows per file (default: 1024 * 1024)
 - `max_rows_per_file`: Maximum rows per file (default: 64 * 1024 * 1024)
 - `data_storage_version`: Optional data storage version

--- a/lance_ray/datasink.py
+++ b/lance_ray/datasink.py
@@ -62,6 +62,7 @@ class _BaseLanceDatasink(Datasink):
         storage_options: Optional[dict[str, Any]] = None,
         base_store_params: Optional[dict[str, dict[str, Any]]] = None,
         initial_bases: Optional[list[Any]] = None,
+        target_bases: Optional[list[str]] = None,
         namespace_impl: Optional[str] = None,
         namespace_properties: Optional[dict[str, str]] = None,
         **kwargs: Any,
@@ -125,6 +126,7 @@ class _BaseLanceDatasink(Datasink):
         self.storage_options = merged_storage_options
         self.base_store_params = base_store_params
         self.initial_bases = normalize_initial_bases(initial_bases)
+        self.target_bases = target_bases
 
     @property
     def namespace_kwargs(self) -> dict[str, Any]:
@@ -274,6 +276,7 @@ class LanceDatasink(_BaseLanceDatasink):
         storage_options: Optional[dict[str, Any]] = None,
         base_store_params: Optional[dict[str, dict[str, Any]]] = None,
         initial_bases: Optional[list[Any]] = None,
+        target_bases: Optional[list[str]] = None,
         namespace_impl: Optional[str] = None,
         namespace_properties: Optional[dict[str, str]] = None,
         **kwargs: Any,
@@ -287,6 +290,7 @@ class LanceDatasink(_BaseLanceDatasink):
             storage_options=storage_options,
             base_store_params=base_store_params,
             initial_bases=initial_bases,
+            target_bases=target_bases,
             namespace_impl=namespace_impl,
             namespace_properties=namespace_properties,
             **kwargs,
@@ -336,6 +340,7 @@ class LanceDatasink(_BaseLanceDatasink):
             data_storage_version=self.data_storage_version,
             storage_options=self.storage_options,
             initial_bases=self.initial_bases if self.mode == "create" else None,
+            target_bases=self.target_bases,
             namespace_impl=self._namespace_impl,
             namespace_properties=self._namespace_properties,
             table_id=self.table_id,

--- a/lance_ray/fragment.py
+++ b/lance_ray/fragment.py
@@ -44,6 +44,7 @@ def write_fragment(
     data_storage_version: Optional[str] = None,
     storage_options: Optional[dict[str, Any]] = None,
     initial_bases: Optional[list[Any]] = None,
+    target_bases: Optional[list[str]] = None,
     namespace_impl: Optional[str] = None,
     namespace_properties: Optional[dict[str, str]] = None,
     table_id: Optional[list[str]] = None,
@@ -113,6 +114,7 @@ def write_fragment(
             max_bytes_per_file=max_bytes_per_file,
             data_storage_version=data_storage_version,
             storage_options=storage_options,
+            target_bases=target_bases,
             **write_kwargs,
             **initial_bases_kwargs,
         ),
@@ -160,6 +162,10 @@ class LanceFragmentWriter:
             The storage options for the writer. Default is None.
     initial_bases : list, optional
         Lance DatasetBasePath objects to register when creating a new dataset.
+    target_bases : list of str, optional
+        References to base paths where data should be written. Each string
+        is resolved by matching base name or base path URI from registered
+        bases.
     namespace_impl : str, optional
         The namespace implementation type (e.g., "rest", "dir").
         Used together with namespace_properties and table_id for credentials
@@ -191,6 +197,7 @@ class LanceFragmentWriter:
         use_legacy_format: Optional[bool] = False,
         storage_options: Optional[dict[str, Any]] = None,
         initial_bases: Optional[list[Any]] = None,
+        target_bases: Optional[list[str]] = None,
         namespace_impl: Optional[str] = None,
         namespace_properties: Optional[dict[str, str]] = None,
         table_id: Optional[list[str]] = None,
@@ -216,6 +223,7 @@ class LanceFragmentWriter:
         self.data_storage_version = data_storage_version
         self.storage_options = storage_options
         self.initial_bases = normalize_initial_bases(initial_bases)
+        self.target_bases = target_bases
         self.namespace_impl = namespace_impl
         self.namespace_properties = namespace_properties
         self.table_id = table_id
@@ -255,6 +263,7 @@ class LanceFragmentWriter:
             data_storage_version=self.data_storage_version,
             storage_options=self.storage_options,
             initial_bases=self.initial_bases,
+            target_bases=self.target_bases,
             namespace_impl=self.namespace_impl,
             namespace_properties=self.namespace_properties,
             table_id=self.table_id,

--- a/lance_ray/io.py
+++ b/lance_ray/io.py
@@ -155,6 +155,7 @@ def write_lance(
     storage_options: Optional[dict[str, Any]] = None,
     base_store_params: Optional[dict[str, dict[str, Any]]] = None,
     initial_bases: Optional[list[Any]] = None,
+    target_bases: Optional[list[str]] = None,
     namespace_impl: Optional[str] = None,
     namespace_properties: Optional[dict[str, str]] = None,
     ray_remote_args: Optional[dict[str, Any]] = None,
@@ -210,6 +211,11 @@ def write_lance(
             dataset root.
         initial_bases: Lance DatasetBasePath objects to register when creating
             a new dataset.
+        target_bases: References to base paths where data should be written.
+            Each string is resolved by matching base name or base path URI
+            from registered bases.  In CREATE mode, references must match
+            bases in ``initial_bases``.  In APPEND/OVERWRITE modes,
+            references must match bases in the existing manifest.
         namespace_impl: The namespace implementation type (e.g., "rest", "dir").
             Used together with namespace_properties and table_id.
         namespace_properties: Properties for connecting to the namespace.
@@ -236,6 +242,7 @@ def write_lance(
             storage_options=storage_options,
             base_store_params=base_store_params,
             initial_bases=initial_bases,
+            target_bases=target_bases,
             namespace_impl=namespace_impl,
             namespace_properties=namespace_properties,
         )
@@ -324,6 +331,7 @@ def write_lance(
             data_storage_version=data_storage_version,
             storage_options=storage_options,
             initial_bases=fragment_initial_bases,
+            target_bases=target_bases,
             namespace_impl=None,
             namespace_properties=None,
             table_id=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,13 @@ version = "0.4.2"
 description = "Ray integration for Lance"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
-license = {file = "LICENSE"}
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 authors = [{ name = "LanceDB Devs", email = "dev@lancedb.com" }]
 keywords = ["ray", "lance", "distributed", "columnar", "data"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,7 @@ def ray_context():
     else:
         # Use an isolated temp dir so we don't pick up a stale
         # /tmp/ray/ray_current_cluster pointer from previous runs.
-        temp_dir = tempfile.mkdtemp(prefix="ray_lance_test_")
+        temp_dir = tempfile.mkdtemp(prefix="rl_", dir="/tmp")
         ray.init(
             num_cpus=4,
             ignore_reinit_error=True,

--- a/tests/test_blob_v2.py
+++ b/tests/test_blob_v2.py
@@ -7,6 +7,10 @@ These tests verify that:
 - Projection and filtering on blob v2 columns work as expected.
 - Underlying ``LanceDataset.take_blobs`` supports both ``ids`` and
   ``indices`` selectors for blob v2 columns.
+- ``target_bases`` controls which registered base path receives appended
+  fragment data.
+- ``allow_external_blob_outside_bases`` permits external blob URIs that
+  do not fall under any registered base path.
 """
 
 from __future__ import annotations
@@ -37,13 +41,6 @@ except Exception:  # pragma: no cover - guarded by importorskip
 import lance_ray.io as lr  # noqa: E402
 from lance_ray.datasink import LanceFragmentCommitter  # noqa: E402
 from lance_ray.fragment import LanceFragmentWriter  # noqa: E402
-
-
-def _supports_base_store_params() -> bool:
-    try:
-        return "base_store_params" in inspect.signature(lance.dataset).parameters
-    except (TypeError, ValueError):
-        return True
 
 
 def _build_blob_v2_table(
@@ -289,3 +286,287 @@ def test_blob_v2_reference_multi_base_all_lance_ray_paths(tmp_path: Path) -> Non
         .reset_index(drop=True)
     )
     assert manual_df["blob"].tolist() == [inline_payload, external_payload, None]
+
+
+def _build_multi_base_blob_v2_table(
+    tmp_path: Path,
+) -> tuple[pa.Table, bytes, bytes, Path, Path]:
+    """Construct a blob v2 table with two external base directories.
+
+    Returns the table, inline payload, packed payload, base_a path, and
+    base_b path.  Two separate base directories are created so that
+    ``target_bases`` can choose which one receives appended data.
+    """
+    inline_payload = b"inline-bytes"
+    packed_payload = b"packed-bytes" * 100
+
+    base_a = tmp_path / "base_a"
+    base_b = tmp_path / "base_b"
+    base_a.mkdir()
+    base_b.mkdir()
+
+    schema = pa.schema(
+        [
+            pa.field("id", pa.int64()),
+            blob_field("blob"),
+        ]
+    )
+
+    table = pa.table(
+        {
+            "id": [1, 2],
+            "blob": blob_array(
+                [
+                    inline_payload,
+                    packed_payload,
+                ]
+            ),
+        },
+        schema=schema,
+    )
+    return table, inline_payload, packed_payload, base_a, base_b
+
+
+def _multi_initial_bases(base_a: Path, base_b: Path) -> list[DatasetBasePath]:
+    return [
+        DatasetBasePath(
+            base_a.as_uri(),
+            name="base_a",
+            is_dataset_root=False,
+            id=1,
+        ),
+        DatasetBasePath(
+            base_b.as_uri(),
+            name="base_b",
+            is_dataset_root=False,
+            id=2,
+        ),
+    ]
+
+
+def test_blob_v2_create_with_initial_bases_and_target_bases(tmp_path: Path) -> None:
+    """Create can route initial fragment data to a named base path."""
+    table, inline_payload, packed_payload, base_a, base_b = (
+        _build_multi_base_blob_v2_table(tmp_path)
+    )
+    initial_bases = _multi_initial_bases(base_a, base_b)
+    base_store_params = {base_a.as_uri(): {}, base_b.as_uri(): {}}
+
+    path = tmp_path / "blob_v2_create_target_bases.lance"
+
+    # Phase 1: Create — write dataset with target_bases=["base_b"] to route initial data to base_b only
+    lr.write_lance(
+        ray.data.from_arrow(table),
+        str(path),
+        schema=table.schema,
+        data_storage_version="2.2",
+        base_store_params=base_store_params,
+        initial_bases=initial_bases,
+        target_bases=["base_b"],
+    )
+
+    # Phase 2: Verify file routing — data files should only exist in base_b
+    b_lance_files = set(base_b.rglob("*.lance"))
+    a_lance_files = set(base_a.rglob("*.lance"))
+    root_lance_files = (
+        set((path / "data").rglob("*.lance")) if (path / "data").exists() else set()
+    )
+    assert b_lance_files, "target_bases did not route initial data files to base_b"
+    assert not a_lance_files, (
+        f"Data files unexpectedly written to base_a: {a_lance_files}"
+    )
+    assert not root_lance_files, (
+        f"Data files unexpectedly written to dataset root: {root_lance_files}"
+    )
+
+    # Phase 3: Verify data integrity — read back and confirm all blobs are correct
+    df = (
+        lr.read_lance(str(path), base_store_params=base_store_params)
+        .to_pandas()
+        .sort_values("id")
+        .reset_index(drop=True)
+    )
+    assert df["blob"].tolist() == [inline_payload, packed_payload]
+
+
+def test_blob_v2_target_bases_multi_base_routing(tmp_path: Path) -> None:
+    """target_bases can route data across multiple base paths.
+
+    Creates a dataset with two registered bases, then performs two
+    append writes: one with ``target_bases=["base_a", "base_b"]``
+    (multi-element candidate pool) and one with
+    ``target_bases=["base_a"]`` (precise routing).  This verifies
+    that:
+
+    1. Multi-element target_bases routes data to the candidate pool
+       (at least one of the named bases receives new files).
+    2. Single-element target_bases routes data to the exact base.
+    3. Data written to different bases is readable as a single
+       coherent dataset.
+    """
+    table, inline_payload, packed_payload, base_a, base_b = (
+        _build_multi_base_blob_v2_table(tmp_path)
+    )
+    initial_bases = _multi_initial_bases(base_a, base_b)
+    base_store_params = {base_a.as_uri(): {}, base_b.as_uri(): {}}
+
+    path = tmp_path / "blob_v2_multi_base_routing.lance"
+
+    # Phase 1: Create — create dataset without target_bases (default routing)
+    lr.write_lance(
+        ray.data.from_arrow(table),
+        str(path),
+        schema=table.schema,
+        data_storage_version="2.2",
+        base_store_params=base_store_params,
+        initial_bases=initial_bases,
+    )
+
+    a_lance_after_create = set(base_a.rglob("*.lance"))
+    b_lance_after_create = set(base_b.rglob("*.lance"))
+    root_lance_after_create = (
+        set((path / "data").rglob("*.lance")) if (path / "data").exists() else set()
+    )
+
+    # Phase 2: Append — multi-element target_bases routing (candidate pool: base_a and base_b)
+    append_payload_multi = b"multi-target-bytes" * 100
+    append_table_multi = pa.table(
+        {
+            "id": [3],
+            "blob": blob_array([append_payload_multi]),
+        },
+        schema=table.schema,
+    )
+
+    lr.write_lance(
+        ray.data.from_arrow(append_table_multi),
+        str(path),
+        mode="append",
+        base_store_params=base_store_params,
+        target_bases=["base_a", "base_b"],
+    )
+
+    a_lance_after_multi = set(base_a.rglob("*.lance"))
+    b_lance_after_multi = set(base_b.rglob("*.lance"))
+    root_lance_after_multi = (
+        set((path / "data").rglob("*.lance")) if (path / "data").exists() else set()
+    )
+    new_in_a_or_b = (a_lance_after_multi - a_lance_after_create) | (
+        b_lance_after_multi - b_lance_after_create
+    )
+    new_in_root = root_lance_after_multi - root_lance_after_create
+    assert new_in_a_or_b, (
+        "target_bases=['base_a', 'base_b'] did not route data files to either base"
+    )
+    assert not new_in_root, (
+        f"Data files unexpectedly written to dataset root: {new_in_root}"
+    )
+
+    # Phase 3: Append — single-element target_bases precise routing (base_a only)
+    append_payload_a = b"routed-to-base-a" * 100
+    append_table_a = pa.table(
+        {
+            "id": [4],
+            "blob": blob_array([append_payload_a]),
+        },
+        schema=table.schema,
+    )
+
+    lr.write_lance(
+        ray.data.from_arrow(append_table_a),
+        str(path),
+        mode="append",
+        base_store_params=base_store_params,
+        target_bases=["base_a"],
+    )
+
+    a_lance_after_precise = set(base_a.rglob("*.lance"))
+    new_in_a = a_lance_after_precise - a_lance_after_multi
+    assert new_in_a, "target_bases=['base_a'] did not route data files to base_a"
+
+    # Phase 4: End-to-end data integrity verification (cross-base transparent read)
+    df = (
+        lr.read_lance(str(path), base_store_params=base_store_params)
+        .to_pandas()
+        .sort_values("id")
+        .reset_index(drop=True)
+    )
+    assert df["blob"].tolist() == [
+        inline_payload,
+        packed_payload,
+        append_payload_multi,
+        append_payload_a,
+    ]
+
+
+def test_blob_v2_append_with_target_bases_stream(tmp_path: Path) -> None:
+    """Streaming append with target_bases should route data to the named base.
+
+    Same as test_blob_v2_target_bases_multi_base_routing but using
+    ``stream=True`` so that each batch is committed as a separate
+    fragment, verifying the streaming write path also respects
+    target_bases.
+    """
+    table, inline_payload, packed_payload, base_a, base_b = (
+        _build_multi_base_blob_v2_table(tmp_path)
+    )
+    initial_bases = _multi_initial_bases(base_a, base_b)
+    base_store_params = {base_a.as_uri(): {}, base_b.as_uri(): {}}
+
+    path = tmp_path / "blob_v2_target_bases_stream.lance"
+
+    # Phase 1: Create — create dataset without target_bases (default routing)
+    lr.write_lance(
+        ray.data.from_arrow(table),
+        str(path),
+        schema=table.schema,
+        data_storage_version="2.2",
+        base_store_params=base_store_params,
+        initial_bases=initial_bases,
+    )
+
+    # Phase 2: Append — streaming write with target_bases=["base_b"] and batch_size=1
+    append_payload = b"stream-appended-bytes" * 100
+    append_table = pa.table(
+        {
+            "id": [3],
+            "blob": blob_array([append_payload]),
+        },
+        schema=table.schema,
+    )
+
+    b_lance_before = set(base_b.rglob("*.lance"))
+    root_data_before = (
+        set((path / "data").rglob("*.lance")) if (path / "data").exists() else set()
+    )
+
+    lr.write_lance(
+        ray.data.from_arrow(append_table),
+        str(path),
+        mode="append",
+        stream=True,
+        batch_size=1,
+        base_store_params=base_store_params,
+        target_bases=["base_b"],
+    )
+
+    # Phase 3: Verify file routing — new data files should only appear in base_b
+    b_lance_after = set(base_b.rglob("*.lance"))
+    root_data_after = (
+        set((path / "data").rglob("*.lance")) if (path / "data").exists() else set()
+    )
+    new_in_b = b_lance_after - b_lance_before
+    new_in_root = root_data_after - root_data_before
+    assert new_in_b, "target_bases did not route data files to base_b"
+    assert not new_in_root, (
+        f"Data files unexpectedly written to dataset root: {new_in_root}"
+    )
+
+    # Phase 4: End-to-end data integrity verification (cross-base transparent read)
+    df = (
+        lr.read_lance(str(path), base_store_params=base_store_params)
+        .to_pandas()
+        .sort_values("id")
+        .reset_index(drop=True)
+    )
+    assert df["blob"].tolist() == [inline_payload, packed_payload, append_payload]


### PR DESCRIPTION
The `lance.write_dataset()` and `lance.fragment.write_fragments()` APIs already support routing data files to specific registered base paths via the `target_bases` parameter. However, lance-ray did not expose or forward this option through its distributed write paths (`write_lance`, `LanceDatasink`, `LanceFragmentWriter`), making it impossible to control which base receives appended data when writing via Ray.

To address this, this PR fills it and introduces the following changes:

- Add `target_bases: Optional[list[str]]` parameter to `write_lance`, `LanceDatasink`, `_BaseLanceDatasink`, `LanceFragmentWriter`, and `write_fragment`.
- Forward `target_bases` to `lance.fragment.write_fragments` in both the datasink and streaming write paths.
- Document `target_bases` in `docs/src/write.md`.