### PR TITLE
feat(index): commit distributed vector segments directly

### DIFF
--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -1309,18 +1309,10 @@ def create_index(
     if not successful_results:
         raise RuntimeError("No successful vector index creation results found")
 
-    segment_indices = [r["segment_index"] for r in successful_results]
-    segment_builder = (
-        dataset_obj.create_index_segment_builder()
-        .with_index_type(index_type_name)
-        .with_segments(segment_indices)
-    )
-    segments = segment_builder.build_all()
-
     updated_dataset = dataset_obj.commit_existing_index_segments(
         index_name=name,
         column=column,
-        segments=segments,
+        segments=[r["segment_index"] for r in successful_results],
     )
 
     logger.info(

--- a/tests/test_distributed_indexing.py
+++ b/tests/test_distributed_indexing.py
@@ -1535,6 +1535,13 @@ def test_build_distributed_vector_index(tmp_path, index_type):
 
     assert result.num_rows == 5
 
+    plan = updated_dataset.scanner(
+        nearest={"column": "vector", "q": q, "k": 5},
+        columns=["id"],
+    ).explain_plan()
+    assert "ANNSubIndex" in plan
+    assert f"idx_{index_type}" in plan
+
 
 @pytest.mark.parametrize("index_type", ["IVF_FLAT", "IVF_PQ"])
 def test_distributed_nested_vector_index_and_search(tmp_path, index_type):

--- a/tests/test_vector_index_options.py
+++ b/tests/test_vector_index_options.py
@@ -101,19 +101,6 @@ class _FakeFragment:
         return self._rows
 
 
-class _FakeSegmentBuilder:
-    def with_index_type(self, index_type):
-        self.index_type = index_type
-        return self
-
-    def with_segments(self, segments):
-        self.segments = segments
-        return self
-
-    def build_all(self):
-        return ["merged_segment"]
-
-
 class _FakeDataset:
     uri = "memory://fake"
     schema = _FakeSchema()
@@ -131,9 +118,6 @@ class _FakeDataset:
 
     def create_scalar_index(self, **kwargs):
         self.scalar_index_kwargs = kwargs
-
-    def create_index_segment_builder(self):
-        return _FakeSegmentBuilder()
 
     def create_index_uncommitted(self, **kwargs):
         self.vector_index_kwargs = kwargs
@@ -265,6 +249,7 @@ def test_create_index_uses_sample_rate_for_global_training(monkeypatch):
     assert captured["fragment_handler_kwargs"]["ivf_centroids"] == "ivf_ref"
     assert captured["fragment_handler_kwargs"]["pq_codebook"] == "pq_ref"
     assert "sample_rate" not in captured["fragment_handler_kwargs"]
+    assert fake_dataset.commit_kwargs["segments"] == ["segment"]
 
 
 def test_create_index_rejects_non_positive_sample_rate(monkeypatch):
@@ -420,6 +405,7 @@ def test_create_index_passes_block_size_to_loads_and_handler(monkeypatch):
     assert [load["block_size"] for load in captured["loads"]] == [8192, 8192]
     assert captured["fragment_handler_kwargs"]["block_size"] == 8192
     assert captured["put_artifacts"] == ("ivf_centroids", "pq_codebook")
+    assert fake_dataset.commit_kwargs["segments"] == ["segment"]
 
 
 def test_fragment_handlers_pass_block_size_to_dataset_load(monkeypatch):


### PR DESCRIPTION
## Background

Lance is migrating distributed index publishing onto the index segment APIs. This adapts lance-ray's distributed vector index build to publish the uncommitted segments returned by workers directly.

The `IndexSegmentBuilder` API was removed upstream in lance-format/lance#6997, so lance-ray should stop using the builder publishing path before upgrading `pylance`.

Part of #5179.

## Changes

- Commit distributed vector worker results directly with `commit_existing_index_segments(...)`.
- Remove the vector-only `create_index_segment_builder().with_index_type(...).with_segments(...).build_all()` publishing step.
- Update focused vector tests to assert direct segment commit and indexed query plans.