### PR TITLE
chore: update pylance dependency to v8.0.0b9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=7.0.0b7",
+    "pylance>=8.0.0b9",
     "lance-namespace",
     "packaging",
     "pyarrow>=17.0.0",


### PR DESCRIPTION
## Summary
- Update the `pylance` dependency lower bound to `pylance>=8.0.0b9` using PEP 440 beta-version format.
- Triggering tag: refs/tags/v8.0.0-beta.9

## Verification
- `make lock` was attempted, but dependency resolution currently fails because the configured package indexes only expose `pylance<=8.0.0b8` to this runner.
- `make lint` was attempted, but it fails at the `lock` prerequisite for the same unresolved `pylance>=8.0.0b9` dependency.
- Confirmed the upstream GitHub release/tag exists: refs/tags/v8.0.0-beta.9.
