### PR TITLE
ci: harden and generalize pylance release checks

### DIFF
--- a/.github/workflows/pylance-release-timer.yml
+++ b/.github/workflows/pylance-release-timer.yml
@@ -44,15 +44,21 @@ jobs:
         id: pr
         env:
           GH_TOKEN: ${{ secrets.LANCE_RELEASE_TOKEN }}
+          LATEST_PYPI_VERSION: ${{ steps.check.outputs.latest_pypi_version }}
+          UPDATE_BRANCH: ${{ steps.check.outputs.update_branch_name }}
         run: |
           set -euo pipefail
-          TITLE="chore: update pylance dependency to v${{ steps.check.outputs.latest_version }}"
-          COUNT=$(gh pr list --search "\"$TITLE\" in:title" --state open --limit 1 --json number --jq 'length')
-          if [ "$COUNT" -gt 0 ]; then
-            echo "Open PR already exists for $TITLE"
+          TITLE="chore: update pylance dependency to v${LATEST_PYPI_VERSION}"
+          # Match by branch head (deterministic) OR by title (PEP 440 format,
+          # produced by codex-update-pylance-dependency.yml). Search both open
+          # and closed states so we don't reopen a manually-closed duplicate.
+          BRANCH_COUNT=$(gh pr list --head "$UPDATE_BRANCH" --state all --limit 1 --json number --jq 'length')
+          TITLE_COUNT=$(gh pr list --search "\"$TITLE\" in:title" --state all --limit 1 --json number --jq 'length')
+          if [ "$BRANCH_COUNT" -gt 0 ] || [ "$TITLE_COUNT" -gt 0 ]; then
+            echo "Existing PR found for branch=$UPDATE_BRANCH or title=$TITLE"
             echo "pr_exists=true" >> "$GITHUB_OUTPUT"
           else
-            echo "No existing PR for $TITLE"
+            echo "No existing PR for branch=$UPDATE_BRANCH or title=$TITLE"
             echo "pr_exists=false" >> "$GITHUB_OUTPUT"
           fi
 

--- a/ci/check_pylance_release.py
+++ b/ci/check_pylance_release.py
@@ -30,6 +30,9 @@ PYPI_PRERELEASE_RE = re.compile(r"^(?P<base>\d+\.\d+\.\d+)(?P<pre>a|b|rc)(?P<num
 
 PYLANCE_DEP_RE = re.compile(r"^pylance[><=!~]+(.+)$")
 
+PYPI_TO_SEMVER_PRE = {"a": "alpha", "b": "beta", "rc": "rc"}
+SEMVER_TO_PYPI_PRE = {v: k for k, v in PYPI_TO_SEMVER_PRE.items()}
+
 
 def pypi_to_semver(version: str) -> str:
     """Convert PyPI version format to semver format.
@@ -46,8 +49,41 @@ def pypi_to_semver(version: str) -> str:
     base = match.group("base")
     pre = match.group("pre")
     num = match.group("num")
-    pre_map = {"a": "alpha", "b": "beta", "rc": "rc"}
-    return f"{base}-{pre_map[pre]}.{num}"
+    return f"{base}-{PYPI_TO_SEMVER_PRE[pre]}.{num}"
+
+
+def semver_to_pypi(version: str) -> str:
+    """Convert semver format to PyPI (PEP 440) version format.
+
+    Examples:
+        2.0.0-beta.8  -> 2.0.0b8
+        2.0.0-alpha.1 -> 2.0.0a1
+        2.0.0-rc.1    -> 2.0.0rc1
+        2.0.0         -> 2.0.0
+    """
+    match = SEMVER_RE.match(version.strip())
+    if not match:
+        return version
+    base = f"{match.group('major')}.{match.group('minor')}.{match.group('patch')}"
+    prerelease = match.group("prerelease")
+    if not prerelease:
+        return base
+    parts = prerelease.split(".")
+    if len(parts) == 2 and parts[0] in SEMVER_TO_PYPI_PRE and parts[1].isdigit():
+        return f"{base}{SEMVER_TO_PYPI_PRE[parts[0]]}{parts[1]}"
+    return version
+
+
+def update_branch_name(dependency_name: str, version: str) -> str:
+    """Return the deterministic codex branch name for a dependency update.
+
+    The codex update workflow creates branches named
+    ``codex/update-<dependency>-<sanitized version>`` so the timer workflow
+    must compute the same value when checking for an existing PR.
+    """
+    sanitized_dependency = re.sub(r"[^a-zA-Z0-9]", "-", dependency_name)
+    sanitized_version = re.sub(r"[^a-zA-Z0-9]", "-", version)
+    return f"codex/update-{sanitized_dependency}-{sanitized_version}"
 
 
 @dataclass(frozen=True)
@@ -220,11 +256,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     latest = determine_latest_tag(tags)
     needs_update = latest.semver > current_semver
 
+    latest_pypi_version = semver_to_pypi(latest.version)
     payload = {
         "current_version": current_version,
         "current_tag": f"v{current_version}",
         "latest_version": latest.version,
         "latest_tag": latest.tag,
+        "latest_pypi_version": latest_pypi_version,
+        "update_branch_name": update_branch_name("pylance", latest.version),
         "needs_update": "true" if needs_update else "false",
     }
 

--- a/tests/test_release_check_helpers.py
+++ b/tests/test_release_check_helpers.py
@@ -1,0 +1,55 @@
+import pytest
+from ci.check_pylance_release import (
+    pypi_to_semver,
+    semver_to_pypi,
+    update_branch_name,
+)
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("7.1.0", "7.1.0"),
+        ("7.1.0-beta.4", "7.1.0-beta.4"),
+        ("7.1.0b4", "7.1.0-beta.4"),
+        ("7.1.0-rc.2", "7.1.0-rc.2"),
+        ("7.1.0rc2", "7.1.0-rc.2"),
+    ],
+)
+def test_pypi_prerelease_versions_convert_to_semver(
+    version: str, expected: str
+) -> None:
+    assert pypi_to_semver(version) == expected
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("7.1.0", "7.1.0"),
+        ("7.1.0-beta.4", "7.1.0b4"),
+        ("7.1.0-alpha.1", "7.1.0a1"),
+        ("7.1.0-rc.2", "7.1.0rc2"),
+        ("7.1.0b4", "7.1.0b4"),
+    ],
+)
+def test_semver_prerelease_versions_convert_to_pypi(
+    version: str, expected: str
+) -> None:
+    assert semver_to_pypi(version) == expected
+
+
+@pytest.mark.parametrize(
+    ("dependency_name", "version", "expected"),
+    [
+        ("pylance", "7.1.0", "codex/update-pylance-7-1-0"),
+        ("pylance", "7.1.0-beta.4", "codex/update-pylance-7-1-0-beta-4"),
+        ("pylance", "7.1.0-rc.2", "codex/update-pylance-7-1-0-rc-2"),
+        ("pylance", "1.0.0+build.1", "codex/update-pylance-1-0-0-build-1"),
+        ("pylance", "1.0.0--foo", "codex/update-pylance-1-0-0--foo"),
+        ("other-extension", "2.0.0", "codex/update-other-extension-2-0-0"),
+    ],
+)
+def test_dependency_update_branch_name_uses_sanitized_parts(
+    dependency_name: str, version: str, expected: str
+) -> None:
+    assert update_branch_name(dependency_name, version) == expected


### PR DESCRIPTION
# Summary

Harden the Pylance release timer against duplicate update PRs and make the release-check helper tests reusable for
future dependency extensions.

# Changes

- Added semver-to-PyPI conversion output for matching Codex update PR titles.
- Added deterministic update branch-name output and use it when checking existing PRs.
- Updated PR detection to search by branch or title across all PR states.
- Generalized branch-name helper/tests to accept a dependency name.

# Testing

Added `tests/test_release_check_helpers.py`.
