### PR TITLE
feat: add segment-owned distributed vector search

### DIFF
--- a/docs/src/distributed-indexing.md
+++ b/docs/src/distributed-indexing.md
@@ -184,6 +184,63 @@ def optimize_indices(
 
 The function returns the Lance dataset instance (optimization is applied on storage).
 
+### Distributed Vector Search
+
+`vector_search()` - Run vector search with Ray workers and merge the global top-k on the driver.
+
+The driver opens one fixed dataset version, reads vector index segment metadata once, and plans work by index segment ownership.  Indexed worker tasks receive only their assigned `index_segments`, so a segment covering multiple fragments is never split across workers.  Fragments not covered by an index can be included as separate flat-search fallback work unless `fast_search=True`; fallback tasks use regular fragment scans and compute vector distances in Lance-Ray.
+
+#### `vector_search`
+
+```python
+def vector_search(
+    uri: Optional[Union[str, "lance.LanceDataset"]] = None,
+    *,
+    nearest: dict[str, Any],
+    index_name: Optional[str] = None,
+    columns: Optional[Union[list[str], dict[str, str]]] = None,
+    filter: Optional[Any] = None,
+    storage_options: Optional[dict[str, Any]] = None,
+    block_size: Optional[int] = None,
+    namespace_impl: Optional[str] = None,
+    namespace_properties: Optional[dict[str, str]] = None,
+    table_id: Optional[list[str]] = None,
+    num_workers: int = 4,
+    ray_remote_args: Optional[dict[str, Any]] = None,
+    oversample_factor: float = 1.0,
+    include_unindexed: bool = True,
+    fast_search: bool = False,
+    analyze_plan: bool = False,
+    scanner_options: Optional[dict[str, Any]] = None,
+) -> Union[pyarrow.Table, str]:
+```
+
+#### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `uri` | `str` or `lance.LanceDataset`, optional | Lance dataset object, or its URI. Either `uri` OR (`namespace_impl` + `table_id`) must be provided when using URI mode. If a `LanceDataset` object is provided, namespace parameters are ignored and workers reopen the same dataset URI/version. |
+| `nearest` | `dict[str, Any]` | Lance vector search options. Must include `column`, `q`, and `k`. Other Lance nearest options such as `minimum_nprobes`, `maximum_nprobes`, `refine_factor`, and distance range are forwarded to every worker. Lance-Ray raises worker-side `k` to at least `k * oversample_factor` before global merge. |
+| `index_name` | `str`, optional | Vector index name to use. If provided and not found, `vector_search()` raises `ValueError` instead of silently falling back. If omitted, Lance-Ray uses the first vector index covering `nearest["column"]`; if none exists, the search uses flat fallback plans unless `fast_search=True`. |
+| `columns` | `list[str]` or `dict[str, str]`, optional | Projection passed to the Lance scanner. When a list is provided and `_distance` is missing, Lance-Ray appends `_distance` automatically because the driver needs it for global top-k merge. |
+| `filter` | `Any`, optional | Filter passed unchanged to every worker scanner. |
+| `storage_options` | `Dict[str, Any]`, optional | Storage options for the dataset. These are merged with namespace storage options when available. |
+| `block_size` | `int`, optional | Block size in bytes to use when loading the dataset on the driver and workers. |
+| `namespace_impl` | `str`, optional | Namespace implementation type, such as `"dir"` or `"rest"`. |
+| `namespace_properties` | `Dict[str, str]`, optional | Namespace connection properties used with `namespace_impl`. |
+| `table_id` | `list[str]`, optional | Table identifier used with namespace parameters. Must be provided together with `namespace_impl` in namespace mode. |
+| `num_workers` | `int`, optional | Maximum number of Ray Pool workers to use. Lance-Ray may create fewer worker tasks when there are fewer search plans. |
+| `ray_remote_args` | `Dict[str, Any]`, optional | Ray task options for Pool workers, such as `num_cpus` or custom resources. |
+| `oversample_factor` | `float`, optional | Multiplier for local worker candidates. Each worker returns at least `nearest["k"] * oversample_factor` rows before driver-side merge. Must be greater than or equal to 1. |
+| `include_unindexed` | `bool`, optional | Include fragments not covered by vector index segments using separate flat-search fallback plans. Fallback plans use regular fragment scans and compute vector distance in Lance-Ray. Ignored when `fast_search=True`. |
+| `fast_search` | `bool`, optional | Search only indexed data. When enabled, Lance-Ray does not schedule flat-search fallback plans for fragments not covered by vector index segments. |
+| `analyze_plan` | `bool`, optional | If `True`, call `LanceScanner.analyze_plan()` for each planned shard and return a string containing the per-shard analysis instead of executing search and returning a table. |
+| `scanner_options` | `Dict[str, Any]`, optional | Extra Lance scanner options, such as `batch_size`, `prefilter`, `with_row_id`, or `late_materialization`. Lance-Ray manages `nearest`, `fragments`, `index_segments`, `fast_search`, `limit`, and `offset` internally, so those options cannot be supplied here. |
+
+#### Return Value
+
+The function returns a `pyarrow.Table` containing the global top-k rows sorted by `_distance`. If `analyze_plan=True`, it returns a `str` containing one Lance scanner analysis section per planned shard.
+
 ## Examples
 
 ### FTS Index (Scalar)
@@ -269,6 +326,31 @@ updated_dataset = lr.create_index(
     num_workers=4,
     num_partitions=256,
 )
+
+# Run distributed vector search against index-owned shards.
+results = lr.vector_search(
+    uri="path/to/dataset.lance",
+    nearest={
+        "column": "vector",
+        "q": query_vector,
+        "k": 10,
+        "minimum_nprobes": 20,
+    },
+    index_name="idx_ivf_flat",
+    columns=["id", "vector"],
+    num_workers=8,
+    oversample_factor=2,
+    fast_search=False,
+)
+
+# Inspect the per-shard Lance scanner plans instead of executing the search.
+plan = lr.vector_search(
+    uri="path/to/dataset.lance",
+    nearest={"column": "vector", "q": query_vector, "k": 10},
+    index_name="idx_ivf_flat",
+    analyze_plan=True,
+)
+print(plan)
 ```
 
 ### Custom Ray Options

--- a/lance_ray/__init__.py
+++ b/lance_ray/__init__.py
@@ -23,10 +23,12 @@ from .io import (
     read_lance,
     write_lance,
 )
+from .search import vector_search
 
 __all__ = [
     "read_lance",
     "write_lance",
+    "vector_search",
     "add_columns",
     "add_columns_from",
     "merge_columns_from",

--- a/lance_ray/search.py
+++ b/lance_ray/search.py
@@ -1,0 +1,694 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+import logging
+import math
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
+
+import pyarrow as pa
+import pyarrow.compute as pc
+from lance.dataset import LanceDataset
+from ray.util.multiprocessing import Pool
+
+from .utils import (
+    get_namespace_kwargs,
+    get_or_create_namespace,
+    validate_uri_or_namespace,
+)
+
+if TYPE_CHECKING:
+    import lance
+
+logger = logging.getLogger(__name__)
+
+
+class _SearchPlan(NamedTuple):
+    fragment_ids: list[int]
+    index_segments: list[str]
+
+
+class _SearchPlanAnalysis(NamedTuple):
+    plan: _SearchPlan
+    analysis: str
+
+
+class _SearchPlanUnit(NamedTuple):
+    fragment_ids: set[int]
+    index_segments: list[str]
+    weight: int
+
+
+def _dataset_load_kwargs(
+    storage_options: Optional[dict[str, Any]],
+    namespace_kwargs: dict[str, Any],
+    block_size: Optional[int],
+) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "storage_options": storage_options,
+        **namespace_kwargs,
+    }
+    if block_size is not None:
+        kwargs["block_size"] = block_size
+    return kwargs
+
+
+def _get_dataset_storage_options(dataset: LanceDataset) -> dict[str, Any]:
+    try:
+        return dataset.initial_storage_options or {}
+    except AttributeError:
+        return getattr(dataset, "_storage_options", None) or {}
+
+
+def _get_fragment_id(fragment: Any) -> int:
+    try:
+        return fragment.fragment_id
+    except AttributeError:
+        return fragment.metadata.id
+
+
+def _get_index_descriptions(dataset: LanceDataset) -> list[Any]:
+    if hasattr(dataset, "describe_indices"):
+        return dataset.describe_indices()
+
+    descriptions = []
+    for index in dataset.list_indices():
+        descriptions.append(
+            {
+                "name": index["name"],
+                "index_type": index.get("type"),
+                "field_names": index.get("fields", []),
+                "segments": [
+                    {
+                        "uuid": index["uuid"],
+                        "fragment_ids": index.get("fragment_ids", set()),
+                    }
+                ],
+            }
+        )
+    return descriptions
+
+
+def _index_value(index: Any, name: str, default: Any = None) -> Any:
+    if isinstance(index, dict):
+        return index.get(name, default)
+    return getattr(index, name, default)
+
+
+def _segment_value(segment: Any, name: str, default: Any = None) -> Any:
+    if isinstance(segment, dict):
+        return segment.get(name, default)
+    return getattr(segment, name, default)
+
+
+def _select_vector_index(
+    dataset: LanceDataset,
+    *,
+    column: str,
+    index_name: Optional[str],
+) -> Any | None:
+    indices = _get_index_descriptions(dataset)
+    for index in indices:
+        name = _index_value(index, "name")
+        field_names = _index_value(index, "field_names")
+        if field_names is None:
+            field_names = _index_value(index, "fields", [])
+
+        if index_name is not None:
+            if name == index_name:
+                return index
+            continue
+
+        if column in field_names:
+            return index
+
+    if index_name is not None:
+        available_names = [str(_index_value(index, "name")) for index in indices]
+        raise ValueError(
+            f"Vector index '{index_name}' was not found. "
+            f"Available indices: {available_names}"
+        )
+
+    return None
+
+
+def _plan_vector_search(
+    *,
+    fragments: list[Any],
+    vector_index: Any | None,
+    num_workers: int,
+    include_unindexed: bool,
+) -> list[_SearchPlan]:
+    fragment_ids = {_get_fragment_id(fragment) for fragment in fragments}
+    if not fragment_ids:
+        return []
+
+    fragment_weights: dict[int, int] = {}
+    for fragment in fragments:
+        fragment_id = _get_fragment_id(fragment)
+        try:
+            fragment_weights[fragment_id] = fragment.count_rows()
+        except Exception:  # pragma: no cover - defensive fallback
+            fragment_weights[fragment_id] = 1
+
+    indexed_units: list[_SearchPlanUnit] = []
+    fallback_units: list[_SearchPlanUnit] = []
+    indexed_fragment_ids: set[int] = set()
+
+    if vector_index is not None:
+        for segment in _index_value(vector_index, "segments", []):
+            segment_fragment_ids = set(_segment_value(segment, "fragment_ids", set()))
+            segment_fragment_ids &= fragment_ids
+            if not segment_fragment_ids:
+                continue
+            segment_uuid = str(_segment_value(segment, "uuid"))
+            indexed_fragment_ids.update(segment_fragment_ids)
+            indexed_units.append(
+                _SearchPlanUnit(
+                    fragment_ids=segment_fragment_ids,
+                    index_segments=[segment_uuid],
+                    weight=sum(fragment_weights[fid] for fid in segment_fragment_ids),
+                )
+            )
+
+    fallback_fragment_ids = fragment_ids - indexed_fragment_ids
+    if include_unindexed:
+        for fragment_id in fallback_fragment_ids:
+            fallback_units.append(
+                _SearchPlanUnit(
+                    fragment_ids={fragment_id},
+                    index_segments=[],
+                    weight=fragment_weights[fragment_id],
+                )
+            )
+
+    plans = [
+        *_pack_search_plan_units(indexed_units, num_workers),
+        *_pack_search_plan_units(fallback_units, num_workers),
+    ]
+
+    if not plans:
+        return []
+
+    included_fallback_count = len(fallback_fragment_ids) if include_unindexed else 0
+    logger.info(
+        "Planned distributed vector search across %d tasks, %d fragments, "
+        "%d index segments, %d fallback fragments",
+        len(plans),
+        len(fragment_ids),
+        sum(len(plan.index_segments) for plan in plans),
+        included_fallback_count,
+    )
+    return plans
+
+
+def _pack_search_plan_units(
+    units: list[_SearchPlanUnit],
+    num_workers: int,
+) -> list[_SearchPlan]:
+    if not units:
+        return []
+
+    plan_count = min(num_workers, len(units))
+    worker_fragment_ids: list[set[int]] = [set() for _ in range(plan_count)]
+    worker_index_segments: list[list[str]] = [[] for _ in range(plan_count)]
+    worker_weights = [0] * plan_count
+
+    for unit in sorted(units, key=lambda item: item.weight, reverse=True):
+        worker_idx = min(range(plan_count), key=lambda idx: worker_weights[idx])
+        worker_fragment_ids[worker_idx].update(unit.fragment_ids)
+        worker_index_segments[worker_idx].extend(unit.index_segments)
+        worker_weights[worker_idx] += unit.weight
+
+    plans = [
+        _SearchPlan(
+            fragment_ids=sorted(worker_fragment_ids[idx]),
+            index_segments=worker_index_segments[idx],
+        )
+        for idx in range(plan_count)
+        if worker_fragment_ids[idx]
+    ]
+    return plans
+
+
+def _execute_vector_search_plan(
+    plan: _SearchPlan,
+    *,
+    dataset_uri: str,
+    dataset_version: int,
+    storage_options: Optional[dict[str, Any]],
+    block_size: Optional[int],
+    namespace_impl: Optional[str],
+    namespace_properties: Optional[dict[str, str]],
+    table_id: Optional[list[str]],
+    base_scanner_options: dict[str, Any],
+    nearest: dict[str, Any],
+    candidate_k: int,
+    analyze_plan: bool,
+) -> pa.Table | _SearchPlanAnalysis:
+    namespace_kwargs = get_namespace_kwargs(
+        namespace_impl, namespace_properties, table_id
+    )
+    dataset = LanceDataset(
+        dataset_uri,
+        version=dataset_version,
+        **_dataset_load_kwargs(storage_options, namespace_kwargs, block_size),
+    )
+
+    if not plan.index_segments:
+        return _execute_flat_fallback_vector_search_plan(
+            dataset,
+            plan=plan,
+            base_scanner_options=base_scanner_options,
+            nearest=nearest,
+            candidate_k=candidate_k,
+            analyze_plan=analyze_plan,
+        )
+
+    scanner_options = dict(base_scanner_options)
+    search_nearest = dict(nearest)
+    search_nearest["k"] = candidate_k
+
+    scanner_options["nearest"] = search_nearest
+    scanner_options["index_segments"] = plan.index_segments
+    scanner_options["fast_search"] = True
+
+    logger.info(
+        "Running indexed vector search plan: fragments=%d, index_segments=%d, k=%d",
+        len(plan.fragment_ids),
+        len(plan.index_segments),
+        candidate_k,
+    )
+    scanner = dataset.scanner(**scanner_options)
+    if analyze_plan:
+        return _SearchPlanAnalysis(plan=plan, analysis=scanner.analyze_plan())
+    return scanner.to_table()
+
+
+def _execute_flat_fallback_vector_search_plan(
+    dataset: LanceDataset,
+    *,
+    plan: _SearchPlan,
+    base_scanner_options: dict[str, Any],
+    nearest: dict[str, Any],
+    candidate_k: int,
+    analyze_plan: bool,
+) -> pa.Table | _SearchPlanAnalysis:
+    vector_column = nearest["column"]
+    vector_scan_column, drop_vector_column = _prepare_fallback_scan_columns(
+        base_scanner_options,
+        vector_column,
+    )
+    scanner_options = dict(base_scanner_options)
+    scanner_options.pop("fast_search", None)
+    scanner_options["fragments"] = [
+        dataset.get_fragment(fragment_id) for fragment_id in plan.fragment_ids
+    ]
+
+    logger.info(
+        "Running flat fallback vector search plan: fragments=%d, k=%d",
+        len(plan.fragment_ids),
+        candidate_k,
+    )
+    scanner = dataset.scanner(**scanner_options)
+    if analyze_plan:
+        return _SearchPlanAnalysis(plan=plan, analysis=scanner.analyze_plan())
+
+    table = scanner.to_table()
+    if table.num_rows == 0:
+        table = table.append_column("_distance", pa.array([], type=pa.float32()))
+        if drop_vector_column and vector_scan_column in table.column_names:
+            table = table.drop_columns([vector_scan_column])
+        return table
+
+    distances = _compute_vector_distances(
+        table[vector_scan_column],
+        nearest["q"],
+        _get_nearest_metric(nearest),
+    )
+    table = table.append_column("_distance", pa.array(distances, type=pa.float32()))
+    table = _take_top_k(table, candidate_k)
+    if drop_vector_column and vector_scan_column in table.column_names:
+        table = table.drop_columns([vector_scan_column])
+    return table
+
+
+def _prepare_fallback_scan_columns(
+    scanner_options: dict[str, Any],
+    vector_column: str,
+) -> tuple[str, bool]:
+    requested_columns = scanner_options.get("columns")
+    if requested_columns is None:
+        return vector_column, False
+
+    if isinstance(requested_columns, list):
+        scan_columns = [column for column in requested_columns if column != "_distance"]
+        if vector_column in scan_columns:
+            scanner_options["columns"] = scan_columns
+            return vector_column, False
+        scanner_options["columns"] = [*scan_columns, vector_column]
+        return vector_column, True
+
+    if isinstance(requested_columns, dict):
+        vector_scan_column = _unique_hidden_vector_column(requested_columns)
+        scanner_options["columns"] = {
+            **requested_columns,
+            vector_scan_column: vector_column,
+        }
+        return vector_scan_column, True
+
+    return vector_column, False
+
+
+def _unique_hidden_vector_column(columns: dict[str, str]) -> str:
+    vector_column = "__lance_ray_vector_search_vector"
+    while vector_column in columns:
+        vector_column = f"_{vector_column}"
+    return vector_column
+
+
+def _get_nearest_metric(nearest: dict[str, Any]) -> str:
+    metric = nearest.get("metric") or nearest.get("distance_type") or "l2"
+    return str(metric).lower()
+
+
+def _compute_vector_distances(
+    vector_column: pa.ChunkedArray,
+    query: Any,
+    metric: str,
+) -> Any:
+    import numpy as np
+
+    matrix = _vector_column_to_numpy(vector_column)
+    query_vector = np.asarray(query, dtype=np.float32)
+    if query_vector.ndim != 1:
+        raise ValueError("nearest['q'] must be a one-dimensional vector")
+    if matrix.shape[1] != query_vector.shape[0]:
+        raise ValueError(
+            "Query vector dimension does not match fallback vector column "
+            f"dimension: {query_vector.shape[0]} != {matrix.shape[1]}"
+        )
+
+    if metric in ("l2", "euclidean"):
+        return np.linalg.norm(matrix - query_vector, axis=1).astype(np.float32)
+    if metric == "cosine":
+        query_norm = np.linalg.norm(query_vector)
+        row_norms = np.linalg.norm(matrix, axis=1)
+        denom = row_norms * query_norm
+        similarities = np.divide(
+            matrix @ query_vector,
+            denom,
+            out=np.zeros(matrix.shape[0], dtype=np.float32),
+            where=denom != 0,
+        )
+        return (1.0 - similarities).astype(np.float32)
+    if metric in ("dot", "ip", "inner_product"):
+        return (-(matrix @ query_vector)).astype(np.float32)
+    if metric == "hamming":
+        return np.count_nonzero(matrix != query_vector, axis=1).astype(np.float32)
+
+    raise ValueError(
+        "Unsupported fallback vector search metric "
+        f"{metric!r}. Supported metrics: l2, cosine, dot, hamming"
+    )
+
+
+def _vector_column_to_numpy(vector_column: pa.ChunkedArray) -> Any:
+    import numpy as np
+
+    values = vector_column.combine_chunks().to_pylist()
+    if not values:
+        return np.empty((0, 0), dtype=np.float32)
+    if any(value is None for value in values):
+        raise ValueError("Fallback vector search does not support null vectors")
+    matrix = np.asarray(values, dtype=np.float32)
+    if matrix.ndim != 2:
+        raise ValueError("Fallback vector search requires a list-like vector column")
+    return matrix
+
+
+def _take_top_k(table: pa.Table, k: int) -> pa.Table:
+    sort_indices = pc.sort_indices(table, sort_keys=[("_distance", "ascending")])
+    return table.take(sort_indices.slice(0, k))
+
+
+def _merge_vector_search_results(tables: list[pa.Table], k: int) -> pa.Table:
+    non_empty_tables = [table for table in tables if table.num_rows > 0]
+    if not non_empty_tables:
+        return tables[0].slice(0, 0) if tables else pa.table({})
+
+    table = pa.concat_tables(non_empty_tables, promote_options="default")
+    if "_distance" not in table.column_names:
+        raise RuntimeError(
+            "Distributed vector search results must include a '_distance' column "
+            "for global top-k merge"
+        )
+
+    return _take_top_k(table, k)
+
+
+def _format_analyze_plan_results(results: list[_SearchPlanAnalysis]) -> str:
+    sections = []
+    for idx, result in enumerate(results):
+        plan_kind = "indexed" if result.plan.index_segments else "flat_fallback"
+        sections.append(
+            "\n".join(
+                [
+                    f"== Lance-Ray vector search shard {idx} ({plan_kind}) ==",
+                    f"fragments: {result.plan.fragment_ids}",
+                    f"index_segments: {result.plan.index_segments}",
+                    result.analysis,
+                ]
+            )
+        )
+    return "\n\n".join(sections)
+
+
+def _validate_search_scanner_options(scanner_options: dict[str, Any]) -> None:
+    reserved_options = {
+        "fast_search",
+        "fragments",
+        "index_segments",
+        "nearest",
+        "limit",
+        "offset",
+    }
+    conflicts = sorted(reserved_options & scanner_options.keys())
+    if conflicts:
+        raise ValueError(
+            "scanner_options cannot include distributed search managed options: "
+            + ", ".join(conflicts)
+        )
+
+
+def _candidate_k(nearest: dict[str, Any], oversample_factor: float) -> tuple[int, int]:
+    try:
+        global_k = int(nearest["k"])
+    except KeyError as exc:
+        raise ValueError("nearest must include 'k' for distributed vector search") from exc
+
+    if global_k <= 0:
+        raise ValueError(f"nearest['k'] must be positive, got {global_k}")
+    if oversample_factor < 1:
+        raise ValueError(
+            f"oversample_factor must be greater than or equal to 1, got {oversample_factor}"
+        )
+
+    return global_k, max(global_k, math.ceil(global_k * oversample_factor))
+
+
+def vector_search(
+    uri: Optional[Union[str, "lance.LanceDataset"]] = None,
+    *,
+    nearest: dict[str, Any],
+    index_name: Optional[str] = None,
+    columns: Optional[list[str] | dict[str, str]] = None,
+    filter: Optional[Any] = None,
+    storage_options: Optional[dict[str, Any]] = None,
+    block_size: Optional[int] = None,
+    namespace_impl: Optional[str] = None,
+    namespace_properties: Optional[dict[str, str]] = None,
+    table_id: Optional[list[str]] = None,
+    num_workers: int = 4,
+    ray_remote_args: Optional[dict[str, Any]] = None,
+    oversample_factor: float = 1.0,
+    include_unindexed: bool = True,
+    fast_search: bool = False,
+    analyze_plan: bool = False,
+    scanner_options: Optional[dict[str, Any]] = None,
+) -> pa.Table | str:
+    """Run a distributed Lance vector search and merge the global top-k.
+
+    The driver opens a fixed dataset version, plans ownership by vector index
+    segment coverage.  Indexed worker tasks search only their assigned
+    ``index_segments``.  Unindexed fallback tasks scan their assigned fragments
+    without ``nearest`` and compute distances locally.  Workers return local
+    candidates and the driver sorts by ``_distance`` to produce the final top-k
+    table.
+
+    Args:
+        uri: Lance dataset object or dataset URI.  In URI mode, provide either
+            ``uri`` or namespace parameters (``namespace_impl`` + ``table_id``).
+        nearest: Lance vector search options.  Must include ``column``, ``q``,
+            and ``k``.  The worker-side ``k`` is raised to at least
+            ``k * oversample_factor`` before the driver performs the final
+            global top-k merge.
+        index_name: Optional vector index name to use.  If specified and the
+            index cannot be found, ``ValueError`` is raised.  If omitted,
+            Lance-Ray uses the first vector index covering ``nearest["column"]``.
+        columns: Projection passed to the Lance scanner.  When a list is
+            provided, ``_distance`` is appended automatically because the driver
+            needs it to merge global top-k results.
+        filter: Filter passed to every worker scanner.
+        storage_options: Storage options used to open the dataset.  In namespace
+            mode these are merged with namespace-provided storage options.
+        block_size: Optional block size in bytes used when loading the dataset.
+        namespace_impl: Namespace implementation type, such as ``"dir"`` or
+            ``"rest"``.
+        namespace_properties: Properties used to connect to the namespace.
+        table_id: Table identifier used with namespace parameters.
+        num_workers: Maximum number of Ray Pool workers to use.
+        ray_remote_args: Ray remote options for Pool workers, such as
+            ``num_cpus`` or custom resources.
+        oversample_factor: Multiplier for local worker candidates.  Each worker
+            returns at least ``nearest["k"] * oversample_factor`` rows before
+            driver-side merge.  Must be greater than or equal to 1.
+        include_unindexed: Include fragments not covered by vector index
+            segments using separate flat-search fallback plans.  Fallback plans
+            use regular fragment scans and compute vector distance in Lance-Ray.
+            Ignored when ``fast_search=True``.
+        fast_search: Search only indexed data.  When enabled, Lance-Ray does
+            not schedule flat-search fallback plans for unindexed fragments.
+        analyze_plan: Return Lance scanner analyze plans instead of executing
+            the query and returning a table.  The result is a string containing
+            one section per planned shard.
+        scanner_options: Additional Lance scanner options.  Lance-Ray manages
+            ``nearest``, ``fragments``, ``index_segments``, ``fast_search``,
+            ``limit``, and ``offset`` internally, so these options cannot be
+            supplied here.
+
+    Returns:
+        A PyArrow table containing the global top-k rows sorted by ``_distance``.
+        If ``analyze_plan=True``, returns a string containing per-shard Lance
+        scanner analysis instead.
+    """
+    if num_workers <= 0:
+        raise ValueError(f"num_workers must be positive, got {num_workers}")
+    if block_size is not None and block_size <= 0:
+        raise ValueError(f"block_size must be positive, got {block_size}")
+
+    column = nearest.get("column")
+    if not column:
+        raise ValueError("nearest must include 'column' for distributed vector search")
+
+    global_k, candidate_k = _candidate_k(nearest, oversample_factor)
+
+    base_scanner_options = dict(scanner_options or {})
+    _validate_search_scanner_options(base_scanner_options)
+    if columns is not None:
+        if isinstance(columns, list) and "_distance" not in columns:
+            columns = [*columns, "_distance"]
+        base_scanner_options["columns"] = columns
+    if filter is not None:
+        base_scanner_options["filter"] = filter
+    base_scanner_options["fast_search"] = fast_search
+
+    merged_storage_options: dict[str, Any] = {}
+    if storage_options:
+        merged_storage_options.update(storage_options)
+
+    if isinstance(uri, str | type(None)):
+        validate_uri_or_namespace(uri, namespace_impl, table_id)
+        namespace = get_or_create_namespace(namespace_impl, namespace_properties)
+        if namespace is not None and table_id is not None:
+            from lance_namespace import DescribeTableRequest
+
+            describe_response = namespace.describe_table(
+                DescribeTableRequest(id=table_id)
+            )
+            uri = describe_response.location
+            if describe_response.storage_options:
+                merged_storage_options.update(describe_response.storage_options)
+
+        dataset_uri = uri
+        namespace_kwargs = get_namespace_kwargs(
+            namespace_impl, namespace_properties, table_id
+        )
+        worker_namespace_impl = namespace_impl
+        worker_namespace_properties = namespace_properties
+        worker_table_id = table_id
+        dataset = LanceDataset(
+            dataset_uri,
+            **_dataset_load_kwargs(merged_storage_options, namespace_kwargs, block_size),
+        )
+    else:
+        dataset = uri
+        dataset_uri = dataset.uri
+        if not merged_storage_options:
+            merged_storage_options.update(_get_dataset_storage_options(dataset))
+        namespace_kwargs = {}
+        worker_namespace_impl = None
+        worker_namespace_properties = None
+        worker_table_id = None
+
+    try:
+        dataset.schema.field(column)
+    except KeyError as exc:
+        available_columns = [field.name for field in dataset.schema]
+        raise ValueError(
+            f"Column '{column}' not found. Available: {available_columns}"
+        ) from exc
+
+    dataset_version = dataset.version
+    fragments = dataset.get_fragments()
+    if not fragments:
+        return pa.table({})
+
+    vector_index = _select_vector_index(
+        dataset,
+        column=column,
+        index_name=index_name,
+    )
+    if vector_index is None:
+        logger.info(
+            "No vector index found for column '%s'; distributed search will use flat scan",
+            column,
+        )
+
+    plans = _plan_vector_search(
+        fragments=fragments,
+        vector_index=vector_index,
+        num_workers=num_workers,
+        include_unindexed=include_unindexed and not fast_search,
+    )
+    if not plans:
+        return pa.table({})
+
+    def run_plan(plan: _SearchPlan) -> pa.Table:
+        return _execute_vector_search_plan(
+            plan,
+            dataset_uri=dataset_uri,
+            dataset_version=dataset_version,
+            storage_options=merged_storage_options,
+            block_size=block_size,
+            namespace_impl=worker_namespace_impl,
+            namespace_properties=worker_namespace_properties,
+            table_id=worker_table_id,
+            base_scanner_options=base_scanner_options,
+            nearest=nearest,
+            candidate_k=candidate_k,
+            analyze_plan=analyze_plan,
+        )
+
+    pool = Pool(processes=min(num_workers, len(plans)), ray_remote_args=ray_remote_args)
+    try:
+        results = pool.map_async(run_plan, plans, chunksize=1).get()
+    except Exception as exc:  # pragma: no cover - exercised via integration tests
+        raise RuntimeError(f"Failed to complete distributed vector search: {exc}") from exc
+    finally:
+        pool.close()
+        pool.join()
+
+    if analyze_plan:
+        return _format_analyze_plan_results(results)
+
+    return _merge_vector_search_results(results, global_k)

--- a/tests/test_distributed_search.py
+++ b/tests/test_distributed_search.py
@@ -1,0 +1,380 @@
+from types import SimpleNamespace
+
+import pyarrow as pa
+import pytest
+from lance_ray.search import (
+    _execute_vector_search_plan,
+    _format_analyze_plan_results,
+    _merge_vector_search_results,
+    _plan_vector_search,
+    _SearchPlan,
+    _SearchPlanAnalysis,
+    _select_vector_index,
+    _validate_search_scanner_options,
+)
+
+
+class _FakeFragment:
+    def __init__(self, fragment_id: int, rows: int = 1):
+        self.fragment_id = fragment_id
+        self._rows = rows
+
+    def count_rows(self):
+        return self._rows
+
+
+def _index_with_segments(*segments):
+    return SimpleNamespace(
+        name="vector_idx",
+        field_names=["vector"],
+        index_type="IVF_PQ",
+        segments=[
+            SimpleNamespace(uuid=uuid, fragment_ids=set(fragment_ids))
+            for uuid, fragment_ids in segments
+        ],
+    )
+
+
+def test_select_vector_index_raises_for_missing_explicit_index_name(monkeypatch):
+    dataset = object()
+    index = _index_with_segments(("S1", [1, 2]))
+
+    monkeypatch.setattr(
+        "lance_ray.search._get_index_descriptions",
+        lambda _: [index],
+    )
+
+    with pytest.raises(ValueError, match="missing_idx.*vector_idx"):
+        _select_vector_index(
+            dataset,
+            column="vector",
+            index_name="missing_idx",
+        )
+
+
+def test_plan_vector_search_keeps_segment_fragments_together():
+    fragments = [_FakeFragment(fragment_id) for fragment_id in range(1, 6)]
+    index = _index_with_segments(
+        ("S1", [1, 2]),
+        ("S2", [3]),
+        ("S3", [4, 5]),
+    )
+
+    plans = _plan_vector_search(
+        fragments=fragments,
+        vector_index=index,
+        num_workers=3,
+        include_unindexed=True,
+    )
+
+    segment_fragments = {
+        segment: set(plan.fragment_ids)
+        for plan in plans
+        for segment in plan.index_segments
+    }
+
+    assert segment_fragments == {
+        "S1": {1, 2},
+        "S2": {3},
+        "S3": {4, 5},
+    }
+
+
+def test_plan_vector_search_adds_unindexed_fragments_as_fallback():
+    fragments = [_FakeFragment(fragment_id) for fragment_id in range(1, 5)]
+    index = _index_with_segments(("S1", [1, 2]))
+
+    plans = _plan_vector_search(
+        fragments=fragments,
+        vector_index=index,
+        num_workers=3,
+        include_unindexed=True,
+    )
+
+    fallback_fragments = {
+        fragment_id
+        for plan in plans
+        if not plan.index_segments
+        for fragment_id in plan.fragment_ids
+    }
+
+    assert fallback_fragments == {3, 4}
+    assert all(
+        not (plan.index_segments and fallback_fragments.intersection(plan.fragment_ids))
+        for plan in plans
+    )
+
+
+def test_plan_vector_search_does_not_mix_indexed_and_fallback_units():
+    fragments = [_FakeFragment(fragment_id) for fragment_id in range(1, 5)]
+    index = _index_with_segments(("S1", [1, 2]))
+
+    plans = _plan_vector_search(
+        fragments=fragments,
+        vector_index=index,
+        num_workers=1,
+        include_unindexed=True,
+    )
+
+    assert plans == [
+        _SearchPlan(fragment_ids=[1, 2], index_segments=["S1"]),
+        _SearchPlan(fragment_ids=[3, 4], index_segments=[]),
+    ]
+
+
+def test_plan_vector_search_can_skip_unindexed_fragments():
+    fragments = [_FakeFragment(fragment_id) for fragment_id in range(1, 5)]
+    index = _index_with_segments(("S1", [1, 2]))
+
+    plans = _plan_vector_search(
+        fragments=fragments,
+        vector_index=index,
+        num_workers=3,
+        include_unindexed=False,
+    )
+
+    assert plans == [_SearchPlan(fragment_ids=[1, 2], index_segments=["S1"])]
+
+
+def test_plan_vector_search_without_index_uses_flat_fallback():
+    fragments = [_FakeFragment(fragment_id) for fragment_id in range(1, 4)]
+
+    plans = _plan_vector_search(
+        fragments=fragments,
+        vector_index=None,
+        num_workers=2,
+        include_unindexed=True,
+    )
+
+    assert {fragment_id for plan in plans for fragment_id in plan.fragment_ids} == {
+        1,
+        2,
+        3,
+    }
+    assert all(not plan.index_segments for plan in plans)
+
+
+def test_execute_indexed_vector_search_plan_does_not_pass_fragments(monkeypatch):
+    scanner_options = {}
+
+    class FakeDataset:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get_fragment(self, fragment_id):
+            raise AssertionError(f"unexpected fragment lookup: {fragment_id}")
+
+        def scanner(self, **kwargs):
+            scanner_options.update(kwargs)
+            return SimpleNamespace(
+                to_table=lambda: pa.table({"id": [1], "_distance": [0.1]})
+            )
+
+    monkeypatch.setattr("lance_ray.search.LanceDataset", FakeDataset)
+
+    result = _execute_vector_search_plan(
+        _SearchPlan(fragment_ids=[1, 2], index_segments=["S1"]),
+        dataset_uri="dataset",
+        dataset_version=1,
+        storage_options=None,
+        block_size=None,
+        namespace_impl=None,
+        namespace_properties=None,
+        table_id=None,
+        base_scanner_options={"fast_search": False},
+        nearest={"column": "vector", "q": [0.0, 0.0], "k": 1},
+        candidate_k=1,
+        analyze_plan=False,
+    )
+
+    assert result.num_rows == 1
+    assert "fragments" not in scanner_options
+    assert scanner_options["index_segments"] == ["S1"]
+    assert scanner_options["fast_search"] is True
+
+
+def test_execute_fallback_vector_search_plan_computes_local_top_k(monkeypatch):
+    scanner_options = {}
+    vectors = pa.FixedSizeListArray.from_arrays(
+        pa.array([10.0, 0.0, 1.0, 0.0, 0.0, 2.0], type=pa.float32()),
+        2,
+    )
+
+    class FakeDataset:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get_fragment(self, fragment_id):
+            return f"fragment-{fragment_id}"
+
+        def scanner(self, **kwargs):
+            scanner_options.update(kwargs)
+            return SimpleNamespace(
+                to_table=lambda: pa.table({"id": [1, 2, 3], "vector": vectors})
+            )
+
+    monkeypatch.setattr("lance_ray.search.LanceDataset", FakeDataset)
+
+    result = _execute_vector_search_plan(
+        _SearchPlan(fragment_ids=[7], index_segments=[]),
+        dataset_uri="dataset",
+        dataset_version=1,
+        storage_options=None,
+        block_size=None,
+        namespace_impl=None,
+        namespace_properties=None,
+        table_id=None,
+        base_scanner_options={"columns": ["id", "_distance"], "fast_search": False},
+        nearest={"column": "vector", "q": [0.0, 0.0], "k": 2},
+        candidate_k=2,
+        analyze_plan=False,
+    )
+
+    assert "nearest" not in scanner_options
+    assert scanner_options["fragments"] == ["fragment-7"]
+    assert scanner_options["columns"] == ["id", "vector"]
+    assert result.column("id").to_pylist() == [2, 3]
+    assert result.column("_distance").to_pylist() == [1.0, 2.0]
+    assert "vector" not in result.column_names
+
+
+def test_execute_indexed_vector_search_plan_can_analyze_plan(monkeypatch):
+    scanner_options = {}
+
+    class FakeScanner:
+        def analyze_plan(self):
+            return "indexed plan"
+
+        def to_table(self):
+            raise AssertionError("analyze_plan should not execute to_table")
+
+    class FakeDataset:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get_fragment(self, fragment_id):
+            raise AssertionError(f"unexpected fragment lookup: {fragment_id}")
+
+        def scanner(self, **kwargs):
+            scanner_options.update(kwargs)
+            return FakeScanner()
+
+    monkeypatch.setattr("lance_ray.search.LanceDataset", FakeDataset)
+
+    result = _execute_vector_search_plan(
+        _SearchPlan(fragment_ids=[1], index_segments=["S1"]),
+        dataset_uri="dataset",
+        dataset_version=1,
+        storage_options=None,
+        block_size=None,
+        namespace_impl=None,
+        namespace_properties=None,
+        table_id=None,
+        base_scanner_options={"fast_search": False},
+        nearest={"column": "vector", "q": [0.0, 0.0], "k": 1},
+        candidate_k=1,
+        analyze_plan=True,
+    )
+
+    assert result == _SearchPlanAnalysis(
+        plan=_SearchPlan(fragment_ids=[1], index_segments=["S1"]),
+        analysis="indexed plan",
+    )
+    assert "fragments" not in scanner_options
+    assert scanner_options["index_segments"] == ["S1"]
+    assert scanner_options["fast_search"] is True
+
+
+def test_execute_fallback_vector_search_plan_can_analyze_plan(monkeypatch):
+    scanner_options = {}
+
+    class FakeScanner:
+        def analyze_plan(self):
+            return "fallback plan"
+
+        def to_table(self):
+            raise AssertionError("analyze_plan should not execute to_table")
+
+    class FakeDataset:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get_fragment(self, fragment_id):
+            return f"fragment-{fragment_id}"
+
+        def scanner(self, **kwargs):
+            scanner_options.update(kwargs)
+            return FakeScanner()
+
+    monkeypatch.setattr("lance_ray.search.LanceDataset", FakeDataset)
+
+    result = _execute_vector_search_plan(
+        _SearchPlan(fragment_ids=[7], index_segments=[]),
+        dataset_uri="dataset",
+        dataset_version=1,
+        storage_options=None,
+        block_size=None,
+        namespace_impl=None,
+        namespace_properties=None,
+        table_id=None,
+        base_scanner_options={"columns": ["id", "_distance"], "fast_search": False},
+        nearest={"column": "vector", "q": [0.0, 0.0], "k": 2},
+        candidate_k=2,
+        analyze_plan=True,
+    )
+
+    assert result == _SearchPlanAnalysis(
+        plan=_SearchPlan(fragment_ids=[7], index_segments=[]),
+        analysis="fallback plan",
+    )
+    assert "nearest" not in scanner_options
+    assert scanner_options["fragments"] == ["fragment-7"]
+    assert scanner_options["columns"] == ["id", "vector"]
+
+
+def test_format_analyze_plan_results():
+    result = _format_analyze_plan_results(
+        [
+            _SearchPlanAnalysis(
+                plan=_SearchPlan(fragment_ids=[1], index_segments=["S1"]),
+                analysis="indexed plan",
+            ),
+            _SearchPlanAnalysis(
+                plan=_SearchPlan(fragment_ids=[2], index_segments=[]),
+                analysis="fallback plan",
+            ),
+        ]
+    )
+
+    assert "shard 0 (indexed)" in result
+    assert "index_segments: ['S1']" in result
+    assert "indexed plan" in result
+    assert "shard 1 (flat_fallback)" in result
+    assert "fallback plan" in result
+
+
+def test_merge_vector_search_results_returns_global_top_k():
+    left = pa.table({"id": [1, 2], "_distance": [0.4, 0.1]})
+    right = pa.table({"id": [3, 4], "_distance": [0.2, 0.3]})
+
+    result = _merge_vector_search_results([left, right], k=3)
+
+    assert result.column("id").to_pylist() == [2, 3, 4]
+    assert result.column("_distance").to_pylist() == [0.1, 0.2, 0.3]
+
+
+def test_merge_vector_search_results_requires_distance():
+    table = pa.table({"id": [1, 2]})
+
+    with pytest.raises(RuntimeError, match="_distance"):
+        _merge_vector_search_results([table], k=1)
+
+
+def test_search_scanner_options_reject_managed_options():
+    with pytest.raises(ValueError, match="nearest"):
+        _validate_search_scanner_options({"nearest": {"column": "vector"}})
+
+
+def test_search_scanner_options_reject_fast_search_override():
+    with pytest.raises(ValueError, match="fast_search"):
+        _validate_search_scanner_options({"fast_search": True})


### PR DESCRIPTION
## Summary

- add `vector_search()` for distributed vector top-k search with Ray
- plan search ownership on the driver by vector index segment coverage, keeping multi-fragment segments on one worker
- execute indexed worker scans with fixed dataset version and `index_segments` only; `fragments` is not passed to Lance nearest search
- schedule unindexed fallback fragments as separate regular fragment scans and compute vector distances in Lance-Ray
- add explicit `fast_search` support; when enabled, unindexed fallback fragments are not scheduled
- add `analyze_plan=True` support to return per-shard `LanceScanner.analyze_plan()` output instead of executing search
- document the new API and add unit coverage for planning, explicit index-name errors, fallback separation, indexed execution options, fallback distance calculation, analyze-plan output, and global top-k merge

## Ray/Lance semantics

The driver reads index metadata once and builds the worker plan before dispatch. Workers do not call `describe_indices()` themselves. Each Ray Pool item is one planned shard.

Indexed shard tasks receive only their owned Lance index segment UUIDs and run Lance nearest search with `index_segments` and `fast_search=True`. They intentionally do not pass `fragments` because Lance nearest search does not support fragment-restricted scans.

Unindexed fallback fragments, when enabled, are scheduled as separate flat-search tasks. These tasks use regular Lance fragment scans without `nearest`, compute `_distance` in Lance-Ray, take local top-k candidates, and return them to the driver.

`fast_search=True` searches only indexed data, so Lance-Ray skips flat-search fallback plans for fragments that are not covered by vector index segments. `analyze_plan=True` builds the same per-shard scanners and returns their `analyze_plan()` text grouped by shard. Otherwise, each worker returns at least the global `k` candidates, or `k * oversample_factor` when requested. The driver concatenates candidate tables, sorts by `_distance`, and returns the final global top-k.

## Validation

- `.venv/bin/ruff check`
- `python -m pytest tests/test_distributed_search.py`
- local smoke test with pylance 5.1: `lr.vector_search(...)` over an existing `IVF_FLAT` index returns the same top-5 ids as Lance nearest search
- local smoke test with pylance 5.1: `lr.vector_search(..., analyze_plan=True)` returns per-shard analyze-plan text

Note: `uv run ruff check ...` could not start on this macOS x86_64 machine because `pylance==7.0.0b7` has no compatible wheel for this platform.