### PR TITLE
fix: validate write mode in write_lance

### DIFF
--- a/lance_ray/io.py
+++ b/lance_ray/io.py
@@ -1144,6 +1144,12 @@ def _validate_write_args(
     together (to create at a specific location and register with namespace).
     For append mode, requires exactly one of uri OR namespace parameters.
     """
+    valid_modes = {"create", "append", "overwrite"}
+    if mode not in valid_modes:
+        raise ValueError(
+            f"Invalid write mode {mode!r}. Must be one of {sorted(valid_modes)}."
+        )
+
     has_ns = has_namespace_params(namespace_impl, table_id)
 
     # For append mode, use the same validation as read operations

--- a/tests/test_basic_read_write.py
+++ b/tests/test_basic_read_write.py
@@ -82,6 +82,13 @@ class TestWriteLance:
         with pytest.raises((ValueError, AttributeError, TypeError)):
             lr.write_lance(None, str(path))  # type: ignore
 
+    def test_write_lance_invalid_mode(self, sample_dataset, temp_dir):
+        """An out-of-contract mode must raise instead of silently no-op'ing."""
+        path = Path(temp_dir) / "bad_mode.lance"
+
+        with pytest.raises(ValueError, match="Invalid write mode"):
+            lr.write_lance(sample_dataset, str(path), mode="upsert")  # type: ignore
+
     def test_write_with_pandas_map_batches(self, temp_dir):
         def map_fn(row):
             return {


### PR DESCRIPTION
`write_lance` never checked that `mode` was one of `create`, `append`, or `overwrite`. A typo like `mode="upsert"` slipped straight through and silently did nothing useful: on the non-stream path the commit op was left as `None`, so fragments were written but never committed, and the streaming path quietly fell back to overwrite.

`_validate_write_args` now rejects any unknown mode up front with a `ValueError` listing the valid options. It runs before the stream/non-stream split, so both paths are covered, and valid modes are unaffected.
