### PR TITLE
chore: update pylance dependency to v7.2.0b2

### DIFF
--- a/lance_ray/search.py
+++ b/lance_ray/search.py
@@ -484,7 +484,9 @@ def _candidate_k(nearest: dict[str, Any], oversample_factor: float) -> tuple[int
     try:
         global_k = int(nearest["k"])
     except KeyError as exc:
-        raise ValueError("nearest must include 'k' for distributed vector search") from exc
+        raise ValueError(
+            "nearest must include 'k' for distributed vector search"
+        ) from exc
 
     if global_k <= 0:
         raise ValueError(f"nearest['k'] must be positive, got {global_k}")
@@ -618,7 +620,9 @@ def vector_search(
         worker_table_id = table_id
         dataset = LanceDataset(
             dataset_uri,
-            **_dataset_load_kwargs(merged_storage_options, namespace_kwargs, block_size),
+            **_dataset_load_kwargs(
+                merged_storage_options, namespace_kwargs, block_size
+            ),
         )
     else:
         dataset = uri
@@ -683,7 +687,9 @@ def vector_search(
     try:
         results = pool.map_async(run_plan, plans, chunksize=1).get()
     except Exception as exc:  # pragma: no cover - exercised via integration tests
-        raise RuntimeError(f"Failed to complete distributed vector search: {exc}") from exc
+        raise RuntimeError(
+            f"Failed to complete distributed vector search: {exc}"
+        ) from exc
     finally:
         pool.close()
         pool.join()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=7.0.0b7",
+    "pylance>=7.2.0b2",
     "lance-namespace",
     "packaging",
     "pyarrow>=17.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -326,19 +326,19 @@ wheels = [
 
 [[package]]
 name = "lance-namespace"
-version = "0.7.6"
+version = "0.7.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/da/134670003173881bed44af656badffd91e0b2e0232c083eeacc5923d7335/lance_namespace-0.7.6.tar.gz", hash = "sha256:4e12094005d105ef1b44346c9d7feda4a0f733b127dab90c1a5ffbf7cd433770", size = 10686, upload-time = "2026-05-05T18:26:38.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/5c/9822af615fc1bd3ee1073994696c739aecde377be32435ec3303aed1bc5d/lance_namespace-0.7.7.tar.gz", hash = "sha256:d00b525f2e26993a6c61668e798bca6c808605ab8a79f29f86a1a1af92d91ae2", size = 10754, upload-time = "2026-05-20T17:32:59.45Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/88/44463a5f41f7077b2ea641f2afded72eaceb6a6a1b4a55c11b22318fed74/lance_namespace-0.7.6-py3-none-any.whl", hash = "sha256:c94a1b8a6aab127e55a20cbf44d927ae3a9b7d435656d2130dccf84ccf7c9999", size = 12519, upload-time = "2026-05-05T18:26:36.425Z" },
+    { url = "https://files.pythonhosted.org/packages/11/43/186acc1156da20c351db196e2b6241b2453b16dc1b4cc8e0a626667ca471/lance_namespace-0.7.7-py3-none-any.whl", hash = "sha256:477a7ca6b5e1f673a2c9ba52f42d6e8e3ff7c27a601392a21eb90fba98d0309b", size = 12581, upload-time = "2026-05-20T17:32:57.389Z" },
 ]
 
 [[package]]
 name = "lance-namespace-urllib3-client"
-version = "0.7.6"
+version = "0.7.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -346,9 +346,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/44/024aae184c08b3800482cd9b832d534249e25de145af732d4e4c8dff38a8/lance_namespace_urllib3_client-0.7.6.tar.gz", hash = "sha256:15ae7f0d8d56fa34d837f7f6ec5c80a327a905e89ccfed05f7b409d6fe704cdf", size = 195551, upload-time = "2026-05-05T18:26:37.808Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/95/38ab81ccc1e09beeecd8ddfc61b8bc73831dc5053db1e3f9021f64a4896b/lance_namespace_urllib3_client-0.7.7.tar.gz", hash = "sha256:4d8c066628c17c6a10cf643b51a7f7ae1bfb8a614d9cc54a5af38a4ba2b4b102", size = 202930, upload-time = "2026-05-20T17:32:58.308Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/50/60c983cc8180772c82370dfad2104b7e788aaacc3bf9a84e8b42bb1ae6a7/lance_namespace_urllib3_client-0.7.6-py3-none-any.whl", hash = "sha256:fb884d8afff8af3aae04a3270624694a189d7ea79225dd349e6c555a1a1d6b52", size = 324603, upload-time = "2026-05-05T18:26:39.718Z" },
+    { url = "https://files.pythonhosted.org/packages/35/96/5483e48e40433b1d078183c15a92c99e59a156041b0260e7f18ee34e7c08/lance_namespace_urllib3_client-0.7.7-py3-none-any.whl", hash = "sha256:9221c3e00fd89f0c811953d94b32d2ea527765280460a174f5872dc8a74c0ed6", size = 334767, upload-time = "2026-05-20T17:32:55.883Z" },
 ]
 
 [[package]]
@@ -387,7 +387,7 @@ requires-dist = [
     { name = "more-itertools", marker = "python_full_version < '3.12'", specifier = ">=2.6.0" },
     { name = "packaging" },
     { name = "pyarrow", specifier = ">=17.0.0" },
-    { name = "pylance", specifier = ">=7.0.0b7" },
+    { name = "pylance", specifier = ">=7.2.0b2" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
@@ -1024,7 +1024,7 @@ wheels = [
 
 [[package]]
 name = "pylance"
-version = "7.0.0b7"
+version = "7.2.0b2"
 source = { registry = "https://pypi.fury.io/lance-format" }
 dependencies = [
     { name = "lance-namespace" },
@@ -1033,12 +1033,12 @@ dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://pypi.fury.io/lance-format/-/ver_1zsVV4/pylance-7.0.0b7-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:66f2ba7969c0fad259f5d13842e89d664956c1415eed644d6956af333e848a62" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1TtYis/pylance-7.0.0b7-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:029ac2359cccbac62345392c78f5aae6596eda4a3398fbf8bef5aad708591d14" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_uZkce/pylance-7.0.0b7-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a53841757573d7c63238d79df94236eb6e46d9508d2690d98ce983e5d04f8c7a" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_3iSeD/pylance-7.0.0b7-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:34c67a0102d47f870d4b795087622c16087aa1928c1925b1acdeb61206f4663a" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_BpURn/pylance-7.0.0b7-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ac70f0248239b50ae718e38e69c1418899a1a7575e7b911beac91eeb60b174ec" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_jVZS2/pylance-7.0.0b7-cp39-abi3-win_amd64.whl", hash = "sha256:0f1caea57ea998f6e59dcb2684a08e4b06f993ecc77c8d0f032a4a43a82ed085" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1GE7gR/pylance-7.2.0b2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:2afdd465ec02dac3b3700ae2e70e35e73983d1b656b6e03d6bf37da4472158b8" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_2glvd2/pylance-7.2.0b2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a33bdb1a7c5cd888581944b48cd003d4b023da394a057d21af58f660c30b6e9e" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1vALS5/pylance-7.2.0b2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bd0e54457dc66dc1a3a2b1ae888c0563b2caf8e6e84d823e6633c3856c28f2f" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_sq5ZB/pylance-7.2.0b2-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f6c90d0131bf0099313208b4c149262a55d51bc211a6393559ddaca72735eafb" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_25hSve/pylance-7.2.0b2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:157ed4db639404490a526c858381717f76b5026a1ca89c9a9c4bb8189a4aecc1" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_22nOtJ/pylance-7.2.0b2-cp39-abi3-win_amd64.whl", hash = "sha256:0a2ac938d956283a037fc1c46b3d051c3396cf00650bb791e2dc30a5bb2bb226" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps the Pylance dependency requirement to `pylance>=7.2.0b2`.
- Refreshes `uv.lock`, including the resolved Pylance wheel hashes and related Lance namespace package updates.
- Applies required Ruff formatting from `make fix`.

## Verification
- `make lock`
- `make lint` initially required dev tooling setup and formatting; after `make fix`, `make lint` passed.

Triggered by tag: `refs/tags/v7.2.0-beta.2`
