### PR TITLE
perf: reuse pickled Lance dataset for vector search

### DIFF
--- a/lance_ray/search.py
+++ b/lance_ray/search.py
@@ -3,6 +3,8 @@
 
 import logging
 import math
+import pickle
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
 
 import pyarrow as pa
@@ -230,29 +232,21 @@ def _pack_search_plan_units(
     return plans
 
 
+@lru_cache(maxsize=16)
+def _load_pickled_dataset(pickled_dataset: bytes) -> LanceDataset:
+    return pickle.loads(pickled_dataset)
+
+
 def _execute_vector_search_plan(
     plan: _SearchPlan,
     *,
-    dataset_uri: str,
-    dataset_version: int,
-    storage_options: Optional[dict[str, Any]],
-    block_size: Optional[int],
-    namespace_impl: Optional[str],
-    namespace_properties: Optional[dict[str, str]],
-    table_id: Optional[list[str]],
+    pickled_dataset: bytes,
     base_scanner_options: dict[str, Any],
     nearest: dict[str, Any],
     candidate_k: int,
     analyze_plan: bool,
 ) -> pa.Table | _SearchPlanAnalysis:
-    namespace_kwargs = get_namespace_kwargs(
-        namespace_impl, namespace_properties, table_id
-    )
-    dataset = LanceDataset(
-        dataset_uri,
-        version=dataset_version,
-        **_dataset_load_kwargs(storage_options, namespace_kwargs, block_size),
-    )
+    dataset = _load_pickled_dataset(pickled_dataset)
 
     if not plan.index_segments:
         return _execute_flat_fallback_vector_search_plan(
@@ -613,22 +607,14 @@ def vector_search(
         namespace_kwargs = get_namespace_kwargs(
             namespace_impl, namespace_properties, table_id
         )
-        worker_namespace_impl = namespace_impl
-        worker_namespace_properties = namespace_properties
-        worker_table_id = table_id
         dataset = LanceDataset(
             dataset_uri,
             **_dataset_load_kwargs(merged_storage_options, namespace_kwargs, block_size),
         )
     else:
         dataset = uri
-        dataset_uri = dataset.uri
         if not merged_storage_options:
             merged_storage_options.update(_get_dataset_storage_options(dataset))
-        namespace_kwargs = {}
-        worker_namespace_impl = None
-        worker_namespace_properties = None
-        worker_table_id = None
 
     try:
         dataset.schema.field(column)
@@ -638,7 +624,6 @@ def vector_search(
             f"Column '{column}' not found. Available: {available_columns}"
         ) from exc
 
-    dataset_version = dataset.version
     fragments = dataset.get_fragments()
     if not fragments:
         return pa.table({})
@@ -663,16 +648,12 @@ def vector_search(
     if not plans:
         return pa.table({})
 
-    def run_plan(plan: _SearchPlan) -> pa.Table:
+    pickled_dataset = pickle.dumps(dataset)
+
+    def run_plan(plan: _SearchPlan) -> pa.Table | _SearchPlanAnalysis:
         return _execute_vector_search_plan(
             plan,
-            dataset_uri=dataset_uri,
-            dataset_version=dataset_version,
-            storage_options=merged_storage_options,
-            block_size=block_size,
-            namespace_impl=worker_namespace_impl,
-            namespace_properties=worker_namespace_properties,
-            table_id=worker_table_id,
+            pickled_dataset=pickled_dataset,
             base_scanner_options=base_scanner_options,
             nearest=nearest,
             candidate_k=candidate_k,

--- a/tests/test_distributed_search.py
+++ b/tests/test_distributed_search.py
@@ -37,6 +37,18 @@ def _index_with_segments(*segments):
     )
 
 
+def _mock_pickled_dataset(monkeypatch, dataset):
+    search_mod._load_pickled_dataset.cache_clear()
+    pickled_dataset = f"pickled-dataset-{id(dataset)}".encode()
+
+    def fake_loads(value):
+        assert value == pickled_dataset
+        return dataset
+
+    monkeypatch.setattr(search_mod.pickle, "loads", fake_loads)
+    return pickled_dataset
+
+
 def test_select_vector_index_raises_for_missing_explicit_index_name(monkeypatch):
     dataset = object()
     index = _index_with_segments(("S1", [1, 2]))
@@ -172,17 +184,9 @@ def test_execute_indexed_vector_search_plan_does_not_pass_fragments(monkeypatch)
                 to_table=lambda: pa.table({"id": [1], "_distance": [0.1]})
             )
 
-    monkeypatch.setattr("lance_ray.search.LanceDataset", FakeDataset)
-
     result = _execute_vector_search_plan(
         _SearchPlan(fragment_ids=[1, 2], index_segments=["S1"]),
-        dataset_uri="dataset",
-        dataset_version=1,
-        storage_options=None,
-        block_size=None,
-        namespace_impl=None,
-        namespace_properties=None,
-        table_id=None,
+        pickled_dataset=_mock_pickled_dataset(monkeypatch, FakeDataset()),
         base_scanner_options={"fast_search": False},
         nearest={"column": "vector", "q": [0.0, 0.0], "k": 1},
         candidate_k=1,
@@ -215,17 +219,9 @@ def test_execute_fallback_vector_search_plan_computes_local_top_k(monkeypatch):
                 to_table=lambda: pa.table({"id": [1, 2, 3], "vector": vectors})
             )
 
-    monkeypatch.setattr("lance_ray.search.LanceDataset", FakeDataset)
-
     result = _execute_vector_search_plan(
         _SearchPlan(fragment_ids=[7], index_segments=[]),
-        dataset_uri="dataset",
-        dataset_version=1,
-        storage_options=None,
-        block_size=None,
-        namespace_impl=None,
-        namespace_properties=None,
-        table_id=None,
+        pickled_dataset=_mock_pickled_dataset(monkeypatch, FakeDataset()),
         base_scanner_options={"columns": ["id", "_distance"], "fast_search": False},
         nearest={"column": "vector", "q": [0.0, 0.0], "k": 2},
         candidate_k=2,
@@ -261,17 +257,9 @@ def test_execute_indexed_vector_search_plan_can_analyze_plan(monkeypatch):
             scanner_options.update(kwargs)
             return FakeScanner()
 
-    monkeypatch.setattr("lance_ray.search.LanceDataset", FakeDataset)
-
     result = _execute_vector_search_plan(
         _SearchPlan(fragment_ids=[1], index_segments=["S1"]),
-        dataset_uri="dataset",
-        dataset_version=1,
-        storage_options=None,
-        block_size=None,
-        namespace_impl=None,
-        namespace_properties=None,
-        table_id=None,
+        pickled_dataset=_mock_pickled_dataset(monkeypatch, FakeDataset()),
         base_scanner_options={"fast_search": False},
         nearest={"column": "vector", "q": [0.0, 0.0], "k": 1},
         candidate_k=1,
@@ -308,17 +296,9 @@ def test_execute_fallback_vector_search_plan_can_analyze_plan(monkeypatch):
             scanner_options.update(kwargs)
             return FakeScanner()
 
-    monkeypatch.setattr("lance_ray.search.LanceDataset", FakeDataset)
-
     result = _execute_vector_search_plan(
         _SearchPlan(fragment_ids=[7], index_segments=[]),
-        dataset_uri="dataset",
-        dataset_version=1,
-        storage_options=None,
-        block_size=None,
-        namespace_impl=None,
-        namespace_properties=None,
-        table_id=None,
+        pickled_dataset=_mock_pickled_dataset(monkeypatch, FakeDataset()),
         base_scanner_options={"columns": ["id", "_distance"], "fast_search": False},
         nearest={"column": "vector", "q": [0.0, 0.0], "k": 2},
         candidate_k=2,
@@ -424,6 +404,8 @@ def test_vector_search_reuses_global_pool(monkeypatch):
         lambda *args, **kwargs: object(),
     )
     monkeypatch.setattr(search_mod, "_plan_vector_search", lambda **kwargs: [plan])
+    monkeypatch.setattr(search_mod.pickle, "dumps", lambda dataset: b"pickled-dataset")
+    search_mod._load_pickled_dataset.cache_clear()
 
     pool_mod.set_global_pool(FakeGlobalPool())
     try:
@@ -438,5 +420,106 @@ def test_vector_search_reuses_global_pool(monkeypatch):
     assert result.column("id").to_pylist() == [1]
     assert events == [
         ("map_async", [plan], 1),
+        "get",
+    ]
+
+
+def test_vector_search_pickles_driver_dataset_for_worker_plan(monkeypatch):
+    events = []
+
+    class FakeAsyncResult:
+        def __init__(self, results):
+            self._results = results
+
+        def get(self):
+            events.append("get")
+            return self._results
+
+    class FakeGlobalPool:
+        def map_async(self, func, plans, chunksize):
+            events.append(("map_async", plans, chunksize))
+            return FakeAsyncResult([func(plan) for plan in plans])
+
+    class FakeSchema:
+        def field(self, column):
+            return column
+
+    class FakeDataset:
+        schema = FakeSchema()
+
+        def get_fragments(self):
+            return [_FakeFragment(1)]
+
+        def scanner(self, **kwargs):
+            events.append(("scanner", kwargs))
+            return SimpleNamespace(
+                to_table=lambda: pa.table({"id": [1], "_distance": [0.1]})
+            )
+
+    fake_dataset = FakeDataset()
+    load_calls = []
+
+    def fake_lance_dataset(*args, **kwargs):
+        load_calls.append((args, kwargs))
+        return fake_dataset
+
+    pickled_dataset = b"pickled-dataset-search"
+
+    def fake_dumps(dataset):
+        events.append(("pickle.dumps", dataset is fake_dataset))
+        return pickled_dataset
+
+    def fake_loads(value):
+        events.append(("pickle.loads", value))
+        assert value == pickled_dataset
+        return fake_dataset
+
+    plans = [
+        _SearchPlan(fragment_ids=[1], index_segments=["S1"]),
+        _SearchPlan(fragment_ids=[2], index_segments=["S2"]),
+    ]
+    monkeypatch.setattr(search_mod, "LanceDataset", fake_lance_dataset)
+    monkeypatch.setattr(
+        search_mod,
+        "_select_vector_index",
+        lambda *args, **kwargs: object(),
+    )
+    monkeypatch.setattr(search_mod, "_plan_vector_search", lambda **kwargs: plans)
+    monkeypatch.setattr(search_mod.pickle, "dumps", fake_dumps)
+    monkeypatch.setattr(search_mod.pickle, "loads", fake_loads)
+    search_mod._load_pickled_dataset.cache_clear()
+
+    pool_mod.set_global_pool(FakeGlobalPool())
+    try:
+        result = search_mod.vector_search(
+            uri="dataset",
+            nearest={"column": "vector", "q": [0.0], "k": 1},
+            num_workers=4,
+        )
+    finally:
+        pool_mod.clear_global_pool()
+
+    assert result.column("id").to_pylist() == [1]
+    assert len(load_calls) == 1
+    assert events == [
+        ("pickle.dumps", True),
+        ("map_async", plans, 1),
+        ("pickle.loads", pickled_dataset),
+        (
+            "scanner",
+            {
+                "fast_search": True,
+                "nearest": {"column": "vector", "q": [0.0], "k": 1},
+                "index_segments": ["S1"],
+            },
+        ),
+        (
+            "scanner",
+            {
+                "fast_search": True,
+                "nearest": {"column": "vector", "q": [0.0], "k": 1},
+                "index_segments": ["S2"],
+            },
+        ),
         "get",
     ]


### PR DESCRIPTION
## Summary
- serialize the driver-opened LanceDataset with stdlib `pickle.dumps()` before dispatching distributed vector search plans
- deserialize on workers with `pickle.loads()` so LanceDataset uses its own pickle protocol (`__reduce__` / `__getstate__` / `__setstate__`) instead of reopening by URI/version
- cache the unpickled dataset per worker process for repeated plans using the same pickled dataset bytes
- add regression coverage for explicit pickle dumps/loads and worker-side dataset cache reuse

## Testing
- `python -m pytest tests/test_distributed_search.py tests/test_vector_index_options.py`
- `./.venv/bin/ruff check lance_ray/search.py tests/test_distributed_search.py`