### PR TITLE
perf: reuse global Ray pool for vector search

### DIFF
--- a/docs/src/distributed-indexing.md
+++ b/docs/src/distributed-indexing.md
@@ -365,6 +365,38 @@ updated_dataset = lr.create_scalar_index(
 )
 ```
 
+### Reusing a Ray Pool
+
+Creating a Ray Pool can be expensive if you repeatedly run distributed vector searches in the same process.  You can explicitly initialize a process-wide Pool with `init_global_pool()`.  After that, Lance-Ray will reuse this global Pool for `vector_search()` calls instead of creating a new local Pool each time.
+
+Use this when the same driver process will call `vector_search()` multiple times in a serial workflow:
+
+```python
+import lance_ray as lr
+
+lr.init_global_pool(
+    processes=16,
+    ray_remote_args={"num_cpus": 2},
+)
+
+try:
+    results = lr.vector_search(
+        uri="path/to/dataset.lance",
+        nearest={"column": "vector", "q": query_vector, "k": 10},
+        num_workers=16,
+    )
+finally:
+    lr.clear_global_pool(close=True)
+```
+
+`init_global_pool()` is idempotent while a global Pool exists: later calls return the existing Pool instead of replacing it.  If a global Pool exists, `vector_search()` reuses it and does not close it after the operation.  In that case, the Pool's original `processes` and `ray_remote_args` control the workers; per-call `num_workers` and `ray_remote_args` are only used when Lance-Ray has to create a local Pool for that call.  Lance-Ray logs a warning when it can determine that the requested worker count differs from the configured global Pool size.
+
+Call `clear_global_pool(close=True)` when the driver is done with the shared Pool.  If you manage the Pool lifecycle yourself, use `set_global_pool(pool)` to register it and `clear_global_pool(close=False)` to clear Lance-Ray's reference without closing the Pool.
+
+The global Pool registry is protected for basic set/get/clear operations, but the intended usage is still a single driver process that reuses the Pool serially across operations.  Avoid concurrently mutating the global Pool while other threads are running Lance-Ray operations.
+
+The current global Pool integration is limited to `vector_search()`.  The same pattern can be applied to I/O, index building, and compaction in follow-up changes.
+
 ### Index Replacement Control
 
 ```python

--- a/lance_ray/__init__.py
+++ b/lance_ray/__init__.py
@@ -23,12 +23,17 @@ from .io import (
     read_lance,
     write_lance,
 )
+from .pool import clear_global_pool, get_global_pool, init_global_pool, set_global_pool
 from .search import vector_search
 
 __all__ = [
     "read_lance",
     "write_lance",
     "vector_search",
+    "init_global_pool",
+    "set_global_pool",
+    "get_global_pool",
+    "clear_global_pool",
     "add_columns",
     "add_columns_from",
     "merge_columns_from",

--- a/lance_ray/pool.py
+++ b/lance_ray/pool.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+import logging
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any, Optional
+
+from ray.util.multiprocessing import Pool
+
+logger = logging.getLogger(__name__)
+
+_GLOBAL_POOL: Any | None = None
+_GLOBAL_POOL_PROCESSES: int | None = None
+_GLOBAL_POOL_LOCK = threading.RLock()
+
+
+def _read_pool_processes(pool: Any) -> int | None:
+    for attr in ("processes", "_processes", "_num_processes"):
+        value = getattr(pool, attr, None)
+        if isinstance(value, int):
+            return value
+    return None
+
+
+def _warn_if_process_count_differs(requested_processes: int) -> None:
+    if _GLOBAL_POOL_PROCESSES is None:
+        return
+    if requested_processes == _GLOBAL_POOL_PROCESSES:
+        return
+
+    logger.warning(
+        "Reusing global Ray Pool with %d processes; requested %d workers will be "
+        "ignored while the global Pool is active.",
+        _GLOBAL_POOL_PROCESSES,
+        requested_processes,
+    )
+
+
+def set_global_pool(pool: Any | None) -> None:
+    """Set a process-wide Ray Pool for Lance-Ray operations to reuse.
+
+    Passing ``None`` clears the global Pool reference without closing it.
+    """
+    global _GLOBAL_POOL, _GLOBAL_POOL_PROCESSES
+    with _GLOBAL_POOL_LOCK:
+        _GLOBAL_POOL = pool
+        _GLOBAL_POOL_PROCESSES = _read_pool_processes(pool) if pool is not None else None
+
+
+def get_global_pool() -> Any | None:
+    """Return the currently configured global Ray Pool, if any."""
+    with _GLOBAL_POOL_LOCK:
+        return _GLOBAL_POOL
+
+
+def init_global_pool(
+    processes: int,
+    ray_remote_args: Optional[dict[str, Any]] = None,
+) -> Any:
+    """Create and register a global Ray Pool if one does not already exist."""
+    if processes <= 0:
+        raise ValueError(f"processes must be positive, got {processes}")
+
+    global _GLOBAL_POOL, _GLOBAL_POOL_PROCESSES
+    with _GLOBAL_POOL_LOCK:
+        if _GLOBAL_POOL is not None:
+            _warn_if_process_count_differs(processes)
+            return _GLOBAL_POOL
+
+        _GLOBAL_POOL = Pool(processes=processes, ray_remote_args=ray_remote_args)
+        _GLOBAL_POOL_PROCESSES = processes
+        return _GLOBAL_POOL
+
+
+def clear_global_pool(*, close: bool = False, join: bool = True) -> None:
+    """Clear the global Pool reference, optionally closing and joining it."""
+    global _GLOBAL_POOL, _GLOBAL_POOL_PROCESSES
+    with _GLOBAL_POOL_LOCK:
+        pool = _GLOBAL_POOL
+        _GLOBAL_POOL = None
+        _GLOBAL_POOL_PROCESSES = None
+
+    if close and pool is not None:
+        pool.close()
+        if join:
+            pool.join()
+
+
+@contextmanager
+def get_or_create_pool(
+    *,
+    processes: int,
+    ray_remote_args: Optional[dict[str, Any]],
+) -> Iterator[Any]:
+    """Yield the global Pool if present, otherwise a local close-and-join Pool."""
+    with _GLOBAL_POOL_LOCK:
+        pool = _GLOBAL_POOL
+        if pool is not None:
+            _warn_if_process_count_differs(processes)
+
+    if pool is not None:
+        yield pool
+        return
+
+    local_pool = Pool(processes=processes, ray_remote_args=ray_remote_args)
+    try:
+        yield local_pool
+    finally:
+        local_pool.close()
+        local_pool.join()

--- a/lance_ray/search.py
+++ b/lance_ray/search.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
 import pyarrow as pa
 import pyarrow.compute as pc
 from lance.dataset import LanceDataset
-from ray.util.multiprocessing import Pool
 
+from .pool import get_or_create_pool
 from .utils import (
     get_namespace_kwargs,
     get_or_create_namespace,
@@ -679,14 +679,14 @@ def vector_search(
             analyze_plan=analyze_plan,
         )
 
-    pool = Pool(processes=min(num_workers, len(plans)), ray_remote_args=ray_remote_args)
     try:
-        results = pool.map_async(run_plan, plans, chunksize=1).get()
+        with get_or_create_pool(
+            processes=min(num_workers, len(plans)),
+            ray_remote_args=ray_remote_args,
+        ) as pool:
+            results = pool.map_async(run_plan, plans, chunksize=1).get()
     except Exception as exc:  # pragma: no cover - exercised via integration tests
         raise RuntimeError(f"Failed to complete distributed vector search: {exc}") from exc
-    finally:
-        pool.close()
-        pool.join()
 
     if analyze_plan:
         return _format_analyze_plan_results(results)

--- a/tests/test_distributed_search.py
+++ b/tests/test_distributed_search.py
@@ -2,6 +2,8 @@ from types import SimpleNamespace
 
 import pyarrow as pa
 import pytest
+from lance_ray import pool as pool_mod
+from lance_ray import search as search_mod
 from lance_ray.search import (
     _execute_vector_search_plan,
     _format_analyze_plan_results,
@@ -378,3 +380,63 @@ def test_search_scanner_options_reject_managed_options():
 def test_search_scanner_options_reject_fast_search_override():
     with pytest.raises(ValueError, match="fast_search"):
         _validate_search_scanner_options({"fast_search": True})
+
+
+def test_vector_search_reuses_global_pool(monkeypatch):
+    events = []
+
+    class FakeAsyncResult:
+        def get(self):
+            events.append("get")
+            return [pa.table({"id": [1], "_distance": [0.1]})]
+
+    class FakeGlobalPool:
+        def map_async(self, func, plans, chunksize):
+            events.append(("map_async", plans, chunksize))
+            return FakeAsyncResult()
+
+        def close(self):
+            events.append("close")
+
+        def join(self):
+            events.append("join")
+
+    class FakeSchema:
+        def field(self, column):
+            return column
+
+    class FakeDataset:
+        uri = "dataset"
+        version = 1
+        schema = FakeSchema()
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get_fragments(self):
+            return [_FakeFragment(1)]
+
+    plan = _SearchPlan(fragment_ids=[1], index_segments=["S1"])
+    monkeypatch.setattr(search_mod, "LanceDataset", FakeDataset)
+    monkeypatch.setattr(
+        search_mod,
+        "_select_vector_index",
+        lambda *args, **kwargs: object(),
+    )
+    monkeypatch.setattr(search_mod, "_plan_vector_search", lambda **kwargs: [plan])
+
+    pool_mod.set_global_pool(FakeGlobalPool())
+    try:
+        result = search_mod.vector_search(
+            uri="dataset",
+            nearest={"column": "vector", "q": [0.0], "k": 1},
+            num_workers=4,
+        )
+    finally:
+        pool_mod.clear_global_pool()
+
+    assert result.column("id").to_pylist() == [1]
+    assert events == [
+        ("map_async", [plan], 1),
+        "get",
+    ]

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,0 +1,97 @@
+import logging
+
+from lance_ray import pool as pool_mod
+
+
+def test_init_global_pool_reuses_existing_pool(monkeypatch):
+    events = []
+
+    class FakePool:
+        def __init__(self, processes, ray_remote_args):
+            events.append(("init", processes, ray_remote_args))
+
+        def close(self):
+            events.append("close")
+
+        def join(self):
+            events.append("join")
+
+    pool_mod.clear_global_pool()
+    monkeypatch.setattr(pool_mod, "Pool", FakePool)
+
+    first_pool = pool_mod.init_global_pool(
+        processes=3,
+        ray_remote_args={"num_cpus": 2},
+    )
+    second_pool = pool_mod.init_global_pool(
+        processes=5,
+        ray_remote_args={"num_cpus": 4},
+    )
+
+    assert first_pool is second_pool
+    assert events == [("init", 3, {"num_cpus": 2})]
+
+    pool_mod.clear_global_pool(close=True)
+    assert events == [
+        ("init", 3, {"num_cpus": 2}),
+        "close",
+        "join",
+    ]
+
+
+def test_init_global_pool_warns_when_existing_pool_size_differs(monkeypatch, caplog):
+    events = []
+
+    class FakePool:
+        def __init__(self, processes, ray_remote_args):
+            events.append(("init", processes, ray_remote_args))
+
+    pool_mod.clear_global_pool()
+    monkeypatch.setattr(pool_mod, "Pool", FakePool)
+
+    first_pool = pool_mod.init_global_pool(processes=4)
+    with caplog.at_level(logging.WARNING, logger="lance_ray.pool"):
+        second_pool = pool_mod.init_global_pool(processes=16)
+
+    assert first_pool is second_pool
+    assert "requested 16 workers will be ignored" in caplog.text
+
+    pool_mod.clear_global_pool()
+
+
+def test_get_or_create_pool_warns_when_global_pool_size_differs(caplog):
+    class FakePool:
+        processes = 4
+
+    pool_mod.set_global_pool(FakePool())
+    try:
+        with (
+            caplog.at_level(logging.WARNING, logger="lance_ray.pool"),
+            pool_mod.get_or_create_pool(processes=16, ray_remote_args=None) as pool,
+        ):
+            assert pool is pool_mod.get_global_pool()
+    finally:
+        pool_mod.clear_global_pool()
+
+    assert "global Ray Pool with 4 processes" in caplog.text
+    assert "requested 16 workers will be ignored" in caplog.text
+
+
+def test_set_global_pool_can_clear_without_closing():
+    events = []
+
+    class FakePool:
+        def close(self):
+            events.append("close")
+
+        def join(self):
+            events.append("join")
+
+    pool = FakePool()
+    pool_mod.set_global_pool(pool)
+    assert pool_mod.get_global_pool() is pool
+
+    pool_mod.set_global_pool(None)
+
+    assert pool_mod.get_global_pool() is None
+    assert events == []


### PR DESCRIPTION
## Summary

- add a process-wide Ray Pool registry with `init_global_pool`, `set_global_pool`, `get_global_pool`, and `clear_global_pool`
- make distributed vector search reuse the configured global Pool when present
- keep `create_index()` / `create_scalar_index()` behavior unchanged: index building still creates and closes its local Pool per operation
- keep current behavior when no global Pool exists by creating a local Pool and closing/joining it after the operation
- warn when a global Pool size is known and a later `vector_search()` requests a different worker count that will be ignored
- protect global Pool set/get/clear operations with a lock and document the intended serial reuse workflow
- document `init_global_pool()` usage, global Pool lifecycle, and the precedence of global Pool settings over per-call Pool creation options
- add tests for local index Pool cleanup, global Pool reuse in vector search, worker-count mismatch warnings, and global Pool lifecycle helpers

## Semantics

When a global Pool is configured, Lance-Ray uses it for `vector_search()` and does not close or join it after each operation. This avoids repeated Ray Pool startup cost across multiple vector search calls in the same process.

`init_global_pool()` creates and registers the shared Pool once. Later calls reuse the existing Pool until `clear_global_pool()` is called. Users can also register an externally managed Pool with `set_global_pool(pool)` and clear only Lance-Ray's reference with `clear_global_pool(close=False)`.

When the configured global Pool size is known and a later `vector_search()` call requests a different `num_workers`, Lance-Ray logs a warning because the global Pool's existing `processes` value controls actual parallelism.

The registry is locked for basic set/get/clear operations. The intended usage is still a single driver process that reuses the global Pool serially across operations; users should avoid mutating the global Pool while other threads are running Lance-Ray operations.

Index building, I/O, and compaction are intentionally left unchanged in this PR. They can be adapted to the same global Pool pattern in follow-up changes.

When no global Pool is configured, `vector_search()` creates a local Pool with the existing per-call `num_workers` / `ray_remote_args` behavior and closes/joins it in the operation scope.

## Validation

- `.venv/bin/ruff check`
- `python -m pytest tests/test_pool.py tests/test_vector_index_options.py tests/test_distributed_search.py`