### PR TITLE
chore: update pylance dependency to v8.0.0b13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=7.0.0b7",
+    "pylance>=8.0.0b13",
     "lance-namespace",
     "packaging",
     "pyarrow>=17.0.0",


### PR DESCRIPTION
## Summary
- Bump the `pylance` dependency requirement to `pylance>=8.0.0b13` using PEP 440 beta format.
- Triggering Lance tag: https://github.com/lance-format/lance/tree/refs/tags/v8.0.0-beta.13 (`refs/tags/v8.0.0-beta.13`).

## Verification
- `make lock` currently fails because the configured package index only exposes `pylance<=8.0.0b12`, so `pylance>=8.0.0b13` cannot be resolved yet.
- `make lint` currently fails at its initial `uv lock` step for the same resolver issue, before ruff checks run.
