### PR TITLE
feat: support nested field paths in Ray workflows

### DIFF
--- a/lance_ray/field_path.py
+++ b/lance_ray/field_path.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+from dataclasses import dataclass
+from typing import Any
+
+import pyarrow as pa
+
+
+@dataclass(frozen=True)
+class ResolvedFieldPath:
+    path: str
+    field: pa.Field
+
+
+@dataclass(frozen=True)
+class ResolvedDatasetFieldPath(ResolvedFieldPath):
+    field_id: int
+
+
+def parse_field_path(path: str) -> list[str]:
+    segments: list[str] = []
+    segment: list[str] = []
+    in_quote = False
+    quoted = False
+    i = 0
+
+    while i < len(path):
+        char = path[i]
+        if in_quote:
+            if char == "`":
+                if i + 1 < len(path) and path[i + 1] == "`":
+                    segment.append("`")
+                    i += 2
+                    continue
+                in_quote = False
+                quoted = True
+                i += 1
+                continue
+            segment.append(char)
+            i += 1
+            continue
+
+        if char == ".":
+            if not segment:
+                raise ValueError(f"Invalid field path {path!r}: empty path segment")
+            segments.append("".join(segment))
+            segment = []
+            quoted = False
+            i += 1
+            continue
+
+        if quoted:
+            raise ValueError(
+                f"Invalid field path {path!r}: quoted path segments must be "
+                "followed by '.' or the end of the path"
+            )
+
+        if char == "`":
+            if segment:
+                raise ValueError(
+                    f"Invalid field path {path!r}: quotes must start a path segment"
+                )
+            in_quote = True
+            i += 1
+            continue
+
+        segment.append(char)
+        i += 1
+
+    if in_quote:
+        raise ValueError(f"Invalid field path {path!r}: unterminated quoted segment")
+    if not segment:
+        raise ValueError(f"Invalid field path {path!r}: empty path segment")
+
+    segments.append("".join(segment))
+    return segments
+
+
+def canonical_field_path(path: str) -> str:
+    return ".".join(_quote_segment(segment) for segment in parse_field_path(path))
+
+
+def resolve_arrow_field_path(schema: pa.Schema, path: str) -> ResolvedFieldPath:
+    segments = parse_field_path(path)
+    field = _schema_field(schema, segments[0])
+
+    for segment in segments[1:]:
+        if not pa.types.is_struct(field.type):
+            raise KeyError(
+                f"Field path {path!r} cannot descend into non-struct field "
+                f"{field.name!r}"
+            )
+        field = _struct_child(field.type, segment)
+
+    return ResolvedFieldPath(path=_canonical_segments(segments), field=field)
+
+
+def resolve_dataset_field_path(dataset: Any, path: str) -> ResolvedDatasetFieldPath:
+    resolved = resolve_arrow_field_path(dataset.schema, path)
+    lance_field = dataset.lance_schema.field(resolved.path)
+    if lance_field is None:
+        raise KeyError(f"Field path {path!r} not found in Lance schema")
+    return ResolvedDatasetFieldPath(
+        path=resolved.path,
+        field=resolved.field,
+        field_id=lance_field.id(),
+    )
+
+
+def _schema_field(schema: pa.Schema, name: str) -> pa.Field:
+    try:
+        return schema.field(name)
+    except KeyError as exc:
+        available = _field_names(schema)
+        raise KeyError(f"Field {name!r} not found. Available: {available}") from exc
+
+
+def _struct_child(data_type: pa.DataType, name: str) -> pa.Field:
+    for child in data_type:
+        if child.name == name:
+            return child
+    available = [child.name for child in data_type]
+    raise KeyError(f"Field {name!r} not found. Available: {available}")
+
+
+def _field_names(schema: pa.Schema) -> list[str]:
+    return [field.name for field in schema]
+
+
+def _canonical_segments(segments: list[str]) -> str:
+    return ".".join(_quote_segment(segment) for segment in segments)
+
+
+def _quote_segment(segment: str) -> str:
+    if segment and all(char.isalnum() or char == "_" for char in segment):
+        return segment
+    return "`" + segment.replace("`", "``") + "`"

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 
 import logging
+import math
 import uuid
 from collections.abc import Callable
 from typing import Any, Literal, Optional, TypeAlias, Union
@@ -14,6 +15,7 @@ from lance.indices import IndicesBuilder
 from packaging import version
 from ray.util.multiprocessing import Pool
 
+from .field_path import resolve_arrow_field_path, resolve_dataset_field_path
 from .utils import (
     get_namespace_kwargs,
     get_or_create_namespace,
@@ -245,10 +247,7 @@ def _handle_fragment_index(
                 **kwargs,
             )
 
-            lance_field = dataset.lance_schema.field(column)
-            if lance_field is None:
-                raise KeyError(f"{column} not found in schema")
-            field_id = lance_field.id()
+            field_id = resolve_dataset_field_path(dataset, column).field_id
 
             logger.info(
                 "Fragment scalar index created successfully for fragments %s",
@@ -440,12 +439,14 @@ def create_scalar_index(
     )
 
     try:
-        field = dataset.schema.field(column)
+        resolved_column = resolve_dataset_field_path(dataset, column)
     except KeyError as exc:
         available_columns = [field.name for field in dataset.schema]
         raise ValueError(
             f"Column '{column}' not found. Available: {available_columns}"
         ) from exc
+    column = resolved_column.path
+    field = resolved_column.field
 
     # Check column type according to index type
     value_type = field.type
@@ -637,6 +638,228 @@ _VECTOR_INDEX_TYPES = {
     "IVF_HNSW_PQ",
     "IVF_HNSW_SQ",
 }
+
+
+def _vector_dimension(field: pa.Field) -> int:
+    if pa.types.is_fixed_size_list(field.type):
+        return field.type.list_size
+    if isinstance(field.type, pa.FixedShapeTensorType) and len(field.type.shape) == 1:
+        return field.type.shape[0]
+    raise TypeError(
+        f"Vector column must be FixedSizeListArray or 1-dimensional "
+        f"FixedShapeTensorArray, got {field.type}"
+    )
+
+
+def _validate_vector_value_type(field: pa.Field) -> None:
+    value_type = field.type.value_type
+    if not (
+        pa.types.is_floating(value_type) or pa.types.is_unsigned_integer(value_type)
+    ):
+        raise TypeError(
+            "Vector column must have floating or unsigned integer value type, "
+            f"got {value_type}"
+        )
+
+
+def _schema_names(schema: pa.Schema) -> list[str]:
+    names = getattr(schema, "names", None)
+    if names is not None:
+        return list(names)
+    return [field.name for field in schema]
+
+
+class _NestedVectorIndicesBuilder:
+    def __init__(self, dataset: LanceDataset, column: str, field: pa.Field):
+        self.dataset = dataset
+        self.column = column
+        self.dimension = _vector_dimension(field)
+        _validate_vector_value_type(field)
+
+    def train_ivf(
+        self,
+        num_partitions: Optional[int] = None,
+        *,
+        distance_type: str = "l2",
+        sample_rate: int = 256,
+        max_iters: int = 50,
+        fragment_ids: Optional[list[int]] = None,
+        **kwargs: Any,
+    ) -> Any:
+        if kwargs.get("accelerator") is not None:
+            raise NotImplementedError(
+                "Nested vector IVF training does not support accelerator training"
+            )
+
+        from lance.indices.ivf import IvfModel
+        from lance.lance import indices
+
+        num_rows = _count_rows_for_fragments(self.dataset, fragment_ids)
+        partition_count = _determine_num_partitions(num_partitions, num_rows)
+        _verify_ivf_sample_rate(sample_rate, partition_count, num_rows)
+        distance_type = _normalize_distance_type(distance_type)
+        _verify_num_partitions(partition_count)
+
+        centroids = indices.train_ivf_model(
+            self.dataset._ds,
+            self.column,
+            self.dimension,
+            partition_count,
+            distance_type,
+            sample_rate,
+            max_iters,
+            fragment_ids,
+        )
+        return IvfModel(centroids, distance_type)
+
+    def train_pq(
+        self,
+        ivf_model: Any,
+        num_subvectors: Optional[int] = None,
+        *,
+        sample_rate: int = 256,
+        max_iters: int = 50,
+        fragment_ids: Optional[list[int]] = None,
+    ) -> Any:
+        from lance.indices.pq import PqModel
+        from lance.lance import indices
+
+        num_rows = _count_rows_for_fragments(self.dataset, fragment_ids)
+        num_subvectors = _normalize_pq_params(num_subvectors, self.dimension)
+        _verify_pq_sample_rate(num_rows, sample_rate)
+        codebook = indices.train_pq_model(
+            self.dataset._ds,
+            self.column,
+            self.dimension,
+            num_subvectors,
+            ivf_model.distance_type,
+            sample_rate,
+            max_iters,
+            ivf_model.centroids,
+            fragment_ids,
+        )
+        return PqModel(num_subvectors, codebook)
+
+
+def _count_rows_for_fragments(
+    dataset: LanceDataset,
+    fragment_ids: Optional[list[int]],
+) -> int:
+    if fragment_ids is None:
+        return dataset.count_rows()
+
+    row_count = 0
+    for fragment_id in fragment_ids:
+        fragment = dataset.get_fragment(fragment_id)
+        if fragment is None:
+            raise ValueError(f"Fragment id does not exist: {fragment_id}")
+        row_count += fragment.count_rows()
+    return row_count
+
+
+def _determine_num_partitions(num_partitions: Optional[int], num_rows: int) -> int:
+    if num_partitions is None:
+        return round(math.sqrt(num_rows))
+    return num_partitions
+
+
+def _verify_base_sample_rate(sample_rate: int) -> None:
+    if not isinstance(sample_rate, int) or sample_rate < 2:
+        raise ValueError(
+            f"The sample_rate must be an int greater than 1, got {sample_rate}"
+        )
+
+
+def _verify_ivf_sample_rate(
+    sample_rate: int,
+    num_partitions: int,
+    num_rows: int,
+) -> None:
+    _verify_base_sample_rate(sample_rate)
+    if num_partitions * sample_rate > num_rows:
+        raise ValueError(
+            "There are not enough rows in the dataset to create IVF centroids with"
+            f" {num_partitions} partitions and a sample rate of {sample_rate}."
+            f" {sample_rate * num_partitions} rows needed and there are {num_rows}"
+        )
+
+
+def _verify_num_partitions(num_partitions: int) -> None:
+    if not isinstance(num_partitions, int):
+        raise TypeError(f"num_partitions must be int, got {type(num_partitions)}")
+
+
+def _normalize_distance_type(distance_type: str) -> str:
+    if not isinstance(distance_type, str) or distance_type.lower() not in [
+        "l2",
+        "cosine",
+        "euclidean",
+        "dot",
+        "hamming",
+    ]:
+        raise ValueError(f"Distance type {distance_type} not supported.")
+    return distance_type.lower()
+
+
+def _normalize_pq_params(num_subvectors: Optional[int], dimension: int) -> int:
+    if num_subvectors is None:
+        if dimension % 16 == 0:
+            return dimension // 16
+        if dimension % 8 == 0:
+            return dimension // 8
+        raise ValueError(
+            f"vector dimension {dimension} is not divisible by 16 or 8."
+            " PQ performance will be poor.  Please specify num_subvectors manually."
+        )
+    if not isinstance(num_subvectors, int):
+        raise ValueError("num_subvectors must be an int")
+    if num_subvectors < 1:
+        raise ValueError("num_subvectors must be greater than 0")
+    if num_subvectors > dimension:
+        raise ValueError(
+            "num_subvectors must be less than or equal to the dimension of the vectors"
+        )
+    if dimension % num_subvectors != 0:
+        raise ValueError(
+            f"dimension ({dimension}) must be divisible by num_subvectors "
+            f"({num_subvectors}) without remainder"
+        )
+    return num_subvectors
+
+
+def _verify_pq_sample_rate(num_rows: int, sample_rate: int) -> None:
+    _verify_base_sample_rate(sample_rate)
+    if 256 * sample_rate > num_rows:
+        raise ValueError(
+            "There are not enough rows in the dataset to create PQ codebook with "
+            f"a sample rate of {sample_rate}. {sample_rate * 256} rows needed and "
+            f"there are {num_rows}"
+        )
+
+
+def _indices_builder_for_field_path(
+    dataset: LanceDataset,
+    column: str,
+    field: pa.Field,
+) -> IndicesBuilder | _NestedVectorIndicesBuilder:
+    if column in _schema_names(dataset.schema):
+        return IndicesBuilder(dataset, column)
+
+    return _NestedVectorIndicesBuilder(dataset, column, field)
+
+
+def _train_pq_for_field_path(
+    builder: IndicesBuilder | _NestedVectorIndicesBuilder,
+    ivf_model: Any,
+    *,
+    num_subvectors: Optional[int],
+    sample_rate: int,
+) -> Any:
+    return builder.train_pq(
+        ivf_model,
+        num_subvectors=num_subvectors,
+        sample_rate=sample_rate,
+    )
 
 
 def _normalize_index_type(index_type: Any) -> str:
@@ -916,12 +1139,14 @@ def create_index(
         namespace_kwargs = {}
 
     try:
-        dataset_obj.schema.field(column)
+        resolved_column = resolve_arrow_field_path(dataset_obj.schema, column)
     except KeyError as exc:
         available_columns = [field.name for field in dataset_obj.schema]
         raise ValueError(
             f"Column '{column}' not found. Available: {available_columns}"
         ) from exc
+    column = resolved_column.path
+    field = resolved_column.field
 
     if name is None:
         name = f"{column}_idx"
@@ -966,7 +1191,7 @@ def create_index(
         index_type_name,
         metric_lower,
     )
-    builder = IndicesBuilder(dataset_obj, column)
+    builder = _indices_builder_for_field_path(dataset_obj, column, field)
     num_rows = dataset_obj.count_rows()
     dimension = builder.dimension
 
@@ -998,7 +1223,8 @@ def create_index(
             requested_num_sub_vectors,
             sample_rate,
         )
-        pq_model = builder.train_pq(
+        pq_model = _train_pq_for_field_path(
+            builder,
             ivf_model,
             num_subvectors=requested_num_sub_vectors,
             sample_rate=sample_rate,

--- a/lance_ray/search.py
+++ b/lance_ray/search.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 
+import inspect
 import logging
 import math
 import pickle
@@ -12,6 +13,7 @@ import pyarrow.compute as pc
 import ray
 from lance.dataset import LanceDataset
 
+from .field_path import canonical_field_path, resolve_arrow_field_path
 from .pool import get_or_create_pool
 from .utils import (
     get_namespace_kwargs,
@@ -121,7 +123,7 @@ def _select_vector_index(
                 return index
             continue
 
-        if column in field_names:
+        if column in _canonical_index_field_names(field_names):
             return index
 
     if index_name is not None:
@@ -132,6 +134,16 @@ def _select_vector_index(
         )
 
     return None
+
+
+def _canonical_index_field_names(field_names: Any) -> set[str]:
+    canonical_names = set()
+    for field_name in field_names or []:
+        try:
+            canonical_names.add(canonical_field_path(str(field_name)))
+        except ValueError:
+            canonical_names.add(str(field_name))
+    return canonical_names
 
 
 def _plan_vector_search(
@@ -276,6 +288,13 @@ def _execute_vector_search_plan(
             analyze_plan=analyze_plan,
         )
 
+    if not _scanner_accepts_index_segments(dataset):
+        raise RuntimeError(
+            "The installed pylance scanner does not support index_segments, "
+            "which is required for distributed indexed vector search plans. "
+            "Upgrade pylance or run without an indexed plan."
+        )
+
     scanner_options = dict(base_scanner_options)
     search_nearest = dict(nearest)
     search_nearest["k"] = candidate_k
@@ -294,6 +313,17 @@ def _execute_vector_search_plan(
     if analyze_plan:
         return _SearchPlanAnalysis(plan=plan, analysis=scanner.analyze_plan())
     return scanner.to_table()
+
+
+def _scanner_accepts_index_segments(dataset: LanceDataset) -> bool:
+    try:
+        parameters = inspect.signature(dataset.scanner).parameters
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return True
+    return "index_segments" in parameters or any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters.values()
+    )
 
 
 def _execute_flat_fallback_vector_search_plan(
@@ -639,12 +669,14 @@ def vector_search(
             merged_storage_options.update(_get_dataset_storage_options(dataset))
 
     try:
-        dataset.schema.field(column)
+        resolved_column = resolve_arrow_field_path(dataset.schema, column)
     except KeyError as exc:
         available_columns = [field.name for field in dataset.schema]
         raise ValueError(
             f"Column '{column}' not found. Available: {available_columns}"
         ) from exc
+    column = resolved_column.path
+    nearest = {**nearest, "column": column}
 
     fragments = dataset.get_fragments()
     if not fragments:

--- a/tests/test_basic_read_write.py
+++ b/tests/test_basic_read_write.py
@@ -126,6 +126,54 @@ class TestWriteLance:
         tbl = ds.to_table()
         assert set(data["name"].tolist()) == set(tbl["name"].to_pylist())
 
+    def test_write_lance_preserves_nested_struct_fields(self, temp_dir):
+        path = Path(temp_dir) / "nested_struct.lance"
+        schema = pa.schema(
+            [
+                pa.field("id", pa.int64()),
+                pa.field(
+                    "meta",
+                    pa.struct(
+                        [
+                            pa.field("userId", pa.string()),
+                            pa.field("a.b", pa.string()),
+                        ]
+                    ),
+                ),
+            ]
+        )
+        table = pa.Table.from_arrays(
+            [
+                pa.array([1, 2], type=pa.int64()),
+                pa.array(
+                    [
+                        {"userId": "u1", "a.b": "literal dot one"},
+                        {"userId": "u2", "a.b": "literal dot two"},
+                    ],
+                    type=schema.field("meta").type,
+                ),
+            ],
+            schema=schema,
+        )
+
+        lr.write_lance(
+            ray.data.from_arrow(table),
+            str(path),
+            min_rows_per_file=1,
+            max_rows_per_file=1,
+        )
+
+        ds = lance.dataset(str(path))
+        assert ds.schema == schema
+        projected = lr.read_lance(str(path), columns=["meta.userId"]).take_all()
+        literal_dot = lr.read_lance(str(path), columns=["meta.`a.b`"]).take_all()
+
+        assert projected == [{"meta.userId": "u1"}, {"meta.userId": "u2"}]
+        assert literal_dot == [
+            {"meta.`a.b`": "literal dot one"},
+            {"meta.`a.b`": "literal dot two"},
+        ]
+
 
 class TestReadLance:
     """Test cases for read_lance function."""

--- a/tests/test_distributed_indexing.py
+++ b/tests/test_distributed_indexing.py
@@ -10,6 +10,7 @@ import numpy as np
 import pyarrow as pa
 import pytest
 import ray
+from lance_ray.search import _scanner_accepts_index_segments
 from packaging import version
 
 import pandas as pd
@@ -149,6 +150,71 @@ def generate_mixed_schema_dataset(
     path = Path(tmp_path) / "mixed_schema.lance"
     lr.write_lance(
         dataset,
+        str(path),
+        min_rows_per_file=rows_per_fragment,
+        max_rows_per_file=rows_per_fragment,
+    )
+    return str(path)
+
+
+def generate_nested_contract_dataset(tmp_path, rows_per_fragment: int = 2):
+    """Generate a multi-fragment dataset with nested field-path edge cases."""
+    schema = pa.schema(
+        [
+            pa.field("id", pa.int64()),
+            pa.field(
+                "meta",
+                pa.struct(
+                    [
+                        pa.field("text", pa.string()),
+                        pa.field("a.b", pa.string()),
+                    ]
+                ),
+            ),
+            pa.field(
+                "meta-data",
+                pa.struct([pa.field("user-id", pa.int64())]),
+            ),
+            pa.field("outer", pa.struct([pa.field("leaf", pa.int64())])),
+            pa.field("other", pa.struct([pa.field("leaf", pa.int64())])),
+        ]
+    )
+    table = pa.Table.from_arrays(
+        [
+            pa.array([1, 2, 3, 4], type=pa.int64()),
+            pa.array(
+                [
+                    {"text": "nestedone", "a.b": "literalone"},
+                    {"text": "nestedtwo", "a.b": "literaltwo"},
+                    {"text": "nestedthree", "a.b": "literalthree"},
+                    {"text": "nestedfour", "a.b": "literalfour"},
+                ],
+                type=schema.field("meta").type,
+            ),
+            pa.array(
+                [
+                    {"user-id": 101},
+                    {"user-id": 102},
+                    {"user-id": 103},
+                    {"user-id": 104},
+                ],
+                type=schema.field("meta-data").type,
+            ),
+            pa.array(
+                [{"leaf": 10}, {"leaf": 20}, {"leaf": 30}, {"leaf": 40}],
+                type=schema.field("outer").type,
+            ),
+            pa.array(
+                [{"leaf": 40}, {"leaf": 30}, {"leaf": 20}, {"leaf": 10}],
+                type=schema.field("other").type,
+            ),
+        ],
+        schema=schema,
+    )
+
+    path = Path(tmp_path) / "nested_contract.lance"
+    lr.write_lance(
+        ray.data.from_arrow(table),
         str(path),
         min_rows_per_file=rows_per_fragment,
         max_rows_per_file=rows_per_fragment,
@@ -429,6 +495,93 @@ class TestDistributedIndexing:
         # Verify the index was created
         indices = updated_dataset.list_indices()
         assert len(indices) > 0, "No indices found after building"
+
+    def test_build_distributed_nested_scalar_indexes(self, temp_dir):
+        """Nested field paths should pass driver validation and reach workers."""
+        dataset_uri = generate_nested_contract_dataset(temp_dir)
+
+        updated_dataset = lr.create_scalar_index(
+            uri=dataset_uri,
+            column="`meta`.`text`",
+            index_type="INVERTED",
+            name="nested_text_idx",
+            num_workers=2,
+        )
+        updated_dataset = lr.create_scalar_index(
+            uri=updated_dataset.uri,
+            column="meta.`a.b`",
+            index_type="INVERTED",
+            name="literal_dot_text_idx",
+            num_workers=2,
+        )
+        updated_dataset = lr.create_scalar_index(
+            uri=updated_dataset.uri,
+            column="`meta-data`.`user-id`",
+            index_type="BTREE",
+            name="hyphen_user_id_idx",
+            num_workers=2,
+        )
+
+        indices = {idx["name"]: idx for idx in updated_dataset.list_indices()}
+        assert indices["nested_text_idx"]["fields"] == ["meta.text"]
+        assert indices["literal_dot_text_idx"]["fields"] == ["meta.`a.b`"]
+        assert indices["hyphen_user_id_idx"]["fields"] == ["`meta-data`.`user-id`"]
+
+        nested_results = updated_dataset.scanner(
+            full_text_query="nestedthree",
+            columns=["id", "meta.text"],
+        ).to_table()
+        literal_dot_results = updated_dataset.scanner(
+            full_text_query="literaltwo",
+            columns=["id", "meta.`a.b`"],
+        ).to_table()
+
+        assert nested_results.column("id").to_pylist() == [3]
+        assert literal_dot_results.column("id").to_pylist() == [2]
+
+    def test_build_distributed_nested_same_leaf_scalar_indexes(self, temp_dir):
+        """Same leaf names must resolve through their full nested paths."""
+        dataset_uri = generate_nested_contract_dataset(temp_dir)
+
+        with pytest.raises(ValueError, match="Column 'leaf' not found"):
+            lr.create_scalar_index(
+                uri=dataset_uri,
+                column="leaf",
+                index_type="BTREE",
+                name="ambiguous_leaf_idx",
+                num_workers=2,
+            )
+
+        updated_dataset = lr.create_scalar_index(
+            uri=dataset_uri,
+            column="outer.leaf",
+            index_type="BTREE",
+            name="outer_leaf_idx",
+            num_workers=2,
+        )
+        updated_dataset = lr.create_scalar_index(
+            uri=updated_dataset.uri,
+            column="other.leaf",
+            index_type="BTREE",
+            name="other_leaf_idx",
+            num_workers=2,
+        )
+
+        indices = {idx["name"]: idx for idx in updated_dataset.list_indices()}
+        assert indices["outer_leaf_idx"]["fields"] == ["outer.leaf"]
+        assert indices["other_leaf_idx"]["fields"] == ["other.leaf"]
+
+        outer_results = updated_dataset.scanner(
+            filter="outer.leaf = 20",
+            columns=["id", "outer.leaf"],
+        ).to_table()
+        other_results = updated_dataset.scanner(
+            filter="other.leaf = 20",
+            columns=["id", "other.leaf"],
+        ).to_table()
+
+        assert outer_results.column("id").to_pylist() == [2]
+        assert other_results.column("id").to_pylist() == [3]
 
     def test_scalar_index_on_mixed_schema_list_indices(self, temp_dir):
         """Create scalar index on schema with both scalar and vector columns; verify list_indices."""
@@ -1295,6 +1448,37 @@ def generate_multi_fragment_vector_dataset(
     return str(path)
 
 
+def generate_nested_vector_dataset(
+    tmp_path, num_fragments: int = 2, rows_per_fragment: int = 256, dim: int = 8
+) -> str:
+    """Generate a Lance dataset with a nested vector column."""
+    num_rows = num_fragments * rows_per_fragment
+    values = pa.array(
+        [
+            float(row_idx) + (dim_idx / 100.0)
+            for row_idx in range(num_rows)
+            for dim_idx in range(dim)
+        ],
+        type=pa.float32(),
+    )
+    vector_array = pa.FixedSizeListArray.from_arrays(values, dim)
+    meta_type = pa.struct([pa.field("vector", vector_array.type)])
+    meta_array = pa.StructArray.from_arrays([vector_array], fields=list(meta_type))
+    tbl = pa.Table.from_arrays(
+        [pa.array(range(num_rows), type=pa.int64()), meta_array],
+        names=["id", "meta"],
+    )
+
+    path = Path(tmp_path) / "nested_vector.lance"
+    lance.write_dataset(
+        tbl,
+        str(path),
+        max_rows_per_file=rows_per_fragment,
+    )
+
+    return str(path)
+
+
 @pytest.mark.parametrize("index_type", ["IVF_FLAT", "IVF_SQ", "IVF_PQ"])
 def test_build_distributed_vector_index(tmp_path, index_type):
     """Build a distributed vector index and verify nearest search works."""
@@ -1350,3 +1534,59 @@ def test_build_distributed_vector_index(tmp_path, index_type):
     )
 
     assert result.num_rows == 5
+
+
+@pytest.mark.parametrize("index_type", ["IVF_FLAT", "IVF_PQ"])
+def test_distributed_nested_vector_index_and_search(tmp_path, index_type):
+    """Distributed vector index and search should accept nested canonical paths."""
+    dataset_uri = generate_nested_vector_dataset(tmp_path)
+    query = [dim_idx / 100.0 for dim_idx in range(8)]
+    index_kwargs = {"num_sub_vectors": 2} if index_type == "IVF_PQ" else {}
+
+    try:
+        updated_dataset = lr.create_index(
+            uri=dataset_uri,
+            column="meta.vector",
+            index_type=index_type,
+            name=f"nested_vector_{index_type.lower()}_idx",
+            num_workers=2,
+            num_partitions=1,
+            sample_rate=2,
+            **index_kwargs,
+        )
+    except RuntimeError as exc:
+        msg = str(exc)
+        if (
+            "Creating empty vector indices with train=False is not yet implemented"
+            in msg
+        ):
+            pytest.skip(f"Skipping: lance version limitation: {exc}")
+        raise
+
+    indices = {idx["name"]: idx for idx in updated_dataset.list_indices()}
+    index_name = f"nested_vector_{index_type.lower()}_idx"
+    assert indices[index_name]["fields"] == ["meta.vector"]
+
+    if not _scanner_accepts_index_segments(updated_dataset):
+        with pytest.raises(RuntimeError, match="does not support index_segments"):
+            lr.vector_search(
+                uri=updated_dataset.uri,
+                nearest={"column": "`meta`.`vector`", "q": query, "k": 5},
+                index_name=index_name,
+                columns=["id"],
+                num_workers=2,
+                fast_search=True,
+            )
+        return
+
+    result = lr.vector_search(
+        uri=updated_dataset.uri,
+        nearest={"column": "`meta`.`vector`", "q": query, "k": 5},
+        index_name=index_name,
+        columns=["id"],
+        num_workers=2,
+        fast_search=True,
+    )
+
+    assert result.num_rows == 5
+    assert result.column("id").to_pylist()[0] == 0

--- a/tests/test_distributed_search.py
+++ b/tests/test_distributed_search.py
@@ -67,6 +67,30 @@ def test_select_vector_index_raises_for_missing_explicit_index_name(monkeypatch)
         )
 
 
+def test_select_vector_index_matches_canonical_lance_field_path(monkeypatch):
+    dataset = object()
+    index = SimpleNamespace(
+        name="hyphen_idx",
+        field_names=["`meta-data`.`user-id`"],
+        index_type="IVF_PQ",
+        segments=[],
+    )
+
+    monkeypatch.setattr(
+        "lance_ray.search._get_index_descriptions",
+        lambda _: [index],
+    )
+
+    assert (
+        _select_vector_index(
+            dataset,
+            column="`meta-data`.`user-id`",
+            index_name=None,
+        )
+        is index
+    )
+
+
 def test_plan_vector_search_keeps_segment_fragments_together():
     fragments = [_FakeFragment(fragment_id) for fragment_id in range(1, 6)]
     index = _index_with_segments(
@@ -198,6 +222,25 @@ def test_execute_indexed_vector_search_plan_does_not_pass_fragments(monkeypatch)
     assert "fragments" not in scanner_options
     assert scanner_options["index_segments"] == ["S1"]
     assert scanner_options["fast_search"] is True
+
+
+def test_execute_indexed_vector_search_plan_without_index_segments_support(monkeypatch):
+    class FakeDataset:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def scanner(self, columns=None):
+            return SimpleNamespace(to_table=lambda: pa.table({"id": [1]}))
+
+    with pytest.raises(RuntimeError, match="index_segments"):
+        _execute_vector_search_plan(
+            _SearchPlan(fragment_ids=[1, 2], index_segments=["S1"]),
+            pickled_dataset=_mock_pickled_dataset(monkeypatch, FakeDataset()),
+            base_scanner_options={"columns": ["id"], "fast_search": True},
+            nearest={"column": "vector", "q": [0.0, 0.0], "k": 1},
+            candidate_k=1,
+            analyze_plan=False,
+        )
 
 
 def test_execute_fallback_vector_search_plan_computes_local_top_k(monkeypatch):

--- a/tests/test_field_path.py
+++ b/tests/test_field_path.py
@@ -1,0 +1,75 @@
+import pyarrow as pa
+import pytest
+from lance_ray.field_path import (
+    canonical_field_path,
+    parse_field_path,
+    resolve_arrow_field_path,
+)
+
+
+def _nested_schema():
+    return pa.schema(
+        [
+            pa.field("id", pa.int64()),
+            pa.field(
+                "meta",
+                pa.struct(
+                    [
+                        pa.field("userId", pa.string()),
+                        pa.field("a.b", pa.string()),
+                        pa.field("a`b", pa.string()),
+                    ]
+                ),
+            ),
+            pa.field(
+                "meta-data",
+                pa.struct([pa.field("user-id", pa.string())]),
+            ),
+            pa.field("outer", pa.struct([pa.field("leaf", pa.int64())])),
+            pa.field("other", pa.struct([pa.field("leaf", pa.int64())])),
+        ]
+    )
+
+
+def test_parse_field_path_supports_quoted_literal_dot_segments():
+    assert parse_field_path("meta.`a.b`") == ["meta", "a.b"]
+    assert parse_field_path("`meta`.`userId`") == ["meta", "userId"]
+    assert parse_field_path("meta.`a``b`") == ["meta", "a`b"]
+
+
+def test_canonical_field_path_matches_lance_formatting_rules():
+    assert canonical_field_path("`meta`.`userId`") == "meta.userId"
+    assert canonical_field_path("meta.`a.b`") == "meta.`a.b`"
+    assert canonical_field_path("`meta-data`.`user-id`") == "`meta-data`.`user-id`"
+    assert canonical_field_path("meta.`a``b`") == "meta.`a``b`"
+
+
+def test_resolve_arrow_field_path_supports_nested_and_literal_dot():
+    schema = _nested_schema()
+
+    assert resolve_arrow_field_path(schema, "meta.userId").field.name == "userId"
+    resolved_literal = resolve_arrow_field_path(schema, "`meta`.`a.b`")
+
+    assert resolved_literal.path == "meta.`a.b`"
+    assert resolved_literal.field.name == "a.b"
+
+    resolved_hyphen = resolve_arrow_field_path(schema, "`meta-data`.`user-id`")
+    assert resolved_hyphen.path == "`meta-data`.`user-id`"
+    assert resolved_hyphen.field.name == "user-id"
+
+
+def test_resolve_arrow_field_path_requires_disambiguated_same_leaf_name():
+    schema = _nested_schema()
+
+    with pytest.raises(KeyError):
+        resolve_arrow_field_path(schema, "leaf")
+
+    assert resolve_arrow_field_path(schema, "outer.leaf").field.name == "leaf"
+    assert resolve_arrow_field_path(schema, "other.leaf").field.name == "leaf"
+
+
+def test_parse_field_path_rejects_malformed_quoted_paths():
+    with pytest.raises(ValueError, match="unterminated"):
+        parse_field_path("meta.`a.b")
+    with pytest.raises(ValueError, match="empty path segment"):
+        parse_field_path("meta..userId")


### PR DESCRIPTION
This PR adds nested field-path support across Lance-Ray read/write validation, distributed index creation, and distributed vector search planning.

The existing Ray index/search paths validated columns against top-level Arrow schema names, which rejected nested fields before Lance could resolve them. Literal-dot field names and same-leaf nested fields also needed canonical path handling so driver validation, worker dispatch, and index metadata matching agree on the same field path format.

The change introduces a shared field-path parser/resolver, keeps nested read/write projection pass-through intact, resolves scalar index field IDs through the Lance schema, and supports nested vector index training through an explicit nested-vector adapter instead of faking a pylance `IndicesBuilder`. Distributed vector search now canonicalizes index field metadata before matching and fails clearly when the installed pylance scanner cannot execute `index_segments`, instead of silently falling back to flat scan for indexed plans.

Validation covered formatting, linting, field-path unit tests, distributed search planning tests, vector index option tests, nested read/write projection, nested scalar index creation, same-leaf disambiguation, and nested vector `IVF_FLAT` / `IVF_PQ` index workflows.