### PR TITLE
feat(index): migrate scalar indexing to segments

### DIFF
--- a/docs/src/distributed-indexing.md
+++ b/docs/src/distributed-indexing.md
@@ -1,7 +1,7 @@
 
 # Distributed Index Building
 
-Lance-Ray provides distributed index building functionality that leverages Ray's distributed computing capabilities to efficiently create text indices for Lance datasets. This is particularly useful for large-scale datasets as it can distribute index building work across multiple Ray worker nodes.
+Lance-Ray provides distributed index building functionality that leverages Ray's distributed computing capabilities to efficiently create indices for Lance datasets. This is particularly useful for large-scale datasets as it can distribute index building work across multiple Ray worker nodes.
 
 ## Distributed APIs
 
@@ -10,12 +10,7 @@ Lance-Ray provides distributed index building functionality that leverages Ray's
 `create_scalar_index()` - Distributedly create scalar index using ray. Currently only Inverted/FTS/BTREE/BITMAP are supported. Will add more index type support in the future.
 
 #### How It Works
-The `create_scalar_index` function allows you to create full-text search indices for Lance datasets using the Ray distributed computing framework. This function distributes the index building process across multiple Ray worker nodes, with each node responsible for building indices for a subset of dataset fragments. These indices are then merged and committed as a single index.
-
-**Backward Compatibility**:
-   - Automatically detect availability of new APIs across different Lance versions
-   - Gracefully fallback to raise tips when new APIs are unavailable
-
+The `create_scalar_index` function allows you to create scalar indices for Lance datasets using the Ray distributed computing framework. This function distributes the index building process across multiple Ray worker nodes, with each node responsible for creating uncommitted index segments for a subset of dataset fragments. These segments are then committed as a single index.
 
 **`create_scalar_index`**
 

--- a/examples/distribute_fts_index.py
+++ b/examples/distribute_fts_index.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """
-Demonstration of distributed text indexing with PR #4578 enhancements.
-This example shows how to use the enhanced distributed text indexing functionality
-that leverages the new API
+Demonstration of distributed text indexing with Lance scalar segment workflow.
+This example shows how to use distributed text indexing across multiple Lance
+fragments with Ray workers.
 
 Requirements:
 - ray
 - lance_ray
-- lance (with PR #4578 changes)
+- lance with scalar segment index API support
 """
 
 import logging
@@ -69,32 +69,32 @@ def create_multi_fragment_dataset(data_df, output_path, max_rows_per_file):
     return dataset
 
 
-def demonstrate_new_api_features(dataset, column="content"):
-    """Demonstrate the new distributed indexing API features from PR #4578."""
-    logger.info("=== Demonstrating New API Features (PR #4578) ===")
+def demonstrate_segment_indexing(dataset, column="content"):
+    """Demonstrate distributed FTS indexing with segment commits."""
+    logger.info("=== Demonstrating Distributed Segment Indexing ===")
 
     try:
-        # Build distributed index using the enhanced API
-        logger.info("Building distributed index with new API features...")
+        # Build distributed index using the scalar segment workflow.
+        logger.info("Building distributed index with segment commits...")
 
         updated_dataset = lr.create_scalar_index(
-            dataset=dataset,
+            uri=dataset.uri,
             column=column,
             index_type="INVERTED",
-            name="pr4578_enhanced_idx",
+            name="distributed_fts_segment_idx",
             num_workers=4,
             remove_stop_words=False,
             with_position=True,  # Enable phrase queries
         )
 
-        logger.info("✅ Successfully created distributed index with new API")
+        logger.info("✅ Successfully created distributed segment index")
 
         # Verify index creation
         indices = updated_dataset.list_indices()
         logger.info(f"Total indices: {len(indices)}")
 
         for idx in indices:
-            if idx["name"] == "pr4578_enhanced_idx":
+            if idx["name"] == "distributed_fts_segment_idx":
                 logger.info(f"✅ Found our index: {idx['name']} (type: {idx['type']})")
                 break
         else:
@@ -103,8 +103,7 @@ def demonstrate_new_api_features(dataset, column="content"):
         return updated_dataset
 
     except Exception as e:
-        logger.error(f"❌ Error with new API: {e}")
-        logger.info("This is expected if PR #4578 changes are not available")
+        logger.error(f"❌ Error with segment indexing: {e}")
         return None
 
 
@@ -144,7 +143,7 @@ def demonstrate_search_functionality(dataset, search_queries=None):
 
 def main():
     """Main demonstration function."""
-    logger.info("🚀 Starting Distributed Text Indexing Demo (PR #4578)")
+    logger.info("🚀 Starting Distributed Text Indexing Demo")
 
     # Initialize Ray
     if not ray.is_initialized():
@@ -157,7 +156,7 @@ def main():
             data_df = generate_sample_dataset(num_fragments=4, rows_per_fragment=500)
 
             # Create multi-fragment dataset
-            dataset_path = Path(temp_dir) / "pr4578_demo_dataset.lance"
+            dataset_path = Path(temp_dir) / "distributed_fts_demo_dataset.lance"
             dataset = create_multi_fragment_dataset(
                 data_df, str(dataset_path), max_rows_per_file=500
             )
@@ -166,17 +165,15 @@ def main():
                 f"Dataset created with {len(dataset.get_fragments())} fragments"
             )
 
-            # Demonstrate new API features
-            enhanced_dataset = demonstrate_new_api_features(dataset)
+            # Demonstrate distributed segment indexing
+            enhanced_dataset = demonstrate_segment_indexing(dataset)
 
             if enhanced_dataset:
-                # Test search functionality with new API
+                # Test search functionality with the built index
                 demonstrate_search_functionality(enhanced_dataset)
                 logger.info("🎉 Demo completed successfully!")
             else:
-                logger.error(
-                    "❌ New API features not available - PR #4578 may not be merged"
-                )
+                logger.error("❌ Segment index creation failed")
 
     except Exception as e:
         logger.error(f"❌ Demo failed: {e}")

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -186,6 +186,97 @@ def _put_vector_index_artifacts_in_object_store(
     )
 
 
+_SCALAR_SEGMENT_INDEX_TYPES = {"BTREE", "BITMAP", "INVERTED", "FTS"}
+
+
+def _scalar_index_type_name(index_type: str | IndexConfig) -> str | None:
+    if isinstance(index_type, str):
+        return index_type.upper()
+    if isinstance(index_type, IndexConfig):
+        return index_type.index_type.upper()
+    return None
+
+
+def _handle_scalar_segment_index(
+    dataset_uri: str,
+    column: str,
+    index_type: str | IndexConfig,
+    name: str,
+    train: bool,
+    storage_options: Optional[dict[str, str]] = None,
+    block_size: Optional[int] = None,
+    namespace_impl: Optional[str] = None,
+    namespace_properties: Optional[dict[str, str]] = None,
+    table_id: Optional[list[str]] = None,
+    **kwargs: Any,
+):
+    """Create a fragment handler closure for scalar segment index builds."""
+
+    def func(fragment_ids: list[int]) -> dict[str, Any]:
+        try:
+            if not fragment_ids:
+                raise ValueError("fragment_ids cannot be empty")
+
+            for fragment_id in fragment_ids:
+                if fragment_id < 0 or fragment_id > 0xFFFFFFFF:
+                    raise ValueError(f"Invalid fragment_id: {fragment_id}")
+
+            namespace_kwargs = get_namespace_kwargs(
+                namespace_impl, namespace_properties, table_id
+            )
+            dataset = LanceDataset(
+                dataset_uri,
+                **_dataset_load_kwargs(storage_options, namespace_kwargs, block_size),
+            )
+
+            available_fragments = {f.fragment_id for f in dataset.get_fragments()}
+            invalid_fragments = set(fragment_ids) - available_fragments
+            if invalid_fragments:
+                raise ValueError(f"Fragment IDs {invalid_fragments} do not exist")
+
+            logger.info(
+                "Building distributed scalar segment index for fragments %s using "
+                "create_index_uncommitted",
+                fragment_ids,
+            )
+
+            segment_index = dataset.create_index_uncommitted(
+                column=column,
+                index_type=index_type,
+                name=name,
+                replace=False,
+                train=train,
+                storage_options=storage_options,
+                fragment_ids=fragment_ids,
+                **kwargs,
+            )
+
+            logger.info(
+                "Fragment scalar segment index created successfully for fragments %s",
+                fragment_ids,
+            )
+
+            return {
+                "status": "success",
+                "fragment_ids": fragment_ids,
+                "segment_index": segment_index,
+            }
+
+        except Exception as exc:  # pragma: no cover - exercised via integration tests
+            logger.error(
+                "Fragment scalar segment index task failed for fragments %s: %s",
+                fragment_ids,
+                exc,
+            )
+            return {
+                "status": "error",
+                "fragment_ids": fragment_ids,
+                "error": str(exc),
+            }
+
+    return func
+
+
 def _handle_fragment_index(
     dataset_uri: str,
     column: str,
@@ -476,6 +567,10 @@ def create_scalar_index(
                 # For other index types, skip strict validation to maintain compatibility
                 pass
 
+    use_segment_workflow = (
+        _scalar_index_type_name(index_type) in _SCALAR_SEGMENT_INDEX_TYPES
+    )
+
     if name is None:
         name = f"{column}_idx"
 
@@ -535,6 +630,21 @@ def create_scalar_index(
     fragment_batches = _distribute_fragments_balanced(fragments, num_workers, logger)
 
     def create_fragment_handler() -> Any:
+        if use_segment_workflow:
+            return _handle_scalar_segment_index(
+                dataset_uri=uri,
+                column=column,
+                index_type=index_type,
+                name=name,
+                train=train,
+                storage_options=merged_storage_options,
+                block_size=block_size,
+                namespace_impl=namespace_impl,
+                namespace_properties=namespace_properties,
+                table_id=table_id,
+                **kwargs,
+            )
+
         return _handle_fragment_index(
             dataset_uri=uri,
             column=column,
@@ -576,6 +686,33 @@ def create_scalar_index(
         **_dataset_load_kwargs(merged_storage_options, namespace_kwargs, block_size),
     )
 
+    successful_results = [r for r in results if r["status"] == "success"]
+    if not successful_results:
+        raise RuntimeError("No successful index creation results found")
+
+    if use_segment_workflow:
+        logger.info(
+            "Phase 2: Committing scalar distributed index segments for index '%s'",
+            name,
+        )
+
+        updated_dataset = dataset.commit_existing_index_segments(
+            index_name=name,
+            column=column,
+            segments=[r["segment_index"] for r in successful_results],
+        )
+
+        logger.info(
+            "Successfully created distributed scalar segment index '%s'",
+            name,
+        )
+        logger.info(
+            "Fragments: %d, Workers: %d",
+            len(fragment_ids_to_use),
+            len(fragment_batches),
+        )
+        return updated_dataset
+
     logger.info("Phase 2: Merging index metadata for index ID: %s", index_id)
     # Convert IndexConfig to string for merge_index_metadata which expects a string
     # (lance's create_scalar_index converts IndexConfig to "scalar" internally)
@@ -583,10 +720,6 @@ def create_scalar_index(
     merge_index_metadata_compat(dataset, index_id, index_type=index_type_str, **kwargs)
 
     logger.info("Phase 3: Creating and committing scalar index '%s'", name)
-
-    successful_results = [r for r in results if r["status"] == "success"]
-    if not successful_results:
-        raise RuntimeError("No successful index creation results found")
 
     fields = successful_results[0]["fields"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=7.0.0b7",
+    "pylance>=8.0.0b11",
     "lance-namespace",
     "packaging",
     "pyarrow>=17.0.0",

--- a/tests/test_distributed_indexing.py
+++ b/tests/test_distributed_indexing.py
@@ -745,8 +745,7 @@ class TestDistributedIndexing:
 
     def test_distributed_fts_index_new_api(self, temp_dir):
         """
-        Test distributed FTS index building using the new API from PR #4578.
-        This test demonstrates the new workflow with execute_uncommitted() and merge_index_metadata().
+        Test distributed FTS index building with the segment workflow.
         """
         # Generate test dataset with multiple fragments
         ds = generate_multi_fragment_dataset(
@@ -797,8 +796,7 @@ class TestDistributedIndexing:
 
     def test_distributed_index_with_index_uuid(self, temp_dir):
         """
-        Test distributed index building with explicit fragment UUID handling.
-        This tests the new index_uuid parameter from PR #4578.
+        Test distributed FTS index creation records the requested index name.
         """
         # Generate test dataset
         ds = generate_multi_fragment_dataset(
@@ -832,7 +830,7 @@ class TestDistributedIndexing:
 
     def test_distributed_index_error_handling_new_api(self, temp_dir):
         """
-        Test error handling in the new distributed indexing API.
+        Test error handling in the distributed indexing API.
         """
         # Generate test dataset
         ds = generate_multi_fragment_dataset(
@@ -915,6 +913,13 @@ class TestDistributedBTreeIndexing:
             filter=f"id = {eq_id}", columns=["id", "text"]
         ).to_table()
         assert eq_tbl.num_rows == 1
+        eq_plan = updated_dataset.scanner(
+            filter=f"id = {eq_id}",
+            columns=["id"],
+            use_scalar_index=True,
+        ).explain_plan()
+        assert "ScalarIndexQuery" in eq_plan
+        assert "btree_multiple_fragment_idx" in eq_plan
 
         rg_tbl = updated_dataset.scanner(
             filter="id >= 200 AND id < 800",
@@ -1160,6 +1165,14 @@ class TestDistributedBitmapIndexing:
         assert sorted(indexed.column("id").to_pylist()) == sorted(
             baseline.column("id").to_pylist()
         )
+
+        plan = updated_dataset.scanner(
+            filter="fragment_id = 1",
+            columns=["id"],
+            use_scalar_index=True,
+        ).explain_plan()
+        assert "ScalarIndexQuery" in plan
+        assert "fragment_bitmap_idx" in plan
 
 
 class TestOptimizeIndices:

--- a/tests/test_vector_index_options.py
+++ b/tests/test_vector_index_options.py
@@ -69,7 +69,7 @@ class _FakeLanceField:
 
 class _FakeLanceSchema:
     def field(self, column):
-        if column != "value":
+        if column not in {"value", "text"}:
             raise KeyError(column)
         return _FakeLanceField()
 
@@ -80,6 +80,8 @@ class _FakeSchema:
             return _FakeField(column)
         if column == "value":
             return _FakeField(column, index_mod.pa.int64())
+        if column == "text":
+            return _FakeField(column, index_mod.pa.string())
         else:
             raise KeyError(column)
 
@@ -88,6 +90,7 @@ class _FakeSchema:
             [
                 _FakeField("vector"),
                 _FakeField("value", index_mod.pa.int64()),
+                _FakeField("text", index_mod.pa.string()),
             ]
         )
 
@@ -266,8 +269,9 @@ def test_create_index_rejects_non_positive_sample_rate(monkeypatch):
         )
 
 
-def test_create_scalar_index_passes_block_size_to_loads_and_handler(monkeypatch):
-    """The scalar index path should use block_size whenever it loads a dataset."""
+@pytest.mark.parametrize("index_type", ["BTREE", "BITMAP", "INVERTED", "FTS"])
+def test_create_scalar_index_uses_segment_path(monkeypatch, index_type):
+    """Migrated scalar indexes should use Lance's segment workflow."""
 
     captured = {"loads": []}
     fake_dataset = _FakeDataset()
@@ -276,12 +280,12 @@ def test_create_scalar_index_passes_block_size_to_loads_and_handler(monkeypatch)
         captured["loads"].append(kwargs)
         return fake_dataset
 
-    def fake_handle_fragment_index(**kwargs):
+    def fake_handle_scalar_segment_index(**kwargs):
         captured["fragment_handler_kwargs"] = kwargs
         return lambda fragment_ids: {
             "status": "success",
             "fragment_ids": fragment_ids,
-            "fields": [7],
+            "segment_index": "segment",
         }
 
     def fake_map_async_with_pool(**kwargs):
@@ -291,43 +295,32 @@ def test_create_scalar_index_passes_block_size_to_loads_and_handler(monkeypatch)
             {
                 "status": "success",
                 "fragment_ids": [0, 1],
-                "fields": [7],
+                "segment_index": "segment",
             }
         ]
 
     monkeypatch.setattr(index_mod, "LanceDataset", fake_lance_dataset)
     monkeypatch.setattr(
         index_mod,
-        "_handle_fragment_index",
-        fake_handle_fragment_index,
+        "_handle_scalar_segment_index",
+        fake_handle_scalar_segment_index,
     )
     monkeypatch.setattr(index_mod, "_map_async_with_pool", fake_map_async_with_pool)
-    monkeypatch.setattr(index_mod, "merge_index_metadata_compat", lambda *a, **k: None)
-    monkeypatch.setattr(index_mod, "Index", SimpleNamespace)
-    monkeypatch.setattr(
-        index_mod.lance,
-        "LanceDataset",
-        SimpleNamespace(commit=lambda *args, **kwargs: fake_dataset),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        index_mod.lance,
-        "LanceOperation",
-        SimpleNamespace(CreateIndex=SimpleNamespace),
-        raising=False,
-    )
 
+    column = "text" if index_type in {"INVERTED", "FTS"} else "value"
     updated_dataset = index_mod.create_scalar_index(
         uri="memory://fake",
-        column="value",
-        index_type="BTREE",
+        column=column,
+        index_type=index_type,
         num_workers=2,
         block_size=4096,
     )
 
     assert updated_dataset is fake_dataset
     assert [load["block_size"] for load in captured["loads"]] == [4096, 4096]
+    assert captured["fragment_handler_kwargs"]["index_type"] == index_type
     assert captured["fragment_handler_kwargs"]["block_size"] == 4096
+    assert fake_dataset.commit_kwargs["segments"] == ["segment"]
 
 
 def test_create_index_passes_block_size_to_loads_and_handler(monkeypatch):
@@ -423,7 +416,7 @@ def test_fragment_handlers_pass_block_size_to_dataset_load(monkeypatch):
     scalar_handler = index_mod._handle_fragment_index(
         dataset_uri="memory://fake",
         column="value",
-        index_type="BTREE",
+        index_type="LABEL_LIST",
         name="value_idx",
         index_uuid="scalar-index",
         replace=False,

--- a/uv.lock
+++ b/uv.lock
@@ -326,19 +326,19 @@ wheels = [
 
 [[package]]
 name = "lance-namespace"
-version = "0.7.6"
+version = "0.8.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/da/134670003173881bed44af656badffd91e0b2e0232c083eeacc5923d7335/lance_namespace-0.7.6.tar.gz", hash = "sha256:4e12094005d105ef1b44346c9d7feda4a0f733b127dab90c1a5ffbf7cd433770", size = 10686, upload-time = "2026-05-05T18:26:38.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/8f/8a03395587a78cfaf92f7307ad931f61eb515af67705c704bd6c7af2f745/lance_namespace-0.8.4.tar.gz", hash = "sha256:1a54ad49e7ace25a629c5f2c99d393629742eceeeb16ba2f51a771ccb350e284", size = 11282, upload-time = "2026-06-10T19:07:21.919Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/88/44463a5f41f7077b2ea641f2afded72eaceb6a6a1b4a55c11b22318fed74/lance_namespace-0.7.6-py3-none-any.whl", hash = "sha256:c94a1b8a6aab127e55a20cbf44d927ae3a9b7d435656d2130dccf84ccf7c9999", size = 12519, upload-time = "2026-05-05T18:26:36.425Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/4b/218c67cafb707024069925ce86534588861a464aaa327f7a457b94eed3c2/lance_namespace-0.8.4-py3-none-any.whl", hash = "sha256:8b347eef4b7c7187a1b52f388b5dcc345fed0bf4ea87728188dcb11a52619d0b", size = 13111, upload-time = "2026-06-10T19:07:22.6Z" },
 ]
 
 [[package]]
 name = "lance-namespace-urllib3-client"
-version = "0.7.6"
+version = "0.8.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -346,9 +346,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/44/024aae184c08b3800482cd9b832d534249e25de145af732d4e4c8dff38a8/lance_namespace_urllib3_client-0.7.6.tar.gz", hash = "sha256:15ae7f0d8d56fa34d837f7f6ec5c80a327a905e89ccfed05f7b409d6fe704cdf", size = 195551, upload-time = "2026-05-05T18:26:37.808Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/55/4a7cc7e5d19bda170c896a6adff2ec925c533df812b91bce2bc8f7aea30b/lance_namespace_urllib3_client-0.8.4.tar.gz", hash = "sha256:1a292a83509ab79475da967b78839e9ead4ab973064d37d1ba1575b23ffdacef", size = 228485, upload-time = "2026-06-10T19:07:19.863Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/50/60c983cc8180772c82370dfad2104b7e788aaacc3bf9a84e8b42bb1ae6a7/lance_namespace_urllib3_client-0.7.6-py3-none-any.whl", hash = "sha256:fb884d8afff8af3aae04a3270624694a189d7ea79225dd349e6c555a1a1d6b52", size = 324603, upload-time = "2026-05-05T18:26:39.718Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/f7/70dd2fc1f9ef462d3802b4cffcd64f2b9233a9907d6071e8694338492608/lance_namespace_urllib3_client-0.8.4-py3-none-any.whl", hash = "sha256:37ee1d74614fae6358f50e3589ac26c29379ffb1346f09c4f5ec8953f823cefd", size = 369807, upload-time = "2026-06-10T19:07:21.001Z" },
 ]
 
 [[package]]
@@ -387,7 +387,7 @@ requires-dist = [
     { name = "more-itertools", marker = "python_full_version < '3.12'", specifier = ">=2.6.0" },
     { name = "packaging" },
     { name = "pyarrow", specifier = ">=17.0.0" },
-    { name = "pylance", specifier = ">=7.0.0b7" },
+    { name = "pylance", specifier = ">=8.0.0b11" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
@@ -1024,7 +1024,7 @@ wheels = [
 
 [[package]]
 name = "pylance"
-version = "7.0.0b7"
+version = "8.0.0b11"
 source = { registry = "https://pypi.fury.io/lance-format" }
 dependencies = [
     { name = "lance-namespace" },
@@ -1033,12 +1033,12 @@ dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://pypi.fury.io/lance-format/-/ver_1zsVV4/pylance-7.0.0b7-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:66f2ba7969c0fad259f5d13842e89d664956c1415eed644d6956af333e848a62" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1TtYis/pylance-7.0.0b7-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:029ac2359cccbac62345392c78f5aae6596eda4a3398fbf8bef5aad708591d14" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_uZkce/pylance-7.0.0b7-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a53841757573d7c63238d79df94236eb6e46d9508d2690d98ce983e5d04f8c7a" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_3iSeD/pylance-7.0.0b7-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:34c67a0102d47f870d4b795087622c16087aa1928c1925b1acdeb61206f4663a" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_BpURn/pylance-7.0.0b7-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ac70f0248239b50ae718e38e69c1418899a1a7575e7b911beac91eeb60b174ec" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_jVZS2/pylance-7.0.0b7-cp39-abi3-win_amd64.whl", hash = "sha256:0f1caea57ea998f6e59dcb2684a08e4b06f993ecc77c8d0f032a4a43a82ed085" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_GL5dn/pylance-8.0.0b11-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:2f2e66c6a7039ba51ac6174d0336b4f38a58351706e16b8b21a6c71f06cd1f20" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1pVrmn/pylance-8.0.0b11-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f85711b2f468acfe20ad2542639b82e9658ed301d72f5cfde82e2e40ef431b15" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1qcBDw/pylance-8.0.0b11-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:602af5469141d0c6667d902f6819cd2b7b5ce40193190be6a030adc753a36fe7" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1V5g0y/pylance-8.0.0b11-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:b6b89f48f198b3fe59ad795bac614a1cc8892e20f2ba2acd1f958a18d05e4b32" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_7rhla/pylance-8.0.0b11-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:4c8b16c860345f3c519dc28dd4dab111bdc2c104795c1c7fb3f245d798f64792" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1f0tKO/pylance-8.0.0b11-cp39-abi3-win_amd64.whl", hash = "sha256:66297c0a3708e4b6921d6430153d2cb89f7a618110bf8d119cb9986a81a6371c" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Background

Lance is moving distributed scalar index publishing onto the index segment APIs. This adapts lance-ray to create uncommitted scalar segments on workers and commit those segments directly on the driver.

This is part of #5179.

## Why bump pylance here

This PR needs `pylance>=8.0.0b11` because the scalar segment workflow used here is provided by the Lance 8 Python API. A standalone dependency-only bump would break existing distributed scalar indexing paths that still publish fragment-local index metadata through the older workflow.

For that reason, the dependency bump is coupled with the scalar index migration instead of being split into a separate PR.

## Changes

- Upgrade `pylance` to `>=8.0.0b11`.
- Route distributed `BTREE`, `BITMAP`, `INVERTED`, and `FTS` builds through `create_index_uncommitted(...)` + `commit_existing_index_segments(...)`.
- Keep the public `create_scalar_index()` API shape unchanged.
- Update focused tests, docs, and the distributed FTS example for the segment workflow.
