### PR TITLE
feat(index): support distributed bitmap indexes

### DIFF
--- a/docs/src/distributed-indexing.md
+++ b/docs/src/distributed-indexing.md
@@ -7,7 +7,7 @@ Lance-Ray provides distributed index building functionality that leverages Ray's
 
 ### Scalar Indexing
 
-`create_scalar_index()` - Distributedly create scalar index using ray. Currently only Inverted/FTS/BTREE are supported. Will add more index type support in the future.
+`create_scalar_index()` - Distributedly create scalar index using ray. Currently only Inverted/FTS/BTREE/BITMAP are supported. Will add more index type support in the future.
 
 #### How It Works
 The `create_scalar_index` function allows you to create full-text search indices for Lance datasets using the Ray distributed computing framework. This function distributes the index building process across multiple Ray worker nodes, with each node responsible for building indices for a subset of dataset fragments. These indices are then merged and committed as a single index.
@@ -72,7 +72,7 @@ def create_scalar_index(
 | `ray_remote_args` | `Dict[str, Any]`, optional | Ray task options (e.g., `num_cpus`, `resources`) |
 | `**kwargs` | `Any` | Additional arguments passed to `create_scalar_index` |
 
-**Note:** For distributed scalar indexing, currently only `"INVERTED"`, `"FTS"` and `"BTREE"` index types are supported.
+**Note:** For distributed scalar indexing, currently only `"INVERTED"`, `"FTS"`, `"BTREE"` and `"BITMAP"` index types are supported.
 
 #### Return Value
 
@@ -444,7 +444,7 @@ except ValueError as e:
 
 ### Important Notes
 
-- **Index Type Support**: For distributed indexing, currently only `"INVERTED"`/`"FTS"`/`"BTREE"` index types are supported, even though the function signature accepts other index types.
+- **Index Type Support**: For distributed indexing, currently only `"INVERTED"`/`"FTS"`/`"BTREE"`/`"BITMAP"` index types are supported, even though the function signature accepts other index types.
 - **Default Behavior**: The `replace` parameter defaults to `True`, meaning existing indices with the same name will be replaced without warning. Set `replace=False` to prevent accidental overwrites.
 - **Fragment Selection**: Use `fragment_ids` parameter to build indices on specific fragments only. This is useful for incremental index building or testing.
 - **Error Handling**: When `replace=False` and an index with the same name exists, a `ValueError` or `RuntimeError` will be raised depending on the execution context.

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -399,7 +399,7 @@ def create_scalar_index(
                 f"Index type must be one of {valid_index_types}, not '{index_type}'"
             )
 
-        supported_distributed_types = {"INVERTED", "FTS", "BTREE"}
+        supported_distributed_types = {"INVERTED", "FTS", "BTREE", "BITMAP"}
         if index_type not in supported_distributed_types:
             raise ValueError(
                 "Distributed indexing currently supports "

--- a/tests/test_distributed_indexing.py
+++ b/tests/test_distributed_indexing.py
@@ -960,6 +960,55 @@ class TestDistributedBTreeIndexing:
         )
 
 
+class TestDistributedBitmapIndexing:
+    """Distributed BITMAP indexing tests."""
+
+    def test_distributed_bitmap_index_matches_baseline(self, temp_dir):
+        """Build a distributed BITMAP index and verify query results."""
+        with_index = generate_multi_fragment_dataset(
+            Path(temp_dir) / "with_bitmap",
+            num_fragments=3,
+            rows_per_fragment=250,
+        )
+        without_index = generate_multi_fragment_dataset(
+            Path(temp_dir) / "without_bitmap",
+            num_fragments=3,
+            rows_per_fragment=250,
+        )
+
+        updated_dataset = lr.create_scalar_index(
+            uri=with_index.uri,
+            column="fragment_id",
+            index_type="BITMAP",
+            name="fragment_bitmap_idx",
+            replace=False,
+            num_workers=3,
+        )
+
+        indices = updated_dataset.list_indices()
+        our_index = next(
+            (idx for idx in indices if idx["name"] == "fragment_bitmap_idx"),
+            None,
+        )
+
+        assert our_index is not None, "BITMAP index not found by name"
+        assert our_index["type"] == "Bitmap"
+
+        indexed = updated_dataset.scanner(
+            filter="fragment_id = 1",
+            columns=["id", "fragment_id"],
+        ).to_table()
+        baseline = without_index.scanner(
+            filter="fragment_id = 1",
+            columns=["id", "fragment_id"],
+        ).to_table()
+
+        assert indexed.num_rows == baseline.num_rows
+        assert sorted(indexed.column("id").to_pylist()) == sorted(
+            baseline.column("id").to_pylist()
+        )
+
+
 class TestOptimizeIndices:
     """Test cases for optimize_indices (incremental index optimization)."""
 


### PR DESCRIPTION
## Summary
- add distributed BITMAP scalar index support through the existing Ray scalar-index build path
- document BITMAP as a supported distributed scalar index type
- add integration coverage that builds a BITMAP index and compares filtered query results with an unindexed baseline

## Validation
- `ruff check lance_ray/index.py tests/test_distributed_indexing.py`
- `pytest -q tests/test_distributed_indexing.py::TestDistributedBitmapIndexing tests/test_distributed_indexing.py::TestDistributedIndexing::test_distributed_index_error_handling_new_api`