### PR TITLE
chore: move pytest and pytest-cov to the dev optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,13 +28,13 @@ dependencies = [
     "lance-namespace",
     "packaging",
     "pyarrow>=17.0.0",
-    "pytest>=8.4.0",
-    "pytest-cov>=5.0.0",
     "more_itertools>=2.6.0; python_version<'3.12'",
 ]
 
 [project.optional-dependencies]
 dev = [
+    "pytest>=8.4.0",
+    "pytest-cov>=5.0.0",
     "pytest-asyncio>=1.0.0",
     "pytest-xdist>=3.6.0",
     "ruff>=0.8.0",

--- a/uv.lock
+++ b/uv.lock
@@ -361,14 +361,14 @@ dependencies = [
     { name = "packaging" },
     { name = "pyarrow" },
     { name = "pylance" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
     { name = "ray", extra = ["data"] },
 ]
 
 [package.optional-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "pytest-xdist" },
     { name = "ruff" },
 ]
@@ -388,9 +388,9 @@ requires-dist = [
     { name = "packaging" },
     { name = "pyarrow", specifier = ">=17.0.0" },
     { name = "pylance", specifier = ">=8.0.0b11" },
-    { name = "pytest", specifier = ">=8.4.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "pytest-cov", specifier = ">=5.0.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.0" },
     { name = "ray", extras = ["data"], specifier = ">=2.41.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },


### PR DESCRIPTION
`pytest` and `pytest-cov` were listed under `[project.dependencies]`, so installing `lance-ray` as a library pulled the test runner in as a runtime requirement even though it's only needed to run the suite. This moves both into the existing `dev` optional-dependencies group, next to `pytest-asyncio`, `pytest-xdist`, and `ruff`.

`uv.lock` is regenerated to match, so the two now resolve under `extra == "dev"`. CI already runs `uv sync --extra dev` before the tests and CONTRIBUTING tells contributors to install `.[dev]`, so the test workflow is unchanged — only a plain `pip install lance-ray` gets lighter.
