### PR TITLE
fix: use RuntimeWarning for empty write results in datasink

### DIFF
--- a/lance_ray/datasink.py
+++ b/lance_ray/datasink.py
@@ -170,7 +170,7 @@ class _BaseLanceDatasink(Datasink):
         if not write_results:
             warnings.warn(
                 "write_results is empty.",
-                DeprecationWarning,
+                RuntimeWarning,
                 stacklevel=2,
             )
             return
@@ -180,7 +180,7 @@ class _BaseLanceDatasink(Datasink):
         if len(write_results) == 0:
             warnings.warn(
                 "write results is empty. please check ray version or internal error",
-                DeprecationWarning,
+                RuntimeWarning,
                 stacklevel=2,
             )
             return

--- a/tests/test_datasink.py
+++ b/tests/test_datasink.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+"""Unit tests for LanceDatasink behaviour that does not require a Ray cluster."""
+
+import warnings
+
+import pytest
+from lance_ray.datasink import LanceDatasink
+
+
+def test_on_write_complete_empty_results_warns_runtimewarning(tmp_path):
+    sink = LanceDatasink(str(tmp_path / "ds.lance"))
+
+    with pytest.warns(RuntimeWarning, match="empty"):
+        sink.on_write_complete([])
+
+    # It must no longer raise a DeprecationWarning for this operational case.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        sink.on_write_complete([])
+
+
+def test_on_write_complete_empty_write_returns_warns_runtimewarning(tmp_path):
+    """The second branch (write_returns unwraps to empty) must also warn RuntimeWarning."""
+    sink = LanceDatasink(str(tmp_path / "ds.lance"))
+
+    class _Wrapped:
+        # Truthy object whose write_returns is empty -> reaches the len()==0 branch.
+        write_returns: list = []
+
+    with pytest.warns(RuntimeWarning, match="please check"):
+        sink.on_write_complete(_Wrapped())
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        sink.on_write_complete(_Wrapped())


### PR DESCRIPTION
`LanceDatasink.on_write_complete` warns and skips the commit when it gets no write results back, but it raised that as a `DeprecationWarning`. Nothing is actually deprecated — it's an empty-input / operational condition — and `DeprecationWarning` is hidden by default outside `__main__`, so the warning meant to flag "your write produced nothing to commit" was effectively invisible.

Both empty-result warnings now use `RuntimeWarning`, which fits the situation and shows up under the default filters. The messages and call sites are otherwise unchanged.

Added unit tests for both branches — the empty list, and the `write_returns` wrapper unwrapping to empty — each asserting `RuntimeWarning` and that no `DeprecationWarning` is raised.
