### PR TITLE
feat(index): support zonemap index creation

### DIFF
--- a/docs/src/distributed-indexing.md
+++ b/docs/src/distributed-indexing.md
@@ -7,7 +7,7 @@ Lance-Ray provides distributed index building functionality that leverages Ray's
 
 ### Scalar Indexing
 
-`create_scalar_index()` - Distributedly create scalar index using ray. Currently only Inverted/FTS/BTREE/BITMAP are supported. Will add more index type support in the future.
+`create_scalar_index()` - Distributedly create scalar indices using Ray. Currently Inverted/FTS/BTREE/BITMAP/ZONEMAP are supported. More index types will be added in the future.
 
 #### How It Works
 The `create_scalar_index` function allows you to create scalar indices for Lance datasets using the Ray distributed computing framework. This function distributes the index building process across multiple Ray worker nodes, with each node responsible for creating uncommitted index segments for a subset of dataset fragments. These segments are then committed as a single index.
@@ -69,7 +69,7 @@ def create_scalar_index(
 | `ray_remote_args` | `Dict[str, Any]`, optional | Ray task options (e.g., `num_cpus`, `resources`) |
 | `**kwargs` | `Any` | Additional arguments passed to `create_scalar_index` |
 
-**Note:** For distributed scalar indexing, currently only `"INVERTED"`, `"FTS"`, `"BTREE"` and `"BITMAP"` index types are supported.
+**Note:** For distributed scalar indexing, currently `"INVERTED"`, `"FTS"`, `"BTREE"`, `"BITMAP"`, and `"ZONEMAP"` index types are supported.
 
 #### Return Value
 

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -215,7 +215,7 @@ def _build_rabitq_model(*, dimension: int, num_bits: int = 1) -> str:
     return indices.build_rq_model(dimension=dimension, num_bits=num_bits)
 
 
-_SCALAR_SEGMENT_INDEX_TYPES = {"BTREE", "BITMAP", "INVERTED", "FTS"}
+_SCALAR_SEGMENT_INDEX_TYPES = {"BTREE", "BITMAP", "INVERTED", "FTS", "ZONEMAP"}
 
 
 def _scalar_index_type_name(index_type: str | IndexConfig) -> str | None:
@@ -520,7 +520,13 @@ def create_scalar_index(
                 f"Index type must be one of {valid_index_types}, not '{index_type}'"
             )
 
-        supported_distributed_types = {"INVERTED", "FTS", "BTREE", "BITMAP"}
+        supported_distributed_types = {
+            "INVERTED",
+            "FTS",
+            "BTREE",
+            "BITMAP",
+            "ZONEMAP",
+        }
         if index_type not in supported_distributed_types:
             raise ValueError(
                 "Distributed indexing currently supports "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=8.0.0b11",
+    "pylance>=8.0.0",
     "lance-namespace",
     "packaging",
     "pyarrow>=17.0.0",

--- a/tests/test_distributed_indexing.py
+++ b/tests/test_distributed_indexing.py
@@ -1213,6 +1213,101 @@ class TestDistributedBitmapIndexing:
         assert "fragment_bitmap_idx" in plan
 
 
+class TestDistributedZonemapIndexing:
+    """Distributed ZONEMAP indexing tests."""
+
+    def test_distributed_zonemap_index_matches_baseline(self, temp_dir):
+        """Build ZONEMAP segments on Ray workers and verify query results."""
+        with_index = generate_multi_fragment_dataset(
+            Path(temp_dir) / "with_zonemap",
+            num_fragments=4,
+            rows_per_fragment=250,
+        )
+        without_index = generate_multi_fragment_dataset(
+            Path(temp_dir) / "without_zonemap",
+            num_fragments=4,
+            rows_per_fragment=250,
+        )
+
+        updated_dataset = lr.create_scalar_index(
+            uri=with_index.uri,
+            column="id",
+            index_type="ZONEMAP",
+            name="id_zonemap_idx",
+            replace=False,
+            num_workers=2,
+            num_segments=4,
+        )
+
+        our_index = next(
+            (
+                idx
+                for idx in updated_dataset.describe_indices()
+                if idx.name == "id_zonemap_idx"
+            ),
+            None,
+        )
+        assert our_index is not None, "ZONEMAP index not found by name"
+        assert our_index.index_type == "ZoneMap"
+        assert len(our_index.segments) == 4
+
+        indexed = updated_dataset.scanner(
+            filter="id >= 250 AND id < 750",
+            columns=["id", "fragment_id"],
+        ).to_table()
+        baseline = without_index.scanner(
+            filter="id >= 250 AND id < 750",
+            columns=["id", "fragment_id"],
+        ).to_table()
+
+        assert indexed.num_rows == baseline.num_rows
+        assert sorted(indexed.column("id").to_pylist()) == sorted(
+            baseline.column("id").to_pylist()
+        )
+
+        plan = updated_dataset.scanner(
+            filter="id >= 250 AND id < 750",
+            columns=["id"],
+            use_scalar_index=True,
+        ).explain_plan()
+        assert "ScalarIndexQuery" in plan
+        assert "id_zonemap_idx" in plan
+
+    def test_distributed_zonemap_index_for_selected_fragments(self, temp_dir):
+        """Build and commit ZONEMAP segments for selected fragments."""
+        dataset = generate_multi_fragment_dataset(
+            temp_dir,
+            num_fragments=4,
+            rows_per_fragment=250,
+        )
+        fragment_ids = [
+            fragment.fragment_id for fragment in list(dataset.get_fragments())[:2]
+        ]
+
+        updated_dataset = lr.create_scalar_index(
+            uri=dataset.uri,
+            column="id",
+            index_type="ZONEMAP",
+            name="partial_zonemap_idx",
+            replace=False,
+            fragment_ids=fragment_ids,
+            num_workers=2,
+            num_segments=2,
+        )
+
+        our_index = next(
+            (
+                idx
+                for idx in updated_dataset.describe_indices()
+                if idx.name == "partial_zonemap_idx"
+            ),
+            None,
+        )
+        assert our_index is not None, "ZONEMAP index not found by name"
+        assert our_index.index_type == "ZoneMap"
+        assert len(our_index.segments) == 2
+
+
 class TestOptimizeIndices:
     """Test cases for optimize_indices (incremental index optimization)."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -326,19 +326,19 @@ wheels = [
 
 [[package]]
 name = "lance-namespace"
-version = "0.8.4"
+version = "0.8.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/8f/8a03395587a78cfaf92f7307ad931f61eb515af67705c704bd6c7af2f745/lance_namespace-0.8.4.tar.gz", hash = "sha256:1a54ad49e7ace25a629c5f2c99d393629742eceeeb16ba2f51a771ccb350e284", size = 11282, upload-time = "2026-06-10T19:07:21.919Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/12/f7ab93b29be3edbf5fc3610714bf2d06088e7f4524bfb38dfd6852458b08/lance_namespace-0.8.6.tar.gz", hash = "sha256:18232e721c8188145f4ec9389cc2dfbeeabf54a619d94885ea1b3375bee9f4af", size = 11529, upload-time = "2026-06-12T17:36:41.651Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/4b/218c67cafb707024069925ce86534588861a464aaa327f7a457b94eed3c2/lance_namespace-0.8.4-py3-none-any.whl", hash = "sha256:8b347eef4b7c7187a1b52f388b5dcc345fed0bf4ea87728188dcb11a52619d0b", size = 13111, upload-time = "2026-06-10T19:07:22.6Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1b/5b1668ee2dc8910965f390640359112a31157092fcf8e000b89c79b58708/lance_namespace-0.8.6-py3-none-any.whl", hash = "sha256:571eae34f9aad70e5b05020416c2860889b9ec82993ccd0eb015e7b39c3ea309", size = 13383, upload-time = "2026-06-12T17:36:43.456Z" },
 ]
 
 [[package]]
 name = "lance-namespace-urllib3-client"
-version = "0.8.4"
+version = "0.8.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -346,9 +346,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/55/4a7cc7e5d19bda170c896a6adff2ec925c533df812b91bce2bc8f7aea30b/lance_namespace_urllib3_client-0.8.4.tar.gz", hash = "sha256:1a292a83509ab79475da967b78839e9ead4ab973064d37d1ba1575b23ffdacef", size = 228485, upload-time = "2026-06-10T19:07:19.863Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/80/fb224b4a89c1c1638cde949cb6cce6c3aca7759effbfea46a3d9c3960b21/lance_namespace_urllib3_client-0.8.6.tar.gz", hash = "sha256:b6fb1d306e74a7576e5309919020be744527de484a63dbf5eed10f8b368548df", size = 228772, upload-time = "2026-06-12T17:36:42.609Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/f7/70dd2fc1f9ef462d3802b4cffcd64f2b9233a9907d6071e8694338492608/lance_namespace_urllib3_client-0.8.4-py3-none-any.whl", hash = "sha256:37ee1d74614fae6358f50e3589ac26c29379ffb1346f09c4f5ec8953f823cefd", size = 369807, upload-time = "2026-06-10T19:07:21.001Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/90/1e27de15cd1b16785a1c7312beb0a59e75c8344a815f600f58173a565bd1/lance_namespace_urllib3_client-0.8.6-py3-none-any.whl", hash = "sha256:9d78249c3fb15aa3d15d668f78f04a275af3d08d800a7027492f37996ac4968b", size = 369950, upload-time = "2026-06-12T17:36:40.438Z" },
 ]
 
 [[package]]
@@ -387,7 +387,7 @@ requires-dist = [
     { name = "more-itertools", marker = "python_full_version < '3.12'", specifier = ">=2.6.0" },
     { name = "packaging" },
     { name = "pyarrow", specifier = ">=17.0.0" },
-    { name = "pylance", specifier = ">=8.0.0b11" },
+    { name = "pylance", specifier = ">=8.0.0" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
@@ -1024,8 +1024,8 @@ wheels = [
 
 [[package]]
 name = "pylance"
-version = "8.0.0b11"
-source = { registry = "https://pypi.fury.io/lance-format" }
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1033,12 +1033,12 @@ dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://pypi.fury.io/lance-format/-/ver_GL5dn/pylance-8.0.0b11-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:2f2e66c6a7039ba51ac6174d0336b4f38a58351706e16b8b21a6c71f06cd1f20" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1pVrmn/pylance-8.0.0b11-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f85711b2f468acfe20ad2542639b82e9658ed301d72f5cfde82e2e40ef431b15" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1qcBDw/pylance-8.0.0b11-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:602af5469141d0c6667d902f6819cd2b7b5ce40193190be6a030adc753a36fe7" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1V5g0y/pylance-8.0.0b11-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:b6b89f48f198b3fe59ad795bac614a1cc8892e20f2ba2acd1f958a18d05e4b32" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_7rhla/pylance-8.0.0b11-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:4c8b16c860345f3c519dc28dd4dab111bdc2c104795c1c7fb3f245d798f64792" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1f0tKO/pylance-8.0.0b11-cp39-abi3-win_amd64.whl", hash = "sha256:66297c0a3708e4b6921d6430153d2cb89f7a618110bf8d119cb9986a81a6371c" },
+    { url = "https://files.pythonhosted.org/packages/3b/99/03db9f4f723353502d2b5f5d8a0eb9a30f0dc41a8cc036ac5fa486471223/pylance-8.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:769cb38e43a533fdffb87a804043f6a37793eb77d4acbc14cffe9e45dc8bd90b", size = 67235437, upload-time = "2026-07-01T15:09:09.519Z" },
+    { url = "https://files.pythonhosted.org/packages/48/af/8f8f8b9c70200e3ab99d8785c26ba691d0ff475cae27f7620618dfc8f3b6/pylance-8.0.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:597277a993d159dfcf58230958f1c5f6edebca8693fbd3502129be951ec6927e", size = 70558570, upload-time = "2026-07-01T15:13:50.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/4c/b10b02a7891753ec1d4a846b8cc001fbafb4bf7c48c2bda5303cf57c1b8a/pylance-8.0.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c8823134a09ff311b0a963227bdfc160c686910944a373af357cd5b3fa70b5c", size = 74747275, upload-time = "2026-07-01T15:27:09.817Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/56/09602b664d8036aa0105ffdb94189c23f9fde4ce71963f4a98f05fda526d/pylance-8.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:28c98c6ae99edc76622e2af331e99da4d57c9f44c32ebba2872a8e60dee9f7f8", size = 70578246, upload-time = "2026-07-01T15:14:53.143Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/1a/9f49850dfee7b1e763f358ff7477a1aa27228d1e40f907020f13ea13b3e1/pylance-8.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0b779a7465424de04975cedc774b1eadff8638e0f96f6f19245e9bea332e1e62", size = 74708654, upload-time = "2026-07-01T15:27:54.326Z" },
+    { url = "https://files.pythonhosted.org/packages/77/5d/1876b43e680b9afb0d827af032bd72d3f70a9eaf68cb8f5f4286b20a613e/pylance-8.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:ea2e35722f546eb2e056eafb1cc39ced5f353157653516a1472f1127bfa92eec", size = 80511928, upload-time = "2026-07-01T15:28:56.53Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- build `ZONEMAP` scalar index segments on Ray workers with `create_index_uncommitted(...)`
- commit worker-created segments on the driver with `commit_existing_index_segments(...)`
- support full-dataset and selected-`fragment_ids` distributed ZONEMAP builds
- require `pylance>=8.0.0`, the first stable release containing the ZONEMAP segment Python API
- document distributed ZONEMAP support and add regression coverage for segment counts and query correctness

## Why

The original draft used Lance's native full-dataset index builder because the available `pylance 8.0.0b11` wheel did not expose ZONEMAP segment builds.

That blocker is now resolved:

- lance-format/lance#7177 exposed ZONEMAP through the Python segment API
- #5180 added the shared scalar segment workflow to lance-ray
- `pylance 8.0.0` includes the required API

This PR now uses the same distributed segment workflow as BTREE, BITMAP, INVERTED, and FTS instead of the temporary native fallback.

## Validation

- `uv lock --check`
- `uv run --extra dev ruff check`
- `uv run --extra dev pytest -q tests/test_distributed_indexing.py::TestDistributedZonemapIndexing` — 2 passed
