### PR TITLE
feat: support setting external blob mode in fragment writes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,8 @@ clean:
 	find . -type d -name __pycache__ -exec rm -rf {} +
 	find . -type d -name .pytest_cache -exec rm -rf {} +
 	find . -type d -name .ruff_cache -exec rm -rf {} +
-	rm -f .coverage
+	rm -f .coverage .coverage.* coverage.xml
+	find . -type d -name htmlcov -exec rm -rf {} +
 
 .PHONY: test
 test: lock

--- a/docs/src/write.md
+++ b/docs/src/write.md
@@ -32,6 +32,8 @@ Write a Ray Dataset to Lance format.
 - `storage_options`: Optional storage configuration dictionary
 - `base_store_params`: Optional runtime storage options keyed by registered base path URI, used for BlobV2 references outside the dataset root
 - `initial_bases`: Optional Lance `DatasetBasePath` objects to register when creating a new dataset
+- `external_blob_mode`: Optional BlobV2 external URI handling mode. `"reference"` stores external references; `"ingest"` reads external bytes and writes them into Lance-managed storage
+- `allow_external_blob_outside_bases`: Optional boolean to allow BlobV2 external references outside registered non-dataset-root base paths when `external_blob_mode="reference"`
 - `ray_remote_args`: Optional kwargs for Ray remote tasks
 - `concurrency`: Optional maximum number of concurrent Ray tasks
 

--- a/lance_ray/datasink.py
+++ b/lance_ray/datasink.py
@@ -14,7 +14,7 @@ from ray.data import DataContext
 from ray.data._internal.util import _check_import
 from ray.data.datasource.datasink import Datasink
 
-from .fragment import write_fragment
+from .fragment import prepare_fragment_write_options, write_fragment
 from .utils import (
     get_namespace_kwargs,
     get_or_create_namespace,
@@ -233,6 +233,9 @@ class LanceDatasink(_BaseLanceDatasink):
 
     Args:
         uri : the base URI of the dataset.
+        table_id : List[str], optional
+            The table identifier as a list of strings.
+            Used together with namespace_impl and namespace_properties.
         schema : pyarrow.Schema, optional.
             The schema of the dataset.
         mode : str, optional
@@ -249,6 +252,22 @@ class LanceDatasink(_BaseLanceDatasink):
             for more details.
         storage_options : Dict[str, Any], optional
             The storage options for the writer. Default is None.
+        base_store_params : dict, optional
+            Runtime-only storage options keyed by registered base path URI.
+            Used for BlobV2 references that live outside the dataset root.
+        initial_bases : list, optional
+            Lance DatasetBasePath objects to register when creating a new dataset.
+        target_bases : list of str, optional
+            References to base paths where data should be written. Each string
+            is resolved by matching base name or base path URI from registered
+            bases.
+        external_blob_mode : {"reference", "ingest"}, default "reference"
+            How external blob URIs are handled on write. ``"reference"`` stores
+            external blob references, while ``"ingest"`` reads external bytes
+            and writes them into Lance-managed storage.
+        allow_external_blob_outside_bases : bool, default False
+            Whether external blob references outside registered bases are allowed.
+            Only applies when ``external_blob_mode="reference"``.
         namespace_impl : str, optional
             The namespace implementation type (e.g., "rest", "dir").
             Used together with namespace_properties and table_id for credentials
@@ -277,10 +296,20 @@ class LanceDatasink(_BaseLanceDatasink):
         base_store_params: Optional[dict[str, dict[str, Any]]] = None,
         initial_bases: Optional[list[Any]] = None,
         target_bases: Optional[list[str]] = None,
+        external_blob_mode: Literal["reference", "ingest"] = "reference",
+        allow_external_blob_outside_bases: bool = False,
         namespace_impl: Optional[str] = None,
         namespace_properties: Optional[dict[str, str]] = None,
         **kwargs: Any,
     ):
+        allow_external_blob_outside_bases = prepare_fragment_write_options(
+            target_bases=target_bases,
+            base_store_params=base_store_params,
+            external_blob_mode=external_blob_mode,
+            allow_external_blob_outside_bases=allow_external_blob_outside_bases,
+            stacklevel=2,
+        )
+
         super().__init__(
             uri,
             table_id,
@@ -307,6 +336,8 @@ class LanceDatasink(_BaseLanceDatasink):
         self.min_rows_per_file = min_rows_per_file
         self.max_rows_per_file = max_rows_per_file
         self.data_storage_version = data_storage_version
+        self.external_blob_mode = external_blob_mode
+        self.allow_external_blob_outside_bases = allow_external_blob_outside_bases
         # if mode is append, read_version is read from existing dataset.
         self.read_version: Optional[int] = None
 
@@ -339,8 +370,11 @@ class LanceDatasink(_BaseLanceDatasink):
             max_rows_per_file=self.max_rows_per_file,
             data_storage_version=self.data_storage_version,
             storage_options=self.storage_options,
+            base_store_params=self.base_store_params,
             initial_bases=self.initial_bases if self.mode == "create" else None,
             target_bases=self.target_bases,
+            external_blob_mode=self.external_blob_mode,
+            allow_external_blob_outside_bases=self.allow_external_blob_outside_bases,
             namespace_impl=self._namespace_impl,
             namespace_properties=self._namespace_properties,
             table_id=self.table_id,

--- a/lance_ray/fragment.py
+++ b/lance_ray/fragment.py
@@ -1,13 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 
+import inspect
 import pickle
 import warnings
-from collections.abc import Callable, Generator, Iterable
+from collections.abc import Callable, Generator, Iterable, Mapping
 from itertools import chain
 from typing import (
     TYPE_CHECKING,
     Any,
+    Literal,
     Optional,
     Union,
 )
@@ -43,8 +45,11 @@ def write_fragment(
     max_rows_per_group: int = 1024,  # Only useful for v1 writer.
     data_storage_version: Optional[str] = None,
     storage_options: Optional[dict[str, Any]] = None,
+    base_store_params: Optional[dict[str, dict[str, Any]]] = None,
     initial_bases: Optional[list[Any]] = None,
     target_bases: Optional[list[str]] = None,
+    external_blob_mode: Literal["reference", "ingest"] = "reference",
+    allow_external_blob_outside_bases: bool = False,
     namespace_impl: Optional[str] = None,
     namespace_properties: Optional[dict[str, str]] = None,
     table_id: Optional[list[str]] = None,
@@ -104,6 +109,14 @@ def write_fragment(
     else:
         initial_bases_kwargs = {}
 
+    optional_write_kwargs = _get_optional_write_fragments_kwargs(
+        write_fragments,
+        target_bases=target_bases,
+        base_store_params=base_store_params,
+        external_blob_mode=external_blob_mode,
+        allow_external_blob_outside_bases=allow_external_blob_outside_bases,
+    )
+
     fragments = call_with_retry(
         lambda: write_fragments(
             reader,
@@ -114,13 +127,125 @@ def write_fragment(
             max_bytes_per_file=max_bytes_per_file,
             data_storage_version=data_storage_version,
             storage_options=storage_options,
-            target_bases=target_bases,
             **write_kwargs,
             **initial_bases_kwargs,
+            **optional_write_kwargs,
         ),
         **retry_params,
     )
     return [(fragment, schema) for fragment in fragments]
+
+
+def _get_optional_write_fragments_kwargs(
+    write_fragments: Callable[..., Any],
+    *,
+    target_bases: Optional[list[str]],
+    base_store_params: Optional[dict[str, dict[str, Any]]],
+    external_blob_mode: Literal["reference", "ingest"],
+    allow_external_blob_outside_bases: bool,
+) -> dict[str, Any]:
+    """Return kwargs supported by the installed pylance fragment writer."""
+    params, allow_external_blob_outside_bases = _prepare_write_fragments_options(
+        write_fragments,
+        target_bases=target_bases,
+        base_store_params=base_store_params,
+        external_blob_mode=external_blob_mode,
+        allow_external_blob_outside_bases=allow_external_blob_outside_bases,
+        stacklevel=4,
+    )
+    kwargs: dict[str, Any] = {}
+
+    if "target_bases" in params and target_bases is not None:
+        kwargs["target_bases"] = target_bases
+
+    if "base_store_params" in params and base_store_params is not None:
+        kwargs["base_store_params"] = base_store_params
+
+    if "external_blob_mode" in params:
+        kwargs["external_blob_mode"] = external_blob_mode
+
+    if "allow_external_blob_outside_bases" in params:
+        kwargs["allow_external_blob_outside_bases"] = allow_external_blob_outside_bases
+
+    return kwargs
+
+
+def prepare_fragment_write_options(
+    *,
+    target_bases: Optional[list[str]] = None,
+    base_store_params: Optional[dict[str, dict[str, Any]]] = None,
+    external_blob_mode: Literal["reference", "ingest"],
+    allow_external_blob_outside_bases: bool,
+    stacklevel: int = 2,
+) -> bool:
+    """Validate fragment write options and return normalized allow flag."""
+    if (
+        target_bases is None
+        and base_store_params is None
+        and external_blob_mode == "reference"
+        and not allow_external_blob_outside_bases
+    ):
+        return allow_external_blob_outside_bases
+
+    from lance.fragment import write_fragments
+
+    _, allow_external_blob_outside_bases = _prepare_write_fragments_options(
+        write_fragments,
+        target_bases=target_bases,
+        base_store_params=base_store_params,
+        external_blob_mode=external_blob_mode,
+        allow_external_blob_outside_bases=allow_external_blob_outside_bases,
+        stacklevel=stacklevel + 2,
+    )
+    return allow_external_blob_outside_bases
+
+
+def _prepare_write_fragments_options(
+    write_fragments: Callable[..., Any],
+    *,
+    target_bases: Optional[list[str]],
+    base_store_params: Optional[dict[str, dict[str, Any]]],
+    external_blob_mode: Literal["reference", "ingest"],
+    allow_external_blob_outside_bases: bool,
+    stacklevel: int,
+) -> tuple[Mapping[str, inspect.Parameter], bool]:
+    params = inspect.signature(write_fragments).parameters
+
+    if target_bases is not None and "target_bases" not in params:
+        raise _unsupported_write_fragments_option_error("target_bases")
+
+    if base_store_params is not None and "base_store_params" not in params:
+        raise _unsupported_write_fragments_option_error("base_store_params")
+
+    if "external_blob_mode" not in params and external_blob_mode != "reference":
+        raise _unsupported_write_fragments_option_error("external_blob_mode")
+
+    if external_blob_mode == "reference":
+        if (
+            "allow_external_blob_outside_bases" not in params
+            and allow_external_blob_outside_bases
+        ):
+            raise _unsupported_write_fragments_option_error(
+                "allow_external_blob_outside_bases"
+            )
+    elif external_blob_mode == "ingest" and allow_external_blob_outside_bases:
+        warnings.warn(
+            "'allow_external_blob_outside_bases' only applies when "
+            "'external_blob_mode=\"reference\"' and will be ignored when "
+            "'external_blob_mode=\"ingest\"'.",
+            stacklevel=stacklevel,
+        )
+        allow_external_blob_outside_bases = False
+
+    return params, allow_external_blob_outside_bases
+
+
+def _unsupported_write_fragments_option_error(option: str) -> RuntimeError:
+    return RuntimeError(
+        f"The installed pylance does not support '{option}' in "
+        "lance.fragment.write_fragments. Install a pylance build with the "
+        "required fragment write option."
+    )
 
 
 class LanceFragmentWriter:
@@ -166,6 +291,12 @@ class LanceFragmentWriter:
         References to base paths where data should be written. Each string
         is resolved by matching base name or base path URI from registered
         bases.
+    base_store_params : dict, optional
+        Runtime-only storage options keyed by registered base path URI.
+    external_blob_mode : {"reference", "ingest"}, default "reference"
+        How external blob URIs are handled on write.
+    allow_external_blob_outside_bases : bool, default False
+        Whether external blob references outside registered bases are allowed.
     namespace_impl : str, optional
         The namespace implementation type (e.g., "rest", "dir").
         Used together with namespace_properties and table_id for credentials
@@ -196,8 +327,11 @@ class LanceFragmentWriter:
         data_storage_version: Optional[str] = None,
         use_legacy_format: Optional[bool] = False,
         storage_options: Optional[dict[str, Any]] = None,
+        base_store_params: Optional[dict[str, dict[str, Any]]] = None,
         initial_bases: Optional[list[Any]] = None,
         target_bases: Optional[list[str]] = None,
+        external_blob_mode: Literal["reference", "ingest"] = "reference",
+        allow_external_blob_outside_bases: bool = False,
         namespace_impl: Optional[str] = None,
         namespace_properties: Optional[dict[str, str]] = None,
         table_id: Optional[list[str]] = None,
@@ -213,6 +347,14 @@ class LanceFragmentWriter:
 
             data_storage_version = "legacy" if use_legacy_format else "stable"
 
+        allow_external_blob_outside_bases = prepare_fragment_write_options(
+            target_bases=target_bases,
+            base_store_params=base_store_params,
+            external_blob_mode=external_blob_mode,
+            allow_external_blob_outside_bases=allow_external_blob_outside_bases,
+            stacklevel=2,
+        )
+
         self.uri = uri
         self.schema = schema
         self.transform = transform if transform is not None else lambda x: x
@@ -222,8 +364,11 @@ class LanceFragmentWriter:
         self.max_bytes_per_file = max_bytes_per_file
         self.data_storage_version = data_storage_version
         self.storage_options = storage_options
+        self.base_store_params = base_store_params
         self.initial_bases = normalize_initial_bases(initial_bases)
         self.target_bases = target_bases
+        self.external_blob_mode = external_blob_mode
+        self.allow_external_blob_outside_bases = allow_external_blob_outside_bases
         self.namespace_impl = namespace_impl
         self.namespace_properties = namespace_properties
         self.table_id = table_id
@@ -262,8 +407,11 @@ class LanceFragmentWriter:
             max_bytes_per_file=self.max_bytes_per_file,
             data_storage_version=self.data_storage_version,
             storage_options=self.storage_options,
+            base_store_params=self.base_store_params,
             initial_bases=self.initial_bases,
             target_bases=self.target_bases,
+            external_blob_mode=self.external_blob_mode,
+            allow_external_blob_outside_bases=self.allow_external_blob_outside_bases,
             namespace_impl=self.namespace_impl,
             namespace_properties=self.namespace_properties,
             table_id=self.table_id,

--- a/lance_ray/io.py
+++ b/lance_ray/io.py
@@ -16,6 +16,7 @@ from ray.util.multiprocessing import Pool
 
 from .datasink import LanceDatasink
 from .datasource import LanceDatasource
+from .fragment import prepare_fragment_write_options
 from .utils import (
     get_namespace_kwargs,
     has_namespace_params,
@@ -156,6 +157,8 @@ def write_lance(
     base_store_params: Optional[dict[str, dict[str, Any]]] = None,
     initial_bases: Optional[list[Any]] = None,
     target_bases: Optional[list[str]] = None,
+    external_blob_mode: Literal["reference", "ingest"] = "reference",
+    allow_external_blob_outside_bases: bool = False,
     namespace_impl: Optional[str] = None,
     namespace_properties: Optional[dict[str, str]] = None,
     ray_remote_args: Optional[dict[str, Any]] = None,
@@ -216,6 +219,12 @@ def write_lance(
             from registered bases.  In CREATE mode, references must match
             bases in ``initial_bases``.  In APPEND/OVERWRITE modes,
             references must match bases in the existing manifest.
+        external_blob_mode: How external blob URIs are handled on write.
+            ``"reference"`` stores external blob references, while ``"ingest"``
+            reads external bytes and writes them into Lance-managed storage.
+        allow_external_blob_outside_bases: Allow external blob references that
+            do not map to a registered non-dataset-root base path. Only applies
+            when ``external_blob_mode="reference"``.
         namespace_impl: The namespace implementation type (e.g., "rest", "dir").
             Used together with namespace_properties and table_id.
         namespace_properties: Properties for connecting to the namespace.
@@ -227,6 +236,13 @@ def write_lance(
     _validate_write_args(uri, namespace_impl, table_id, mode)
     if initial_bases and mode != "create":
         raise ValueError("'initial_bases' can only be used with mode='create'")
+    allow_external_blob_outside_bases = prepare_fragment_write_options(
+        target_bases=target_bases,
+        base_store_params=base_store_params,
+        external_blob_mode=external_blob_mode,
+        allow_external_blob_outside_bases=allow_external_blob_outside_bases,
+        stacklevel=2,
+    )
     initial_bases = normalize_initial_bases(initial_bases)
 
     # Fast path: non-streaming write using the Datasink API.
@@ -243,6 +259,8 @@ def write_lance(
             base_store_params=base_store_params,
             initial_bases=initial_bases,
             target_bases=target_bases,
+            external_blob_mode=external_blob_mode,
+            allow_external_blob_outside_bases=allow_external_blob_outside_bases,
             namespace_impl=namespace_impl,
             namespace_properties=namespace_properties,
         )
@@ -330,8 +348,11 @@ def write_lance(
             max_rows_per_group=min_rows_per_file,  # keep naming aligned with v1 semantics
             data_storage_version=data_storage_version,
             storage_options=storage_options,
+            base_store_params=base_store_params,
             initial_bases=fragment_initial_bases,
             target_bases=target_bases,
+            external_blob_mode=external_blob_mode,
+            allow_external_blob_outside_bases=allow_external_blob_outside_bases,
             namespace_impl=None,
             namespace_properties=None,
             table_id=None,

--- a/lance_ray/pool.py
+++ b/lance_ray/pool.py
@@ -46,7 +46,9 @@ def set_global_pool(pool: Any | None) -> None:
     global _GLOBAL_POOL, _GLOBAL_POOL_PROCESSES
     with _GLOBAL_POOL_LOCK:
         _GLOBAL_POOL = pool
-        _GLOBAL_POOL_PROCESSES = _read_pool_processes(pool) if pool is not None else None
+        _GLOBAL_POOL_PROCESSES = (
+            _read_pool_processes(pool) if pool is not None else None
+        )
 
 
 def get_global_pool() -> Any | None:

--- a/lance_ray/search.py
+++ b/lance_ray/search.py
@@ -484,7 +484,9 @@ def _candidate_k(nearest: dict[str, Any], oversample_factor: float) -> tuple[int
     try:
         global_k = int(nearest["k"])
     except KeyError as exc:
-        raise ValueError("nearest must include 'k' for distributed vector search") from exc
+        raise ValueError(
+            "nearest must include 'k' for distributed vector search"
+        ) from exc
 
     if global_k <= 0:
         raise ValueError(f"nearest['k'] must be positive, got {global_k}")
@@ -618,7 +620,9 @@ def vector_search(
         worker_table_id = table_id
         dataset = LanceDataset(
             dataset_uri,
-            **_dataset_load_kwargs(merged_storage_options, namespace_kwargs, block_size),
+            **_dataset_load_kwargs(
+                merged_storage_options, namespace_kwargs, block_size
+            ),
         )
     else:
         dataset = uri
@@ -686,7 +690,9 @@ def vector_search(
         ) as pool:
             results = pool.map_async(run_plan, plans, chunksize=1).get()
     except Exception as exc:  # pragma: no cover - exercised via integration tests
-        raise RuntimeError(f"Failed to complete distributed vector search: {exc}") from exc
+        raise RuntimeError(
+            f"Failed to complete distributed vector search: {exc}"
+        ) from exc
 
     if analyze_plan:
         return _format_analyze_plan_results(results)

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -1,0 +1,19 @@
+"""Shared helpers for tests."""
+
+import inspect
+
+
+def missing_fragment_write_options(*options: str) -> tuple[str, ...]:
+    from lance.fragment import write_fragments
+
+    params = inspect.signature(write_fragments).parameters
+    return tuple(sorted(set(options).difference(params)))
+
+
+def fragment_write_options_skip_reason(*options: str) -> str:
+    missing = missing_fragment_write_options(*options)
+    return (
+        "Installed pylance does not expose the missing fragment write "
+        "option(s) on lance.fragment.write_fragments: "
+        f"{', '.join(missing)}"
+    )

--- a/tests/test_basic_read_write.py
+++ b/tests/test_basic_read_write.py
@@ -13,6 +13,10 @@ import ray
 from ray.data import Dataset
 
 import pandas as pd
+from _utils import (
+    fragment_write_options_skip_reason,
+    missing_fragment_write_options,
+)
 
 sys.path.insert(
     0, str(Path(__file__).resolve().parents[1] / "lance" / "python" / "python")
@@ -438,6 +442,10 @@ class TestMultiBaseLayout:
             f"Base path IDs must be unique, got: {base_paths}"
         )
 
+    @pytest.mark.skipif(
+        bool(missing_fragment_write_options("base_store_params")),
+        reason=fragment_write_options_skip_reason("base_store_params"),
+    )
     def test_multiple_initial_bases_with_blob_v2(self, temp_dir):
         """Multi-base write/read with blob v2 columns and no explicit IDs.
 

--- a/tests/test_blob_v2.py
+++ b/tests/test_blob_v2.py
@@ -24,6 +24,11 @@ import pytest
 import ray
 from ray.exceptions import RayTaskError
 
+from _utils import (
+    fragment_write_options_skip_reason,
+    missing_fragment_write_options,
+)
+
 # Prefer the local Lance Python package when running in a monorepo layout
 sys.path.insert(
     0, str(Path(__file__).resolve().parents[1] / "lance" / "python" / "python")
@@ -99,6 +104,36 @@ def _initial_bases(external_base: Path) -> list[DatasetBasePath]:
             id=1,
         )
     ]
+
+
+def _build_external_only_blob_v2_table(
+    tmp_path: Path,
+    filename: str,
+    payload: bytes = b"hello",
+) -> tuple[pa.Table, bytes, Path]:
+    blob_path = tmp_path / filename
+    blob_path.write_bytes(payload)
+
+    schema = pa.schema(
+        [
+            pa.field("id", pa.int64()),
+            blob_field("blob"),
+        ]
+    )
+
+    sig = inspect.signature(Blob.from_uri)
+    blob_kwargs: dict[str, object] = {}
+    if "position" in sig.parameters and "size" in sig.parameters:
+        blob_kwargs = {"position": 0, "size": len(payload)}
+
+    table = pa.table(
+        {
+            "id": [1],
+            "blob": blob_array([Blob.from_uri(blob_path.as_uri(), **blob_kwargs)]),
+        },
+        schema=schema,
+    )
+    return table, payload, blob_path
 
 
 def test_blob_v2_roundtrip_with_projection_and_filter(tmp_path: Path) -> None:
@@ -196,9 +231,130 @@ def test_blob_v2_take_blobs_ids_and_indices(tmp_path: Path) -> None:
     assert values_by_ids == expected
 
 
+@pytest.mark.skipif(
+    bool(
+        missing_fragment_write_options(
+            "external_blob_mode",
+            "allow_external_blob_outside_bases",
+        )
+    ),
+    reason=fragment_write_options_skip_reason(
+        "external_blob_mode",
+        "allow_external_blob_outside_bases",
+    ),
+)
+def test_blob_v2_reference_outside_bases_write_lance(tmp_path: Path) -> None:
+    """write_lance can opt into absolute external blob references."""
+    table, payload, _ = _build_external_only_blob_v2_table(
+        tmp_path,
+        "external_reference.bin",
+    )
+    path = tmp_path / "blob_v2_external_reference.lance"
+
+    lr.write_lance(
+        ray.data.from_arrow(table),
+        str(path),
+        schema=table.schema,
+        data_storage_version="2.2",
+        external_blob_mode="reference",
+        allow_external_blob_outside_bases=True,
+    )
+
+    df = lr.read_lance(str(path)).to_pandas().sort_values("id").reset_index(drop=True)
+    assert df["blob"].tolist() == [payload]
+
+
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.skipif(
+    bool(
+        missing_fragment_write_options(
+            "external_blob_mode",
+            "allow_external_blob_outside_bases",
+        )
+    ),
+    reason=fragment_write_options_skip_reason(
+        "external_blob_mode",
+        "allow_external_blob_outside_bases",
+    ),
+)
+def test_blob_v2_external_blob_ingest_write_lance(
+    tmp_path: Path,
+    stream: bool,
+) -> None:
+    """write_lance can ingest external blobs into Lance-managed storage."""
+    table, payload, blob_path = _build_external_only_blob_v2_table(
+        tmp_path,
+        f"external_ingest_{stream}.bin",
+    )
+    path = tmp_path / f"blob_v2_external_ingest_{stream}.lance"
+
+    stream_kwargs = {"stream": stream}
+    if stream:
+        stream_kwargs["batch_size"] = 1
+
+    lr.write_lance(
+        ray.data.from_arrow(table),
+        str(path),
+        schema=table.schema,
+        data_storage_version="2.2",
+        external_blob_mode="ingest",
+        **stream_kwargs,
+    )
+
+    blob_path.unlink()
+
+    df = lr.read_lance(str(path)).to_pandas().sort_values("id").reset_index(drop=True)
+    assert df["blob"].tolist() == [payload]
+
+
+@pytest.mark.skipif(
+    bool(
+        missing_fragment_write_options(
+            "external_blob_mode",
+            "allow_external_blob_outside_bases",
+        )
+    ),
+    reason=fragment_write_options_skip_reason(
+        "external_blob_mode",
+        "allow_external_blob_outside_bases",
+    ),
+)
+def test_blob_v2_reference_outside_bases_manual_fragment_writer(
+    tmp_path: Path,
+) -> None:
+    """Manual fragment writes can opt into base-outside external references."""
+    table, payload, _ = _build_external_only_blob_v2_table(
+        tmp_path,
+        "manual_external_reference.bin",
+    )
+    path = tmp_path / "blob_v2_manual_external_reference.lance"
+
+    (
+        ray.data.from_arrow(table)
+        .map_batches(
+            LanceFragmentWriter(
+                str(path),
+                schema=table.schema,
+                data_storage_version="2.2",
+                external_blob_mode="reference",
+                allow_external_blob_outside_bases=True,
+            ),
+            batch_size=1,
+            batch_format="pyarrow",
+        )
+        .write_datasink(LanceFragmentCommitter(str(path)))
+    )
+
+    df = lr.read_lance(str(path)).to_pandas().sort_values("id").reset_index(drop=True)
+    assert df["blob"].tolist() == [payload]
+
+
+@pytest.mark.skipif(
+    bool(missing_fragment_write_options("base_store_params")),
+    reason=fragment_write_options_skip_reason("base_store_params"),
+)
 def test_blob_v2_reference_multi_base_all_lance_ray_paths(tmp_path: Path) -> None:
     """Read/write BlobV2 references through all Lance-Ray base-store paths."""
-
     table, inline_payload, external_payload, external_base, _ = _build_blob_v2_table(
         tmp_path
     )
@@ -344,6 +500,10 @@ def _multi_initial_bases(base_a: Path, base_b: Path) -> list[DatasetBasePath]:
     ]
 
 
+@pytest.mark.skipif(
+    bool(missing_fragment_write_options("base_store_params", "target_bases")),
+    reason=fragment_write_options_skip_reason("base_store_params", "target_bases"),
+)
 def test_blob_v2_create_with_initial_bases_and_target_bases(tmp_path: Path) -> None:
     """Create can route initial fragment data to a named base path."""
     table, inline_payload, packed_payload, base_a, base_b = (
@@ -389,6 +549,10 @@ def test_blob_v2_create_with_initial_bases_and_target_bases(tmp_path: Path) -> N
     assert df["blob"].tolist() == [inline_payload, packed_payload]
 
 
+@pytest.mark.skipif(
+    bool(missing_fragment_write_options("base_store_params", "target_bases")),
+    reason=fragment_write_options_skip_reason("base_store_params", "target_bases"),
+)
 def test_blob_v2_target_bases_multi_base_routing(tmp_path: Path) -> None:
     """target_bases can route data across multiple base paths.
 
@@ -499,6 +663,10 @@ def test_blob_v2_target_bases_multi_base_routing(tmp_path: Path) -> None:
     ]
 
 
+@pytest.mark.skipif(
+    bool(missing_fragment_write_options("base_store_params", "target_bases")),
+    reason=fragment_write_options_skip_reason("base_store_params", "target_bases"),
+)
 def test_blob_v2_append_with_target_bases_stream(tmp_path: Path) -> None:
     """Streaming append with target_bases should route data to the named base.
 

--- a/tests/test_fragment.py
+++ b/tests/test_fragment.py
@@ -1,13 +1,184 @@
 """Test cases for lance_ray.fragment module."""
 
+import warnings
 from pathlib import Path
 
 import lance
+import lance_ray.io as lr
 import pyarrow as pa
 import pytest
 import ray
-from lance_ray.datasink import LanceFragmentCommitter
+from lance_ray.datasink import LanceDatasink, LanceFragmentCommitter
 from lance_ray.fragment import LanceFragmentWriter
+
+
+def _legacy_write_fragments(reader, uri, *, schema=None):
+    return []
+
+
+def _write_fragments_with_external_blob_options(
+    reader,
+    uri,
+    *,
+    external_blob_mode="reference",
+    allow_external_blob_outside_bases=False,
+):
+    return []
+
+
+def test_fragment_writer_external_blob_options_fail_fast(monkeypatch, tmp_path: Path):
+    import lance.fragment as lance_fragment
+
+    monkeypatch.setattr(
+        lance_fragment,
+        "write_fragments",
+        _legacy_write_fragments,
+    )
+
+    with pytest.raises(RuntimeError, match="external_blob_mode.*write_fragments"):
+        LanceFragmentWriter(
+            str(tmp_path),
+            data_storage_version="stable",
+            external_blob_mode="ingest",
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match="allow_external_blob_outside_bases.*write_fragments",
+    ):
+        LanceFragmentWriter(
+            str(tmp_path),
+            data_storage_version="stable",
+            allow_external_blob_outside_bases=True,
+        )
+
+
+def test_datasink_external_blob_options_fail_fast(monkeypatch, tmp_path: Path):
+    import lance.fragment as lance_fragment
+
+    monkeypatch.setattr(
+        lance_fragment,
+        "write_fragments",
+        _legacy_write_fragments,
+    )
+
+    with pytest.raises(RuntimeError, match="external_blob_mode.*write_fragments"):
+        LanceDatasink(str(tmp_path), external_blob_mode="ingest")
+
+
+def test_write_lance_external_blob_options_fail_fast(monkeypatch, tmp_path: Path):
+    import lance.fragment as lance_fragment
+
+    monkeypatch.setattr(
+        lance_fragment,
+        "write_fragments",
+        _legacy_write_fragments,
+    )
+
+    with pytest.raises(RuntimeError, match="external_blob_mode.*write_fragments"):
+        lr.write_lance(object(), str(tmp_path), external_blob_mode="ingest")
+
+
+def test_base_store_params_fail_fast_when_fragment_api_unsupported(
+    monkeypatch,
+    tmp_path: Path,
+):
+    import lance.fragment as lance_fragment
+
+    monkeypatch.setattr(
+        lance_fragment,
+        "write_fragments",
+        _legacy_write_fragments,
+    )
+    base_store_params = {tmp_path.as_uri(): {}}
+
+    with pytest.raises(RuntimeError, match="base_store_params.*write_fragments"):
+        LanceFragmentWriter(
+            str(tmp_path),
+            data_storage_version="stable",
+            base_store_params=base_store_params,
+        )
+
+    with pytest.raises(RuntimeError, match="base_store_params.*write_fragments"):
+        LanceDatasink(str(tmp_path), base_store_params=base_store_params)
+
+    with pytest.raises(RuntimeError, match="base_store_params.*write_fragments"):
+        lr.write_lance(object(), str(tmp_path), base_store_params=base_store_params)
+
+
+def test_target_bases_fail_fast_when_fragment_api_unsupported(
+    monkeypatch,
+    tmp_path: Path,
+):
+    import lance.fragment as lance_fragment
+
+    monkeypatch.setattr(
+        lance_fragment,
+        "write_fragments",
+        _legacy_write_fragments,
+    )
+    target_bases = ["archive"]
+
+    with pytest.raises(RuntimeError, match="target_bases.*write_fragments"):
+        LanceFragmentWriter(
+            str(tmp_path),
+            data_storage_version="stable",
+            target_bases=target_bases,
+        )
+
+    with pytest.raises(RuntimeError, match="target_bases.*write_fragments"):
+        LanceDatasink(str(tmp_path), target_bases=target_bases)
+
+    with pytest.raises(RuntimeError, match="target_bases.*write_fragments"):
+        lr.write_lance(object(), str(tmp_path), target_bases=target_bases)
+
+
+def test_allow_external_blob_outside_bases_ignored_for_ingest(
+    monkeypatch,
+    tmp_path: Path,
+):
+    import lance.fragment as lance_fragment
+
+    monkeypatch.setattr(
+        lance_fragment,
+        "write_fragments",
+        _write_fragments_with_external_blob_options,
+    )
+
+    with pytest.warns(UserWarning, match="will be ignored"):
+        writer = LanceFragmentWriter(
+            str(tmp_path),
+            data_storage_version="stable",
+            external_blob_mode="ingest",
+            allow_external_blob_outside_bases=True,
+        )
+
+    assert writer.allow_external_blob_outside_bases is False
+
+
+def test_unsupported_ingest_with_allow_external_blob_outside_bases_does_not_warn(
+    monkeypatch,
+    tmp_path: Path,
+):
+    import lance.fragment as lance_fragment
+
+    monkeypatch.setattr(
+        lance_fragment,
+        "write_fragments",
+        _legacy_write_fragments,
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with pytest.raises(RuntimeError, match="external_blob_mode.*write_fragments"):
+            LanceFragmentWriter(
+                str(tmp_path),
+                data_storage_version="stable",
+                external_blob_mode="ingest",
+                allow_external_blob_outside_bases=True,
+            )
+
+    assert not any("will be ignored" in str(warning.message) for warning in caught)
 
 
 class TestLanceFragmentWriterCommitter:


### PR DESCRIPTION
The `lance.write_dataset()` API already supports controlling BlobV2 external URI handling via the `external_blob_mode` and `allow_external_blob_outside_bases` parameters. Local Lance builds have also added these options to the fragment write API. However, lance-ray did not expose or forward these options through its distributed write paths (`write_lance`, `LanceDatasink`, `LanceFragmentWriter`, `write_fragment`), making it impossible to ingest external BlobV2 data or explicitly allow external references outside registered bases when writing via Ray.

To address this, this PR introduces the following changes:

- Add `external_blob_mode` and `allow_external_blob_outside_bases` parameters to `write_lance`, `LanceDatasink`, `LanceFragmentWriter`, and `write_fragment`.
- Forward supported external blob options to `lance.fragment.write_fragments` in both datasink and streaming write paths.
- Forward `base_store_params` through the fragment write path so BlobV2 base storage options are preserved during distributed writes.
- Add driver-side compatibility checks so unsupported pylance versions fail fast before Ray worker execution.
- Warn and normalize `allow_external_blob_outside_bases=True` when used with `external_blob_mode="ingest"`, since that flag only applies to reference mode.
- Document the new write options in `docs/src/write.md`.
- Add BlobV2 tests covering reference mode, ingest mode, streaming writes, non-streaming writes, and manual `LanceFragmentWriter` usage.

__Compatibility Notes:__

- If the installed pylance build does not expose these options on `lance.fragment.write_fragments`, lance-ray preserves the existing default behavior: `external_blob_mode="reference"` and `allow_external_blob_outside_bases=False` are not forwarded and continue to work with older pylance versions.
- If users explicitly opt into new fragment external blob behavior, such as `external_blob_mode="ingest"` or `allow_external_blob_outside_bases=True`, lance-ray performs a driver-side fail-fast check and raises a clear `RuntimeError` before Ray worker execution.
- If `allow_external_blob_outside_bases=True` is used together with `external_blob_mode="ingest"`, lance-ray emits a warning and normalizes the flag to `False`, since the option only applies to reference mode.