### PR TITLE
chore: update pylance dependency to v8.0.0b6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=7.0.0b7",
+    "pylance>=8.0.0b6",
     "lance-namespace",
     "packaging",
     "pyarrow>=17.0.0",


### PR DESCRIPTION
## Summary

- Bumps the `pylance` dependency requirement from `>=7.0.0b7` to `>=8.0.0b6` in `pyproject.toml`.
- Triggering tag: https://github.com/lance-format/lance/releases/tag/v8.0.0-beta.6 (`refs/tags/v8.0.0-beta.6`).

## Verification

- `make lock` was run, but could not update `uv.lock` because the configured Lance Fury package index currently resolves only up to `pylance<=8.0.0b5` while this PR requires `pylance>=8.0.0b6`.
- `make lint` was run, but it also failed at the `lock` prerequisite for the same resolver issue before Ruff checks could run.
- Confirmed the `v8.0.0-beta.6` Lance tag exists; the GitHub release has no wheel assets attached, and the configured Fury simple index does not list `pylance-8.0.0b6` yet.
