### PR TITLE
feat: support namespace-only add column operations

### DIFF
--- a/lance_ray/compaction.py
+++ b/lance_ray/compaction.py
@@ -9,6 +9,7 @@ from ray.util.multiprocessing import Pool
 from .utils import (
     get_namespace_kwargs,
     get_or_create_namespace,
+    resolve_namespace_table,
     validate_uri_or_namespace,
 )
 
@@ -118,19 +119,10 @@ def compact_files(
     """
     validate_uri_or_namespace(uri, namespace_impl, table_id)
 
-    merged_storage_options: dict[str, Any] = {}
-    if storage_options:
-        merged_storage_options.update(storage_options)
-
     # Resolve URI and get storage options from namespace if provided
-    namespace = get_or_create_namespace(namespace_impl, namespace_properties)
-    if namespace is not None and table_id is not None:
-        from lance_namespace import DescribeTableRequest
-
-        describe_response = namespace.describe_table(DescribeTableRequest(id=table_id))
-        uri = describe_response.location
-        if describe_response.storage_options:
-            merged_storage_options.update(describe_response.storage_options)
+    uri, merged_storage_options = resolve_namespace_table(
+        uri, storage_options, namespace_impl, namespace_properties, table_id
+    )
 
     namespace_kwargs = get_namespace_kwargs(
         namespace_impl, namespace_properties, table_id

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -16,7 +16,8 @@ from ray.util.multiprocessing import Pool
 
 from .utils import (
     get_namespace_kwargs,
-    get_or_create_namespace,
+    has_namespace_params,
+    resolve_namespace_table,
     validate_uri_or_namespace,
 )
 
@@ -415,19 +416,10 @@ def create_scalar_index(
     # Note: Ray initialization is now handled by the Pool, following the pattern from io.py
     # This removes the need for explicit ray.init() calls
 
-    merged_storage_options: dict[str, Any] = {}
-    if storage_options:
-        merged_storage_options.update(storage_options)
-
     # Resolve URI and get storage options from namespace if provided
-    namespace = get_or_create_namespace(namespace_impl, namespace_properties)
-    if namespace is not None and table_id is not None:
-        from lance_namespace import DescribeTableRequest
-
-        describe_response = namespace.describe_table(DescribeTableRequest(id=table_id))
-        uri = describe_response.location
-        if describe_response.storage_options:
-            merged_storage_options.update(describe_response.storage_options)
+    uri, merged_storage_options = resolve_namespace_table(
+        uri, storage_options, namespace_impl, namespace_properties, table_id
+    )
 
     namespace_kwargs = get_namespace_kwargs(
         namespace_impl, namespace_properties, table_id
@@ -884,17 +876,9 @@ def create_index(
         validate_uri_or_namespace(uri, namespace_impl, table_id)
 
         # Resolve URI and storage options from namespace if provided
-        namespace = get_or_create_namespace(namespace_impl, namespace_properties)
-        if namespace is not None and table_id is not None:
-            from lance_namespace import DescribeTableRequest
-
-            describe_response = namespace.describe_table(
-                DescribeTableRequest(id=table_id)
-            )
-            uri = describe_response.location
-            if describe_response.storage_options:
-                merged_storage_options.update(describe_response.storage_options)
-
+        uri, merged_storage_options = resolve_namespace_table(
+            uri, storage_options, namespace_impl, namespace_properties, table_id
+        )
         dataset_uri = uri
         namespace_kwargs = get_namespace_kwargs(
             namespace_impl, namespace_properties, table_id
@@ -1185,18 +1169,13 @@ def optimize_indices(
     )
     validate_uri_or_namespace(uri, namespace_impl, table_id)
 
-    merged_storage_options: dict[str, Any] = {}
-    if storage_options:
-        merged_storage_options.update(storage_options)
-
-    namespace = get_or_create_namespace(namespace_impl, namespace_properties)
-    if namespace is not None and table_id is not None:
-        from lance_namespace import DescribeTableRequest
-
-        describe_response = namespace.describe_table(DescribeTableRequest(id=table_id))
-        uri = describe_response.location
-        if describe_response.storage_options:
-            merged_storage_options.update(describe_response.storage_options)
+    resolve_from_namespace = uri is None and has_namespace_params(
+        namespace_impl, table_id
+    )
+    uri, merged_storage_options = resolve_namespace_table(
+        uri, storage_options, namespace_impl, namespace_properties, table_id
+    )
+    if resolve_from_namespace:
         logger.info(
             "Resolved dataset URI from namespace (table_id=%s): %s",
             table_id,

--- a/lance_ray/io.py
+++ b/lance_ray/io.py
@@ -19,10 +19,10 @@ from .datasource import LanceDatasource
 from .fragment import prepare_fragment_write_options
 from .utils import (
     get_namespace_kwargs,
-    get_or_create_namespace,
     has_namespace_params,
     materialize_initial_bases,
     normalize_initial_bases,
+    resolve_namespace_table,
     validate_uri_or_namespace,
 )
 
@@ -35,40 +35,6 @@ if TYPE_CHECKING:
         | ReaderLike
         | Callable[[pa.RecordBatch], pa.RecordBatch]
     )
-
-
-def _resolve_namespace_table(
-    uri: Optional[str],
-    storage_options: Optional[dict[str, Any]],
-    namespace_impl: Optional[str],
-    namespace_properties: Optional[dict[str, str]],
-    table_id: Optional[list[str]],
-) -> tuple[str, dict[str, Any]]:
-    """Resolve table location and storage options from namespace if available."""
-    resolved_uri = uri
-    merged_storage_options = dict(storage_options or {})
-
-    if has_namespace_params(namespace_impl, table_id):
-        namespace = get_or_create_namespace(namespace_impl, namespace_properties)
-        if namespace is not None:
-            from lance_namespace import DescribeTableRequest
-
-            describe_response = namespace.describe_table(
-                DescribeTableRequest(id=table_id)
-            )
-            if resolved_uri is None:
-                resolved_uri = describe_response.location
-                if resolved_uri is None:
-                    raise ValueError(
-                        "Namespace did not return a 'location' for the table"
-                    )
-            if describe_response.storage_options:
-                merged_storage_options.update(describe_response.storage_options)
-
-    if resolved_uri is None:
-        raise ValueError("Must provide either 'uri' OR ('namespace_impl' + 'table_id').")
-
-    return resolved_uri, merged_storage_options
 
 
 def read_lance(
@@ -591,7 +557,7 @@ def add_columns(
     """
     validate_uri_or_namespace(uri, namespace_impl, table_id)
 
-    uri, storage_options = _resolve_namespace_table(
+    uri, storage_options = resolve_namespace_table(
         uri,
         storage_options,
         namespace_impl,
@@ -932,7 +898,7 @@ def merge_columns_from(
 
     validate_uri_or_namespace(uri, namespace_impl, table_id)
 
-    uri, storage_options = _resolve_namespace_table(
+    uri, storage_options = resolve_namespace_table(
         uri,
         storage_options,
         namespace_impl,

--- a/lance_ray/io.py
+++ b/lance_ray/io.py
@@ -19,6 +19,7 @@ from .datasource import LanceDatasource
 from .fragment import prepare_fragment_write_options
 from .utils import (
     get_namespace_kwargs,
+    get_or_create_namespace,
     has_namespace_params,
     materialize_initial_bases,
     normalize_initial_bases,
@@ -34,6 +35,40 @@ if TYPE_CHECKING:
         | ReaderLike
         | Callable[[pa.RecordBatch], pa.RecordBatch]
     )
+
+
+def _resolve_namespace_table(
+    uri: Optional[str],
+    storage_options: Optional[dict[str, Any]],
+    namespace_impl: Optional[str],
+    namespace_properties: Optional[dict[str, str]],
+    table_id: Optional[list[str]],
+) -> tuple[str, dict[str, Any]]:
+    """Resolve table location and storage options from namespace if available."""
+    resolved_uri = uri
+    merged_storage_options = dict(storage_options or {})
+
+    if has_namespace_params(namespace_impl, table_id):
+        namespace = get_or_create_namespace(namespace_impl, namespace_properties)
+        if namespace is not None:
+            from lance_namespace import DescribeTableRequest
+
+            describe_response = namespace.describe_table(
+                DescribeTableRequest(id=table_id)
+            )
+            if resolved_uri is None:
+                resolved_uri = describe_response.location
+                if resolved_uri is None:
+                    raise ValueError(
+                        "Namespace did not return a 'location' for the table"
+                    )
+            if describe_response.storage_options:
+                merged_storage_options.update(describe_response.storage_options)
+
+    if resolved_uri is None:
+        raise ValueError("Must provide either 'uri' OR ('namespace_impl' + 'table_id').")
+
+    return resolved_uri, merged_storage_options
 
 
 def read_lance(
@@ -496,7 +531,7 @@ def _handle_fragment(
 
 
 def add_columns(
-    uri: str,
+    uri: Optional[str] = None,
     *,
     transform: "TransformType",
     filter: Optional[str] = None,
@@ -530,7 +565,9 @@ def add_columns(
         >>> lr.add_columns("/tmp/data/", transform=double_score, concurrency=2)
 
     Args:
-        uri: The path to the destination Lance dataset.
+        uri: The path to the destination Lance dataset. If omitted, provide
+            ``namespace_impl`` and ``table_id`` to resolve the location from
+            the namespace.
         transform: The transform to apply to the dataset. It support a lot of types,
             see `LanceDB API doc https://lancedb.github.io/lance-python-doc/data-evolution.html ` for more details.
         filter: The filter to apply to the dataset. It is not supported yet, will be
@@ -552,7 +589,13 @@ def add_columns(
         batch_size: The batch size to use for the reader.
         concurrency: The number of processes to use for the pool.
     """
-    storage_options = storage_options or {}
+    uri, storage_options = _resolve_namespace_table(
+        uri,
+        storage_options,
+        namespace_impl,
+        namespace_properties,
+        table_id,
+    )
 
     namespace_kwargs = get_namespace_kwargs(
         namespace_impl, namespace_properties, table_id
@@ -695,7 +738,7 @@ def _fill_null_fragment(
 
 
 def add_columns_from(
-    uri: str,
+    uri: Optional[str] = None,
     *,
     transform: "TransformType",
     read_columns: Optional[list[str]] = None,
@@ -731,7 +774,9 @@ def add_columns_from(
         >>> lr.add_columns_from("/tmp/data/", transform=compute_name_len)
 
     Args:
-        uri: The path to the destination Lance dataset.
+        uri: The path to the destination Lance dataset. If omitted, provide
+            ``namespace_impl`` and ``table_id`` to resolve the location from
+            the namespace.
         transform: The transform to apply to each batch. It receives a dict
             mapping column names to Python lists (metadata columns like
             ``_rowaddr`` are excluded) and must return only the new columns
@@ -751,14 +796,19 @@ def add_columns_from(
     if read_version is not None:
         dataset_options["version"] = read_version
 
+    uri, storage_options = _resolve_namespace_table(
+        uri,
+        storage_options,
+        namespace_impl,
+        namespace_properties,
+        table_id,
+    )
+
     ray_ds = read_lance(
         uri,
         columns=read_columns,
         dataset_options=dataset_options or None,
         storage_options=storage_options,
-        namespace_impl=namespace_impl,
-        namespace_properties=namespace_properties,
-        table_id=table_id,
         ray_remote_args=ray_remote_args,
         with_metadata=True,
     )
@@ -825,8 +875,8 @@ def add_columns_from(
 
 
 def merge_columns_from(
-    uri: str,
-    ds: Dataset,
+    uri: Optional[str] = None,
+    ds: Optional[Dataset] = None,
     *,
     read_version: Optional[int | str] = None,
     ray_remote_args: Optional[dict[str, Any]] = None,
@@ -860,7 +910,9 @@ def merge_columns_from(
         >>> lr.merge_columns_from("/tmp/data/", ray_ds)
 
     Args:
-        uri: The path to the destination Lance dataset.
+        uri: The path to the destination Lance dataset. If omitted, provide
+            ``namespace_impl`` and ``table_id`` to resolve the location from
+            the namespace.
         ds: A Ray Dataset containing ``_rowaddr`` and the new column(s) to add.
             Every fragment in the target Lance dataset must be represented
             (unless ``require_full_coverage=False``).
@@ -876,7 +928,16 @@ def merge_columns_from(
             target Lance dataset. Set to False to allow merging new columns
             into a subset of fragments only.
     """
-    storage_options = storage_options or {}
+    if ds is None:
+        raise ValueError("'ds' must be provided")
+
+    uri, storage_options = _resolve_namespace_table(
+        uri,
+        storage_options,
+        namespace_impl,
+        namespace_properties,
+        table_id,
+    )
     namespace_kwargs = get_namespace_kwargs(
         namespace_impl, namespace_properties, table_id
     )

--- a/lance_ray/io.py
+++ b/lance_ray/io.py
@@ -589,6 +589,8 @@ def add_columns(
         batch_size: The batch size to use for the reader.
         concurrency: The number of processes to use for the pool.
     """
+    validate_uri_or_namespace(uri, namespace_impl, table_id)
+
     uri, storage_options = _resolve_namespace_table(
         uri,
         storage_options,
@@ -796,19 +798,16 @@ def add_columns_from(
     if read_version is not None:
         dataset_options["version"] = read_version
 
-    uri, storage_options = _resolve_namespace_table(
-        uri,
-        storage_options,
-        namespace_impl,
-        namespace_properties,
-        table_id,
-    )
+    validate_uri_or_namespace(uri, namespace_impl, table_id)
 
     ray_ds = read_lance(
         uri,
         columns=read_columns,
         dataset_options=dataset_options or None,
         storage_options=storage_options,
+        namespace_impl=namespace_impl,
+        namespace_properties=namespace_properties,
+        table_id=table_id,
         ray_remote_args=ray_remote_args,
         with_metadata=True,
     )
@@ -930,6 +929,8 @@ def merge_columns_from(
     """
     if ds is None:
         raise ValueError("'ds' must be provided")
+
+    validate_uri_or_namespace(uri, namespace_impl, table_id)
 
     uri, storage_options = _resolve_namespace_table(
         uri,

--- a/lance_ray/search.py
+++ b/lance_ray/search.py
@@ -15,7 +15,7 @@ from lance.dataset import LanceDataset
 from .pool import get_or_create_pool
 from .utils import (
     get_namespace_kwargs,
-    get_or_create_namespace,
+    resolve_namespace_table,
     validate_uri_or_namespace,
 )
 
@@ -612,16 +612,9 @@ def vector_search(
 
     if isinstance(uri, str | type(None)):
         validate_uri_or_namespace(uri, namespace_impl, table_id)
-        namespace = get_or_create_namespace(namespace_impl, namespace_properties)
-        if namespace is not None and table_id is not None:
-            from lance_namespace import DescribeTableRequest
-
-            describe_response = namespace.describe_table(
-                DescribeTableRequest(id=table_id)
-            )
-            uri = describe_response.location
-            if describe_response.storage_options:
-                merged_storage_options.update(describe_response.storage_options)
+        uri, merged_storage_options = resolve_namespace_table(
+            uri, storage_options, namespace_impl, namespace_properties, table_id
+        )
 
         dataset_uri = uri
         namespace_kwargs = get_namespace_kwargs(

--- a/lance_ray/utils.py
+++ b/lance_ray/utils.py
@@ -193,6 +193,61 @@ def get_or_create_namespace(
     return _get_cached_namespace(namespace_impl, namespace_properties_tuple)
 
 
+def resolve_namespace_table(
+    uri: Optional[str],
+    storage_options: Optional[dict[str, Any]],
+    namespace_impl: Optional[str],
+    namespace_properties: Optional[dict[str, str]],
+    table_id: Optional[list[str]],
+) -> tuple[str, dict[str, Any]]:
+    """Resolve a dataset location and merge namespace-vended storage options.
+
+    Resolution rules:
+
+    - When ``uri`` is provided it is returned as-is and the namespace is *not*
+      consulted for location or storage options. The namespace client is still
+      wired separately (via :func:`get_namespace_kwargs`) for credential
+      refresh, so an explicit ``uri`` never picks up another table's
+      credentials. Callers should additionally call
+      :func:`validate_uri_or_namespace` to reject the ``uri`` + namespace
+      combination up front.
+    - When ``uri`` is ``None`` and namespace parameters are present, the table
+      location is fetched from the namespace via ``describe_table`` and any
+      namespace-returned storage options are merged on top of the caller's
+      (namespace values win).
+
+    Returns:
+        A ``(uri, merged_storage_options)`` tuple with a non-None ``uri``.
+
+    Raises:
+        ValueError: If neither ``uri`` nor a resolvable namespace location is
+            available.
+    """
+    merged_storage_options = dict(storage_options or {})
+
+    if uri is not None:
+        return uri, merged_storage_options
+
+    if has_namespace_params(namespace_impl, table_id):
+        namespace = get_or_create_namespace(namespace_impl, namespace_properties)
+        if namespace is not None:
+            from lance_namespace import DescribeTableRequest
+
+            describe_response = namespace.describe_table(
+                DescribeTableRequest(id=table_id)
+            )
+            location = describe_response.location
+            if location is None:
+                raise ValueError(
+                    "Namespace did not return a 'location' for the table"
+                )
+            if describe_response.storage_options:
+                merged_storage_options.update(describe_response.storage_options)
+            return location, merged_storage_options
+
+    raise ValueError("Must provide either 'uri' OR ('namespace_impl' + 'table_id').")
+
+
 def _create_storage_options_provider(
     namespace_impl: Optional[str],
     namespace_properties: Optional[dict[str, str]],

--- a/tests/test_add_columns_from.py
+++ b/tests/test_add_columns_from.py
@@ -181,7 +181,7 @@ class TestAddColumnsFrom:
         assert df["doubled"].tolist() == [20, 40, 60, 80]
 
     def test_namespace_storage_options_override_local_options(self, monkeypatch):
-        from lance_ray.io import _resolve_namespace_table
+        from lance_ray.utils import resolve_namespace_table
 
         class FakeNamespace:
             def describe_table(self, request):
@@ -197,11 +197,11 @@ class TestAddColumnsFrom:
                 )
 
         monkeypatch.setattr(
-            "lance_ray.io.get_or_create_namespace",
+            "lance_ray.utils.get_or_create_namespace",
             lambda namespace_impl, namespace_properties: FakeNamespace(),
         )
 
-        uri, storage_options = _resolve_namespace_table(
+        uri, storage_options = resolve_namespace_table(
             None,
             {"access_key_id": "local-ak", "region": "us-east-1"},
             "rest",
@@ -217,6 +217,32 @@ class TestAddColumnsFrom:
             "allow_http": "true",
             "region": "us-east-1",
         }
+
+    def test_resolve_namespace_table_prefers_explicit_uri(self, monkeypatch):
+        """An explicit uri must not trigger describe_table or pull foreign creds."""
+        from lance_ray.utils import resolve_namespace_table
+
+        class ExplodingNamespace:
+            def describe_table(self, request):  # pragma: no cover - must not run
+                raise AssertionError(
+                    "describe_table must not be called when uri is provided"
+                )
+
+        monkeypatch.setattr(
+            "lance_ray.utils.get_or_create_namespace",
+            lambda namespace_impl, namespace_properties: ExplodingNamespace(),
+        )
+
+        uri, storage_options = resolve_namespace_table(
+            "s3://bucket-a/table-a.lance",
+            {"access_key_id": "local-ak"},
+            "rest",
+            {"uri": "http://127.0.0.1:9101/lance"},
+            ["lance_catalog", "sales", "orders"],
+        )
+
+        assert uri == "s3://bucket-a/table-a.lance"
+        assert storage_options == {"access_key_id": "local-ak"}
 
     def test_namespace_args_preserved_for_read_lance(self, monkeypatch):
         calls = {}

--- a/tests/test_add_columns_from.py
+++ b/tests/test_add_columns_from.py
@@ -2,11 +2,13 @@
 
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import lance
 import lance_ray as lr
 import pyarrow as pa
 import pytest
+import ray
 
 import pandas as pd
 
@@ -142,6 +144,79 @@ class TestAddColumnsFrom:
         )
         assert result["id"].tolist() == list(range(n_rows))
         assert result["doubled"].tolist() == [x * 20 for x in range(n_rows)]
+
+    def test_namespace_only_resolves_uri(self, temp_dir):
+        table_id = ["acf_namespace_only"]
+        data = pd.DataFrame(
+            {
+                "id": [1, 2, 3, 4],
+                "value": [10, 20, 30, 40],
+            }
+        )
+        lr.write_lance(
+            ray.data.from_pandas(data),
+            namespace_impl="dir",
+            namespace_properties={"root": temp_dir},
+            table_id=table_id,
+            min_rows_per_file=1,
+            max_rows_per_file=2,
+        )
+
+        def add_double(batch):
+            return {"doubled": [int(x) * 2 for x in batch["value"]]}
+
+        lr.add_columns_from(
+            transform=add_double,
+            namespace_impl="dir",
+            namespace_properties={"root": temp_dir},
+            table_id=table_id,
+        )
+
+        result = lr.read_lance(
+            namespace_impl="dir",
+            namespace_properties={"root": temp_dir},
+            table_id=table_id,
+        )
+        df = result.to_pandas().sort_values("id").reset_index(drop=True)
+        assert df["doubled"].tolist() == [20, 40, 60, 80]
+
+    def test_namespace_storage_options_override_local_options(self, monkeypatch):
+        from lance_ray.io import _resolve_namespace_table
+
+        class FakeNamespace:
+            def describe_table(self, request):
+                assert request.id == ["lance_catalog", "sales", "orders"]
+                return SimpleNamespace(
+                    location="s3://contacts/raw/lance/sales/orders.lance",
+                    storage_options={
+                        "endpoint": "http://127.0.0.1:9000",
+                        "access_key_id": "namespace-ak",
+                        "secret_access_key": "namespace-sk",
+                        "allow_http": "true",
+                    },
+                )
+
+        monkeypatch.setattr(
+            "lance_ray.io.get_or_create_namespace",
+            lambda namespace_impl, namespace_properties: FakeNamespace(),
+        )
+
+        uri, storage_options = _resolve_namespace_table(
+            None,
+            {"access_key_id": "local-ak", "region": "us-east-1"},
+            "rest",
+            {"uri": "http://127.0.0.1:9101/lance"},
+            ["lance_catalog", "sales", "orders"],
+        )
+
+        assert uri == "s3://contacts/raw/lance/sales/orders.lance"
+        assert storage_options == {
+            "endpoint": "http://127.0.0.1:9000",
+            "access_key_id": "namespace-ak",
+            "secret_access_key": "namespace-sk",
+            "allow_http": "true",
+            "region": "us-east-1",
+        }
 
 
 class TestMergeColumnsFrom:

--- a/tests/test_add_columns_from.py
+++ b/tests/test_add_columns_from.py
@@ -218,6 +218,81 @@ class TestAddColumnsFrom:
             "region": "us-east-1",
         }
 
+    def test_namespace_args_preserved_for_read_lance(self, monkeypatch):
+        calls = {}
+
+        class FakeRayDataset:
+            def map_batches(self, fn, batch_format=None):
+                calls["map_batches"] = {
+                    "fn": fn,
+                    "batch_format": batch_format,
+                }
+                return self
+
+        def fake_read_lance(*args, **kwargs):
+            calls["read_lance"] = {"args": args, "kwargs": kwargs}
+            return FakeRayDataset()
+
+        def fake_merge_columns_from(*args, **kwargs):
+            calls["merge_columns_from"] = {"args": args, "kwargs": kwargs}
+
+        monkeypatch.setattr("lance_ray.io.read_lance", fake_read_lance)
+        monkeypatch.setattr("lance_ray.io.merge_columns_from", fake_merge_columns_from)
+
+        def add_double(batch):
+            return {"doubled": [int(x) * 2 for x in batch["value"]]}
+
+        lr.add_columns_from(
+            transform=add_double,
+            storage_options={"region": "us-east-1"},
+            namespace_impl="rest",
+            namespace_properties={"uri": "http://127.0.0.1:9101/lance"},
+            table_id=["lance_catalog", "sales", "orders"],
+        )
+
+        read_kwargs = calls["read_lance"]["kwargs"]
+        assert calls["read_lance"]["args"] == (None,)
+        assert read_kwargs["namespace_impl"] == "rest"
+        assert read_kwargs["namespace_properties"] == {
+            "uri": "http://127.0.0.1:9101/lance"
+        }
+        assert read_kwargs["table_id"] == ["lance_catalog", "sales", "orders"]
+        assert read_kwargs["storage_options"] == {"region": "us-east-1"}
+        assert read_kwargs["with_metadata"] is True
+
+        merge_kwargs = calls["merge_columns_from"]["kwargs"]
+        assert calls["merge_columns_from"]["args"][0] is None
+        assert merge_kwargs["namespace_impl"] == "rest"
+        assert merge_kwargs["table_id"] == ["lance_catalog", "sales", "orders"]
+
+    def test_uri_and_namespace_are_mutually_exclusive(self):
+        def add_double(batch):
+            return {"doubled": [1]}
+
+        with pytest.raises(ValueError, match="Cannot provide both 'uri'"):
+            lr.add_columns_from(
+                "/tmp/table.lance",
+                transform=add_double,
+                namespace_impl="dir",
+                table_id=["table"],
+            )
+
+        with pytest.raises(ValueError, match="Cannot provide both 'uri'"):
+            lr.add_columns(
+                "/tmp/table.lance",
+                transform=add_double,
+                namespace_impl="dir",
+                table_id=["table"],
+            )
+
+        with pytest.raises(ValueError, match="Cannot provide both 'uri'"):
+            lr.merge_columns_from(
+                "/tmp/table.lance",
+                object(),
+                namespace_impl="dir",
+                table_id=["table"],
+            )
+
 
 class TestMergeColumnsFrom:
     """Tests for the low-level merge_columns_from(uri, ds) API."""


### PR DESCRIPTION
## Summary

- Add namespace table resolution for `add_columns`, `add_columns_from`, and `merge_columns_from`
- Resolve table `location` via `describe_table` when callers provide `namespace_impl + table_id` without a URI
- Merge namespace-returned `storage_options` with user-provided options, with namespace values taking precedence
- Add tests for namespace-only add-column flow and storage option precedence

Closes #5176.

## Tests

- `uv run --extra dev ruff check lance_ray/io.py tests/test_add_columns_from.py`
- `uv run pytest tests/test_add_columns_from.py -q`
