### PR TITLE
feat: migrate distributed indexing to index segment APIs

### DIFF
--- a/docs/src/distributed-indexing.md
+++ b/docs/src/distributed-indexing.md
@@ -10,11 +10,7 @@ Lance-Ray provides distributed index building functionality that leverages Ray's
 `create_scalar_index()` - Distributedly create scalar index using ray. Currently only Inverted/FTS/BTREE/BITMAP are supported. Will add more index type support in the future.
 
 #### How It Works
-The `create_scalar_index` function allows you to create full-text search indices for Lance datasets using the Ray distributed computing framework. This function distributes the index building process across multiple Ray worker nodes, with each node responsible for building indices for a subset of dataset fragments. These indices are then merged and committed as a single index.
-
-**Backward Compatibility**:
-   - Automatically detect availability of new APIs across different Lance versions
-   - Gracefully fallback to raise tips when new APIs are unavailable
+The `create_scalar_index` function allows you to create scalar indices for Lance datasets using the Ray distributed computing framework. For segment-backed scalar types (`BTREE`, `BITMAP`, `INVERTED` / `FTS`), this function distributes the segment building process across multiple Ray worker nodes, with each node responsible for building uncommitted index segments for a subset of dataset fragments. These segments are then committed as a single index. Other scalar index types continue to use the legacy workflow.
 
 
 **`create_scalar_index`**
@@ -72,7 +68,7 @@ def create_scalar_index(
 | `ray_remote_args` | `Dict[str, Any]`, optional | Ray task options (e.g., `num_cpus`, `resources`) |
 | `**kwargs` | `Any` | Additional arguments passed to `create_scalar_index` |
 
-**Note:** For distributed scalar indexing, currently only `"INVERTED"`, `"FTS"`, `"BTREE"` and `"BITMAP"` index types are supported.
+**Note:** `"INVERTED"`, `"FTS"`, `"BTREE"` and `"BITMAP"` use Lance's segment-index workflow. Other scalar index types use the legacy distributed scalar-index workflow.
 
 #### Return Value
 
@@ -444,7 +440,7 @@ except ValueError as e:
 
 ### Important Notes
 
-- **Index Type Support**: For distributed indexing, currently only `"INVERTED"`/`"FTS"`/`"BTREE"`/`"BITMAP"` index types are supported, even though the function signature accepts other index types.
+- **Index Type Support**: `"INVERTED"`/`"FTS"`/`"BTREE"`/`"BITMAP"` use the segment-index workflow. Other scalar index types continue to use the legacy distributed scalar-index workflow.
 - **Default Behavior**: The `replace` parameter defaults to `True`, meaning existing indices with the same name will be replaced without warning. Set `replace=False` to prevent accidental overwrites.
 - **Fragment Selection**: Use `fragment_ids` parameter to build indices on specific fragments only. This is useful for incremental index building or testing.
 - **Error Handling**: When `replace=False` and an index with the same name exists, a `ValueError` or `RuntimeError` will be raised depending on the execution context.

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -186,6 +186,97 @@ def _put_vector_index_artifacts_in_object_store(
     )
 
 
+_SCALAR_SEGMENT_INDEX_TYPES = {"BTREE", "BITMAP", "INVERTED", "FTS"}
+
+
+def _scalar_index_type_name(index_type: str | IndexConfig) -> str | None:
+    if isinstance(index_type, str):
+        return index_type.upper()
+    if isinstance(index_type, IndexConfig):
+        return index_type.index_type.upper()
+    return None
+
+
+def _handle_scalar_segment_index(
+    dataset_uri: str,
+    column: str,
+    index_type: str | IndexConfig,
+    name: str,
+    train: bool,
+    storage_options: Optional[dict[str, str]] = None,
+    block_size: Optional[int] = None,
+    namespace_impl: Optional[str] = None,
+    namespace_properties: Optional[dict[str, str]] = None,
+    table_id: Optional[list[str]] = None,
+    **kwargs: Any,
+):
+    """Create a fragment handler closure for scalar segment index builds."""
+
+    def func(fragment_ids: list[int]) -> dict[str, Any]:
+        try:
+            if not fragment_ids:
+                raise ValueError("fragment_ids cannot be empty")
+
+            for fragment_id in fragment_ids:
+                if fragment_id < 0 or fragment_id > 0xFFFFFFFF:
+                    raise ValueError(f"Invalid fragment_id: {fragment_id}")
+
+            namespace_kwargs = get_namespace_kwargs(
+                namespace_impl, namespace_properties, table_id
+            )
+            dataset = LanceDataset(
+                dataset_uri,
+                **_dataset_load_kwargs(storage_options, namespace_kwargs, block_size),
+            )
+
+            available_fragments = {f.fragment_id for f in dataset.get_fragments()}
+            invalid_fragments = set(fragment_ids) - available_fragments
+            if invalid_fragments:
+                raise ValueError(f"Fragment IDs {invalid_fragments} do not exist")
+
+            logger.info(
+                "Building distributed scalar segment index for fragments %s using "
+                "create_index_uncommitted",
+                fragment_ids,
+            )
+
+            segment_index = dataset.create_index_uncommitted(
+                column=column,
+                index_type=index_type,
+                name=name,
+                replace=False,
+                train=train,
+                storage_options=storage_options,
+                fragment_ids=fragment_ids,
+                **kwargs,
+            )
+
+            logger.info(
+                "Fragment scalar segment index created successfully for fragments %s",
+                fragment_ids,
+            )
+
+            return {
+                "status": "success",
+                "fragment_ids": fragment_ids,
+                "segment_index": segment_index,
+            }
+
+        except Exception as exc:  # pragma: no cover - exercised via integration tests
+            logger.error(
+                "Fragment scalar segment index task failed for fragments %s: %s",
+                fragment_ids,
+                exc,
+            )
+            return {
+                "status": "error",
+                "fragment_ids": fragment_ids,
+                "error": str(exc),
+            }
+
+    return func
+
+
 def _handle_fragment_index(
     dataset_uri: str,
     column: str,
@@ -398,13 +489,6 @@ def create_scalar_index(
                 f"Index type must be one of {valid_index_types}, not '{index_type}'"
             )
 
-        supported_distributed_types = {"INVERTED", "FTS", "BTREE", "BITMAP"}
-        if index_type not in supported_distributed_types:
-            raise ValueError(
-                "Distributed indexing currently supports "
-                f"{sorted(supported_distributed_types)} index types, "
-                f"not '{index_type}'"
-            )
     elif not isinstance(index_type, IndexConfig):
         raise ValueError(
             "index_type must be a string literal or IndexConfig object, got "
@@ -476,6 +560,10 @@ def create_scalar_index(
                 # For other index types, skip strict validation to maintain compatibility
                 pass
 
+    use_segment_workflow = (
+        _scalar_index_type_name(index_type) in _SCALAR_SEGMENT_INDEX_TYPES
+    )
+
     if name is None:
         name = f"{column}_idx"
 
@@ -535,6 +623,21 @@ def create_scalar_index(
     fragment_batches = _distribute_fragments_balanced(fragments, num_workers, logger)
 
     def create_fragment_handler() -> Any:
+        if use_segment_workflow:
+            return _handle_scalar_segment_index(
+                dataset_uri=uri,
+                column=column,
+                index_type=index_type,
+                name=name,
+                train=train,
+                storage_options=merged_storage_options,
+                block_size=block_size,
+                namespace_impl=namespace_impl,
+                namespace_properties=namespace_properties,
+                table_id=table_id,
+                **kwargs,
+            )
+
         return _handle_fragment_index(
             dataset_uri=uri,
             column=column,
@@ -576,6 +679,33 @@ def create_scalar_index(
         **_dataset_load_kwargs(merged_storage_options, namespace_kwargs, block_size),
     )
 
+    successful_results = [r for r in results if r["status"] == "success"]
+    if not successful_results:
+        raise RuntimeError("No successful index creation results found")
+
+    if use_segment_workflow:
+        logger.info(
+            "Phase 2: Committing scalar distributed index segments for index '%s'",
+            name,
+        )
+
+        updated_dataset = dataset.commit_existing_index_segments(
+            index_name=name,
+            column=column,
+            segments=[r["segment_index"] for r in successful_results],
+        )
+
+        logger.info(
+            "Successfully created distributed scalar segment index '%s'",
+            name,
+        )
+        logger.info(
+            "Fragments: %d, Workers: %d",
+            len(fragment_ids_to_use),
+            len(fragment_batches),
+        )
+        return updated_dataset
+
     logger.info("Phase 2: Merging index metadata for index ID: %s", index_id)
     # Convert IndexConfig to string for merge_index_metadata which expects a string
     # (lance's create_scalar_index converts IndexConfig to "scalar" internally)
@@ -583,10 +713,6 @@ def create_scalar_index(
     merge_index_metadata_compat(dataset, index_id, index_type=index_type_str, **kwargs)
 
     logger.info("Phase 3: Creating and committing scalar index '%s'", name)
-
-    successful_results = [r for r in results if r["status"] == "success"]
-    if not successful_results:
-        raise RuntimeError("No successful index creation results found")
 
     fields = successful_results[0]["fields"]
 
@@ -1309,18 +1435,10 @@ def create_index(
     if not successful_results:
         raise RuntimeError("No successful vector index creation results found")
 
-    segment_indices = [r["segment_index"] for r in successful_results]
-    segment_builder = (
-        dataset_obj.create_index_segment_builder()
-        .with_index_type(index_type_name)
-        .with_segments(segment_indices)
-    )
-    segments = segment_builder.build_all()
-
     updated_dataset = dataset_obj.commit_existing_index_segments(
         index_name=name,
         column=column,
-        segments=segments,
+        segments=[r["segment_index"] for r in successful_results],
     )
 
     logger.info(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=7.0.0b7",
+    "pylance>=8.0.0b11",
     "lance-namespace",
     "packaging",
     "pyarrow>=17.0.0",

--- a/tests/test_distributed_indexing.py
+++ b/tests/test_distributed_indexing.py
@@ -745,8 +745,9 @@ class TestDistributedIndexing:
 
     def test_distributed_fts_index_new_api(self, temp_dir):
         """
-        Test distributed FTS index building using the new API from PR #4578.
-        This test demonstrates the new workflow with execute_uncommitted() and merge_index_metadata().
+        Test distributed FTS index building using Lance's segment FTS API.
+        This test demonstrates the segment workflow with create_index_uncommitted()
+        and commit_existing_index_segments().
         """
         # Generate test dataset with multiple fragments
         ds = generate_multi_fragment_dataset(
@@ -915,12 +916,54 @@ class TestDistributedBTreeIndexing:
             filter=f"id = {eq_id}", columns=["id", "text"]
         ).to_table()
         assert eq_tbl.num_rows == 1
+        eq_plan = updated_dataset.scanner(
+            filter=f"id = {eq_id}",
+            columns=["id"],
+            use_scalar_index=True,
+        ).explain_plan()
+        assert "ScalarIndexQuery" in eq_plan
+        assert "btree_multiple_fragment_idx" in eq_plan
 
         rg_tbl = updated_dataset.scanner(
             filter="id >= 200 AND id < 800",
             columns=["id", "text"],
         ).to_table()
         assert rg_tbl.num_rows > 0
+
+    def test_distributed_bitmap_index_basic(self, temp_dir):
+        """Build a distributed BITMAP index and verify equality search uses it."""
+        ds = generate_multi_fragment_dataset(
+            temp_dir, num_fragments=3, rows_per_fragment=500
+        )
+
+        updated_dataset = lr.create_scalar_index(
+            uri=ds.uri,
+            column="fragment_id",
+            index_type="BITMAP",
+            name="bitmap_fragment_idx",
+            replace=False,
+            num_workers=3,
+        )
+
+        indices = updated_dataset.list_indices()
+        our_index = next(
+            (idx for idx in indices if idx["name"] == "bitmap_fragment_idx"),
+            None,
+        )
+        assert our_index is not None, "BITMAP index not found by name"
+
+        tbl = updated_dataset.scanner(
+            filter="fragment_id = 1", columns=["id", "fragment_id"]
+        ).to_table()
+        assert tbl.num_rows == 500
+
+        plan = updated_dataset.scanner(
+            filter="fragment_id = 1",
+            columns=["id"],
+            use_scalar_index=True,
+        ).explain_plan()
+        assert "ScalarIndexQuery" in plan
+        assert "bitmap_fragment_idx" in plan
 
     @pytest.fixture
     def btree_comp_datasets(self, tmp_path):
@@ -1534,6 +1577,13 @@ def test_build_distributed_vector_index(tmp_path, index_type):
     )
 
     assert result.num_rows == 5
+
+    plan = updated_dataset.scanner(
+        nearest={"column": "vector", "q": q, "k": 5},
+        columns=["id"],
+    ).explain_plan()
+    assert "ANNSubIndex" in plan
+    assert f"idx_{index_type}" in plan
 
 
 @pytest.mark.parametrize("index_type", ["IVF_FLAT", "IVF_PQ"])

--- a/tests/test_vector_index_options.py
+++ b/tests/test_vector_index_options.py
@@ -291,12 +291,12 @@ def test_create_scalar_index_passes_block_size_to_loads_and_handler(monkeypatch)
         captured["loads"].append(kwargs)
         return fake_dataset
 
-    def fake_handle_fragment_index(**kwargs):
+    def fake_handle_scalar_segment_index(**kwargs):
         captured["fragment_handler_kwargs"] = kwargs
         return lambda fragment_ids: {
             "status": "success",
             "fragment_ids": fragment_ids,
-            "fields": [7],
+            "segment_index": "segment",
         }
 
     def fake_map_async_with_pool(**kwargs):
@@ -306,18 +306,248 @@ def test_create_scalar_index_passes_block_size_to_loads_and_handler(monkeypatch)
             {
                 "status": "success",
                 "fragment_ids": [0, 1],
-                "fields": [7],
+                "segment_index": "segment",
             }
         ]
 
     monkeypatch.setattr(index_mod, "LanceDataset", fake_lance_dataset)
     monkeypatch.setattr(
         index_mod,
-        "_handle_fragment_index",
-        fake_handle_fragment_index,
+        "_handle_scalar_segment_index",
+        fake_handle_scalar_segment_index,
     )
     monkeypatch.setattr(index_mod, "_map_async_with_pool", fake_map_async_with_pool)
-    monkeypatch.setattr(index_mod, "merge_index_metadata_compat", lambda *a, **k: None)
+
+    updated_dataset = index_mod.create_scalar_index(
+        uri="memory://fake",
+        column="value",
+        index_type="BTREE",
+        num_workers=2,
+        block_size=4096,
+    )
+
+    assert updated_dataset is fake_dataset
+    assert [load["block_size"] for load in captured["loads"]] == [4096, 4096]
+    assert captured["fragment_handler_kwargs"]["block_size"] == 4096
+
+
+def test_create_scalar_index_uses_segment_path_for_bitmap(monkeypatch):
+    """BITMAP should use the segment workflow in pylance 8.0."""
+
+    captured = {"loads": []}
+    fake_dataset = _FakeDataset()
+
+    def fake_lance_dataset(*args, **kwargs):
+        captured["loads"].append(kwargs)
+        return fake_dataset
+
+    def fake_handle_scalar_segment_index(**kwargs):
+        captured["fragment_handler_kwargs"] = kwargs
+        return lambda fragment_ids: {
+            "status": "success",
+            "fragment_ids": fragment_ids,
+            "segment_index": "segment",
+        }
+
+    def fake_map_async_with_pool(**kwargs):
+        kwargs["create_fragment_handler"]()
+        return [
+            {
+                "status": "success",
+                "fragment_ids": [0, 1],
+                "segment_index": "segment",
+            }
+        ]
+
+    monkeypatch.setattr(index_mod, "LanceDataset", fake_lance_dataset)
+    monkeypatch.setattr(
+        index_mod,
+        "_handle_scalar_segment_index",
+        fake_handle_scalar_segment_index,
+    )
+    monkeypatch.setattr(index_mod, "_map_async_with_pool", fake_map_async_with_pool)
+
+    updated_dataset = index_mod.create_scalar_index(
+        uri="memory://fake",
+        column="value",
+        index_type="BITMAP",
+        num_workers=2,
+        block_size=4096,
+    )
+
+    assert updated_dataset is fake_dataset
+    assert captured["fragment_handler_kwargs"]["index_type"] == "BITMAP"
+    assert captured["fragment_handler_kwargs"]["block_size"] == 4096
+    assert fake_dataset.commit_kwargs["segments"] == ["segment"]
+
+
+def test_create_scalar_index_uses_segment_path_for_supported_index_config(monkeypatch):
+    """IndexConfig should use segment workflow when its index type supports it."""
+
+    captured = {}
+    fake_dataset = _FakeDataset()
+    index_config = index_mod.IndexConfig("BTREE", {})
+
+    def fake_handle_scalar_segment_index(**kwargs):
+        captured["fragment_handler_kwargs"] = kwargs
+        return lambda fragment_ids: {
+            "status": "success",
+            "fragment_ids": fragment_ids,
+            "segment_index": "segment",
+        }
+
+    def fake_map_async_with_pool(**kwargs):
+        kwargs["create_fragment_handler"]()
+        return [
+            {
+                "status": "success",
+                "fragment_ids": [0, 1],
+                "segment_index": "segment",
+            }
+        ]
+
+    monkeypatch.setattr(index_mod, "LanceDataset", lambda *a, **k: fake_dataset)
+    monkeypatch.setattr(
+        index_mod,
+        "_handle_scalar_segment_index",
+        fake_handle_scalar_segment_index,
+    )
+    monkeypatch.setattr(index_mod, "_map_async_with_pool", fake_map_async_with_pool)
+
+    updated_dataset = index_mod.create_scalar_index(
+        uri="memory://fake",
+        column="value",
+        index_type=index_config,
+        num_workers=2,
+    )
+
+    assert updated_dataset is fake_dataset
+    assert captured["fragment_handler_kwargs"]["index_type"] is index_config
+    assert fake_dataset.commit_kwargs["segments"] == ["segment"]
+
+
+@pytest.mark.parametrize("index_type", ["LABEL_LIST", "NGRAM", "ZONEMAP"])
+def test_create_scalar_index_uses_legacy_path_for_non_segment_types(
+    monkeypatch, index_type
+):
+    """Non-segment scalar types should keep the legacy distributed workflow."""
+
+    captured = {"loads": []}
+    fake_dataset = _FakeDataset()
+
+    def fake_lance_dataset(*args, **kwargs):
+        captured["loads"].append(kwargs)
+        return fake_dataset
+
+    def fake_handle_fragment_index(**kwargs):
+        captured["legacy_handler_kwargs"] = kwargs
+        return lambda fragment_ids: {
+            "status": "success",
+            "fragment_ids": fragment_ids,
+            "fields": [7],
+        }
+
+    def fake_map_async_with_pool(**kwargs):
+        kwargs["create_fragment_handler"]()
+        return [
+            {
+                "status": "success",
+                "fragment_ids": [0, 1],
+                "fields": [7],
+            }
+        ]
+
+    def fake_merge_index_metadata(dataset, index_id, index_type, **kwargs):
+        captured["merge"] = {
+            "dataset": dataset,
+            "index_id": index_id,
+            "index_type": index_type,
+            "kwargs": kwargs,
+        }
+
+    def fake_commit(*args, **kwargs):
+        captured["commit"] = {"args": args, "kwargs": kwargs}
+        return fake_dataset
+
+    monkeypatch.setattr(index_mod, "LanceDataset", fake_lance_dataset)
+    monkeypatch.setattr(index_mod, "_handle_fragment_index", fake_handle_fragment_index)
+    monkeypatch.setattr(index_mod, "_map_async_with_pool", fake_map_async_with_pool)
+    monkeypatch.setattr(
+        index_mod,
+        "merge_index_metadata_compat",
+        fake_merge_index_metadata,
+    )
+    monkeypatch.setattr(index_mod, "Index", SimpleNamespace)
+    monkeypatch.setattr(
+        index_mod.lance,
+        "LanceDataset",
+        SimpleNamespace(commit=fake_commit),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        index_mod.lance,
+        "LanceOperation",
+        SimpleNamespace(CreateIndex=SimpleNamespace),
+        raising=False,
+    )
+
+    updated_dataset = index_mod.create_scalar_index(
+        uri="memory://fake",
+        column="value",
+        index_type=index_type,
+        num_workers=2,
+        block_size=4096,
+    )
+
+    assert updated_dataset is fake_dataset
+    assert captured["legacy_handler_kwargs"]["index_type"] == index_type
+    assert captured["legacy_handler_kwargs"]["block_size"] == 4096
+    assert captured["merge"]["index_type"] == index_type
+    assert "commit" in captured
+    assert not hasattr(fake_dataset, "commit_kwargs")
+
+
+def test_create_scalar_index_uses_legacy_path_for_index_config(monkeypatch):
+    """Non-segment IndexConfig should keep the legacy distributed workflow."""
+
+    captured = {}
+    fake_dataset = _FakeDataset()
+    index_config = index_mod.IndexConfig("ZONEMAP", {})
+
+    def fake_handle_fragment_index(**kwargs):
+        captured["legacy_handler_kwargs"] = kwargs
+        return lambda fragment_ids: {
+            "status": "success",
+            "fragment_ids": fragment_ids,
+            "fields": [7],
+        }
+
+    def fake_map_async_with_pool(**kwargs):
+        kwargs["create_fragment_handler"]()
+        return [
+            {
+                "status": "success",
+                "fragment_ids": [0, 1],
+                "fields": [7],
+            }
+        ]
+
+    def fake_merge_index_metadata(dataset, index_id, index_type, **kwargs):
+        captured["merge"] = {
+            "dataset": dataset,
+            "index_id": index_id,
+            "index_type": index_type,
+            "kwargs": kwargs,
+        }
+
+    monkeypatch.setattr(index_mod, "LanceDataset", lambda *a, **k: fake_dataset)
+    monkeypatch.setattr(index_mod, "_handle_fragment_index", fake_handle_fragment_index)
+    monkeypatch.setattr(index_mod, "_map_async_with_pool", fake_map_async_with_pool)
+    monkeypatch.setattr(
+        index_mod,
+        "merge_index_metadata_compat",
+        fake_merge_index_metadata,
+    )
     monkeypatch.setattr(index_mod, "Index", SimpleNamespace)
     monkeypatch.setattr(
         index_mod.lance,
@@ -335,14 +565,14 @@ def test_create_scalar_index_passes_block_size_to_loads_and_handler(monkeypatch)
     updated_dataset = index_mod.create_scalar_index(
         uri="memory://fake",
         column="value",
-        index_type="BTREE",
+        index_type=index_config,
         num_workers=2,
-        block_size=4096,
     )
 
     assert updated_dataset is fake_dataset
-    assert [load["block_size"] for load in captured["loads"]] == [4096, 4096]
-    assert captured["fragment_handler_kwargs"]["block_size"] == 4096
+    assert captured["legacy_handler_kwargs"]["index_type"] is index_config
+    assert captured["merge"]["index_type"] == "scalar"
+    assert not hasattr(fake_dataset, "commit_kwargs")
 
 
 def test_create_index_passes_block_size_to_loads_and_handler(monkeypatch):
@@ -434,13 +664,11 @@ def test_fragment_handlers_pass_block_size_to_dataset_load(monkeypatch):
 
     monkeypatch.setattr(index_mod, "LanceDataset", fake_lance_dataset)
 
-    scalar_handler = index_mod._handle_fragment_index(
+    scalar_handler = index_mod._handle_scalar_segment_index(
         dataset_uri="memory://fake",
         column="value",
         index_type="BTREE",
         name="value_idx",
-        index_uuid="scalar-index",
-        replace=False,
         train=True,
         block_size=4096,
     )

--- a/uv.lock
+++ b/uv.lock
@@ -326,19 +326,19 @@ wheels = [
 
 [[package]]
 name = "lance-namespace"
-version = "0.7.6"
+version = "0.8.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/da/134670003173881bed44af656badffd91e0b2e0232c083eeacc5923d7335/lance_namespace-0.7.6.tar.gz", hash = "sha256:4e12094005d105ef1b44346c9d7feda4a0f733b127dab90c1a5ffbf7cd433770", size = 10686, upload-time = "2026-05-05T18:26:38.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/8f/8a03395587a78cfaf92f7307ad931f61eb515af67705c704bd6c7af2f745/lance_namespace-0.8.4.tar.gz", hash = "sha256:1a54ad49e7ace25a629c5f2c99d393629742eceeeb16ba2f51a771ccb350e284", size = 11282, upload-time = "2026-06-10T19:07:21.919Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/88/44463a5f41f7077b2ea641f2afded72eaceb6a6a1b4a55c11b22318fed74/lance_namespace-0.7.6-py3-none-any.whl", hash = "sha256:c94a1b8a6aab127e55a20cbf44d927ae3a9b7d435656d2130dccf84ccf7c9999", size = 12519, upload-time = "2026-05-05T18:26:36.425Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/4b/218c67cafb707024069925ce86534588861a464aaa327f7a457b94eed3c2/lance_namespace-0.8.4-py3-none-any.whl", hash = "sha256:8b347eef4b7c7187a1b52f388b5dcc345fed0bf4ea87728188dcb11a52619d0b", size = 13111, upload-time = "2026-06-10T19:07:22.6Z" },
 ]
 
 [[package]]
 name = "lance-namespace-urllib3-client"
-version = "0.7.6"
+version = "0.8.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -346,9 +346,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/44/024aae184c08b3800482cd9b832d534249e25de145af732d4e4c8dff38a8/lance_namespace_urllib3_client-0.7.6.tar.gz", hash = "sha256:15ae7f0d8d56fa34d837f7f6ec5c80a327a905e89ccfed05f7b409d6fe704cdf", size = 195551, upload-time = "2026-05-05T18:26:37.808Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/55/4a7cc7e5d19bda170c896a6adff2ec925c533df812b91bce2bc8f7aea30b/lance_namespace_urllib3_client-0.8.4.tar.gz", hash = "sha256:1a292a83509ab79475da967b78839e9ead4ab973064d37d1ba1575b23ffdacef", size = 228485, upload-time = "2026-06-10T19:07:19.863Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/50/60c983cc8180772c82370dfad2104b7e788aaacc3bf9a84e8b42bb1ae6a7/lance_namespace_urllib3_client-0.7.6-py3-none-any.whl", hash = "sha256:fb884d8afff8af3aae04a3270624694a189d7ea79225dd349e6c555a1a1d6b52", size = 324603, upload-time = "2026-05-05T18:26:39.718Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/f7/70dd2fc1f9ef462d3802b4cffcd64f2b9233a9907d6071e8694338492608/lance_namespace_urllib3_client-0.8.4-py3-none-any.whl", hash = "sha256:37ee1d74614fae6358f50e3589ac26c29379ffb1346f09c4f5ec8953f823cefd", size = 369807, upload-time = "2026-06-10T19:07:21.001Z" },
 ]
 
 [[package]]
@@ -387,7 +387,7 @@ requires-dist = [
     { name = "more-itertools", marker = "python_full_version < '3.12'", specifier = ">=2.6.0" },
     { name = "packaging" },
     { name = "pyarrow", specifier = ">=17.0.0" },
-    { name = "pylance", specifier = ">=7.0.0b7" },
+    { name = "pylance", specifier = ">=8.0.0b11" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
@@ -1024,7 +1024,7 @@ wheels = [
 
 [[package]]
 name = "pylance"
-version = "7.0.0b7"
+version = "8.0.0b11"
 source = { registry = "https://pypi.fury.io/lance-format" }
 dependencies = [
     { name = "lance-namespace" },
@@ -1033,12 +1033,12 @@ dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://pypi.fury.io/lance-format/-/ver_1zsVV4/pylance-7.0.0b7-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:66f2ba7969c0fad259f5d13842e89d664956c1415eed644d6956af333e848a62" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1TtYis/pylance-7.0.0b7-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:029ac2359cccbac62345392c78f5aae6596eda4a3398fbf8bef5aad708591d14" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_uZkce/pylance-7.0.0b7-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a53841757573d7c63238d79df94236eb6e46d9508d2690d98ce983e5d04f8c7a" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_3iSeD/pylance-7.0.0b7-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:34c67a0102d47f870d4b795087622c16087aa1928c1925b1acdeb61206f4663a" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_BpURn/pylance-7.0.0b7-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ac70f0248239b50ae718e38e69c1418899a1a7575e7b911beac91eeb60b174ec" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_jVZS2/pylance-7.0.0b7-cp39-abi3-win_amd64.whl", hash = "sha256:0f1caea57ea998f6e59dcb2684a08e4b06f993ecc77c8d0f032a4a43a82ed085" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_GL5dn/pylance-8.0.0b11-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:2f2e66c6a7039ba51ac6174d0336b4f38a58351706e16b8b21a6c71f06cd1f20" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1pVrmn/pylance-8.0.0b11-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f85711b2f468acfe20ad2542639b82e9658ed301d72f5cfde82e2e40ef431b15" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1qcBDw/pylance-8.0.0b11-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:602af5469141d0c6667d902f6819cd2b7b5ce40193190be6a030adc753a36fe7" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1V5g0y/pylance-8.0.0b11-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:b6b89f48f198b3fe59ad795bac614a1cc8892e20f2ba2acd1f958a18d05e4b32" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_7rhla/pylance-8.0.0b11-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:4c8b16c860345f3c519dc28dd4dab111bdc2c104795c1c7fb3f245d798f64792" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1f0tKO/pylance-8.0.0b11-cp39-abi3-win_amd64.whl", hash = "sha256:66297c0a3708e4b6921d6430153d2cb89f7a618110bf8d119cb9986a81a6371c" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Background

Lance 8 moves distributed index builds onto the index segment workflow. The key upstream change for this PR is lance-format/lance#7170, which exposes segment FTS builds through `create_index_uncommitted(...)`; in the same Lance 8 API surface, fragment-level `BTREE` and `BITMAP` distributed builds are also directed through `create_index_uncommitted(...)` instead of `create_scalar_index(..., fragment_ids=...)`.

This updates lance-ray to use Lance's index segment workflow with `pylance>=8.0.0b11`.

## Changes

- Bump the `pylance` requirement to `>=8.0.0b11`.
- Update distributed vector indexing to commit `create_index_uncommitted(...)` results directly with `commit_existing_index_segments(...)`, instead of using `create_index_segment_builder()`.
- Route Lance 8 segment-backed scalar index types through `create_index_uncommitted(...)` + `commit_existing_index_segments(...)`: `BTREE`, `BITMAP`, `INVERTED` / `FTS`, and matching `IndexConfig` values.
- Keep non-segment scalar types such as `LABEL_LIST`, `NGRAM`, and `ZONEMAP` on the existing legacy distributed scalar-index workflow.
- Update focused tests and docs for the segment return/commit flow and indexed query plans.