### PR TITLE
fix: skip explicit base IDs when auto-assigning in normalize_initial_bases

### DIFF
--- a/lance_ray/utils.py
+++ b/lance_ray/utils.py
@@ -28,26 +28,42 @@ def normalize_initial_bases(
     if not initial_bases:
         return None
 
+    # Parse base inputs once and collect IDs the caller supplied explicitly so
+    # auto-assignment can skip them (avoids spurious "Duplicate base path ID"
+    # errors when an auto-assigned base would otherwise collide with one).
+    parsed: list[tuple[Any, Any, bool, Any]] = []
+    explicit_ids: set[int] = set()
+    for base in initial_bases:
+        if isinstance(base, dict):
+            path = base["path"]
+            name = base.get("name")
+            is_root = base.get("is_dataset_root", False)
+            raw_id = base.get("id", 0)
+        else:
+            path = base.path
+            name = base.name
+            is_root = base.is_dataset_root
+            raw_id = base.id
+        parsed.append((path, name, is_root, raw_id))
+        if not is_root and raw_id not in (0, None):
+            explicit_ids.add(raw_id)
+
     specs: list[dict[str, Any]] = []
     next_auto_id = 1
-    for base in initial_bases:
-        raw_id = base.get("id", 0) if isinstance(base, dict) else base.id
-        is_root = (
-            base.get("is_dataset_root", False)
-            if isinstance(base, dict)
-            else base.is_dataset_root
-        )
+    for path, name, is_root, raw_id in parsed:
         if is_root:
             assigned_id = 0
         elif raw_id not in (0, None):
             assigned_id = raw_id
         else:
+            while next_auto_id in explicit_ids:
+                next_auto_id += 1
             assigned_id = next_auto_id
             next_auto_id += 1
         specs.append(
             {
-                "path": base["path"] if isinstance(base, dict) else base.path,
-                "name": base.get("name") if isinstance(base, dict) else base.name,
+                "path": path,
+                "name": name,
                 "is_dataset_root": is_root,
                 "id": assigned_id,
             }

--- a/tests/test_initial_bases.py
+++ b/tests/test_initial_bases.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+"""Unit tests for normalize_initial_bases ID assignment."""
+
+import pytest
+from lance_ray.utils import normalize_initial_bases
+
+
+def _ids_by_path(bases):
+    return {spec["path"]: spec["id"] for spec in normalize_initial_bases(bases)}
+
+
+def test_none_and_empty_return_none():
+    assert normalize_initial_bases(None) is None
+    assert normalize_initial_bases([]) is None
+
+
+def test_root_gets_zero_and_auto_ids_are_sequential():
+    by_path = _ids_by_path(
+        [
+            {"path": "/root", "is_dataset_root": True},
+            {"path": "/x"},
+            {"path": "/y"},
+        ]
+    )
+    assert by_path == {"/root": 0, "/x": 1, "/y": 2}
+
+
+def test_auto_id_skips_explicit_id_declared_later():
+    # On the old code /c auto-takes 1, then /b's explicit 1 collides -> raise.
+    by_path = _ids_by_path(
+        [
+            {"path": "/c"},
+            {"path": "/b", "id": 1},
+        ]
+    )
+    assert by_path == {"/c": 2, "/b": 1}
+
+
+def test_duplicate_explicit_ids_still_raise():
+    with pytest.raises(ValueError, match="Duplicate base path ID"):
+        normalize_initial_bases(
+            [
+                {"path": "/x", "id": 5},
+                {"path": "/y", "id": 5},
+            ]
+        )


### PR DESCRIPTION
`normalize_initial_bases` auto-assigns IDs (starting at 1) to base paths that don't specify one, but it counted up without looking at the IDs the caller had already set explicitly. So a base left to auto-assignment could land on an ID another base was given by hand — one base with `id=1` next to one without an ID, say — and the duplicate check then rejected it with a confusing "Duplicate base path ID" error.

This collects the explicit IDs in a first pass and skips them while auto-assigning, so auto and explicit IDs no longer collide. Genuine duplicates (two bases sharing one explicit ID) still raise, and id 0 stays reserved for the dataset root.

Added unit tests for the collision case (including the auto base declared before the explicit one), explicit-duplicate rejection, root handling, and empty/None input.
