### PR TITLE
perf: use select_k_unstable for top-k vector merge

### DIFF
--- a/lance_ray/search.py
+++ b/lance_ray/search.py
@@ -469,8 +469,10 @@ def _vector_column_to_numpy(vector_column: pa.ChunkedArray) -> Any:
 
 
 def _take_top_k(table: pa.Table, k: int) -> pa.Table:
-    sort_indices = pc.sort_indices(table, sort_keys=[("_distance", "ascending")])
-    return table.take(sort_indices.slice(0, k))
+    # select_k_unstable is an O(n log k) partial sort, cheaper than fully
+    # sorting all candidates before slicing the global top-k.
+    indices = pc.select_k_unstable(table, k=k, sort_keys=[("_distance", "ascending")])
+    return table.take(indices)
 
 
 def _merge_vector_search_results(tables: list[pa.Table], k: int) -> pa.Table:

--- a/tests/test_search_topk.py
+++ b/tests/test_search_topk.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+"""Unit tests for the top-k selection / merge helpers in search.py."""
+
+import pyarrow as pa
+from lance_ray.search import _merge_vector_search_results, _take_top_k
+
+
+def _table(distances, ids):
+    # Integer-valued floats are exactly representable in float32.
+    return pa.table({"_distance": pa.array(distances, type=pa.float32()), "id": ids})
+
+
+def test_take_top_k_selects_smallest_ascending():
+    table = _table([5.0, 1.0, 9.0, 3.0], [1, 2, 3, 4])
+    top2 = _take_top_k(table, 2)
+    assert top2.column("_distance").to_pylist() == [1.0, 3.0]
+    assert top2.column("id").to_pylist() == [2, 4]
+
+
+def test_take_top_k_k_larger_than_rows_returns_all_sorted():
+    table = _table([5.0, 1.0], [1, 2])
+    top = _take_top_k(table, 10)
+    assert top.num_rows == 2
+    assert top.column("_distance").to_pylist() == [1.0, 5.0]
+
+
+def test_merge_vector_search_results_global_topk():
+    t1 = _table([5.0, 9.0], [1, 3])
+    t2 = _table([1.0, 3.0], [2, 4])
+    merged = _merge_vector_search_results([t1, t2], 3)
+    assert merged.column("_distance").to_pylist() == [1.0, 3.0, 5.0]
+    assert merged.column("id").to_pylist() == [2, 4, 1]


### PR DESCRIPTION
Distributed vector search trims candidates to the top k in two places — once per worker and once when merging shard results — and both went through `_take_top_k`, which fully sorted every candidate by `_distance` and then sliced off the first k.

Sorting the whole set just to keep a few rows is wasteful. This swaps it for Arrow's `select_k_unstable`, a partial selection that's O(n log k) and still returns the k smallest in ascending order, so the "sorted by `_distance`" contract is unchanged. The only behavioral difference is that ties at the k-boundary are no longer broken by input order, which doesn't matter for nearest-neighbor results (equidistant rows are interchangeable, and the distance ranking is identical).

Added unit tests for the top-k selection (including k larger than the row count) and the global merge.
