### PR TITLE
perf: avoid Python round-trip in flat fallback vector distance

### DIFF
--- a/lance_ray/search.py
+++ b/lance_ray/search.py
@@ -457,7 +457,13 @@ def _compute_vector_distances(
 def _vector_column_to_numpy(vector_column: pa.ChunkedArray) -> Any:
     import numpy as np
 
-    values = vector_column.combine_chunks().to_pylist()
+    combined = vector_column.combine_chunks()
+
+    fast = _fixed_size_list_to_matrix(combined)
+    if fast is not None:
+        return fast
+
+    values = combined.to_pylist()
     if not values:
         return np.empty((0, 0), dtype=np.float32)
     if any(value is None for value in values):
@@ -466,6 +472,33 @@ def _vector_column_to_numpy(vector_column: pa.ChunkedArray) -> Any:
     if matrix.ndim != 2:
         raise ValueError("Fallback vector search requires a list-like vector column")
     return matrix
+
+
+def _fixed_size_list_to_matrix(array: pa.Array) -> Any | None:
+    """Convert a FixedSizeList vector column to a 2-D matrix without a Python round-trip.
+
+    Returns ``None`` (so the caller falls back to the generic, slower
+    ``to_pylist`` path) unless ``array`` is a non-empty, null-free
+    FixedSizeList whose contiguous child buffer can be reshaped directly.
+    """
+    import numpy as np
+
+    if not pa.types.is_fixed_size_list(array.type):
+        return None
+    if array.null_count or len(array) == 0:
+        return None
+
+    values = array.values
+    if values.null_count:
+        return None
+
+    list_size = array.type.list_size
+    if len(values) != len(array) * list_size:
+        # Offset/sliced child buffer: defer to the safe generic path.
+        return None
+
+    flat = np.asarray(values.to_numpy(zero_copy_only=False), dtype=np.float32)
+    return flat.reshape(len(array), list_size)
 
 
 def _take_top_k(table: pa.Table, k: int) -> pa.Table:

--- a/tests/test_search_fallback.py
+++ b/tests/test_search_fallback.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+"""Unit tests for the flat fallback vector-distance helpers in search.py."""
+
+import numpy as np
+import pyarrow as pa
+import pytest
+from lance_ray.search import (
+    _compute_vector_distances,
+    _fixed_size_list_to_matrix,
+    _vector_column_to_numpy,
+)
+
+
+def _fixed_size_list_chunked(rows, dim):
+    return pa.chunked_array([pa.array(rows, type=pa.list_(pa.float32(), dim))])
+
+
+def test_fixed_size_list_fast_path_matches_generic():
+    rows = [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]
+    col = _fixed_size_list_chunked(rows, 2)
+
+    matrix = _vector_column_to_numpy(col)
+
+    assert matrix.dtype == np.float32
+    np.testing.assert_array_equal(matrix, np.asarray(rows, dtype=np.float32))
+    # The fast path must actually engage for fixed-size-list input.
+    assert _fixed_size_list_to_matrix(col.combine_chunks()) is not None
+
+
+def test_generic_path_for_variable_list():
+    rows = [[1.0, 2.0], [3.0, 4.0]]
+    col = pa.chunked_array([pa.array(rows, type=pa.list_(pa.float32()))])
+
+    # Not fixed-size: fast path declines, generic path still produces the matrix.
+    assert _fixed_size_list_to_matrix(col.combine_chunks()) is None
+    np.testing.assert_array_equal(
+        _vector_column_to_numpy(col), np.asarray(rows, dtype=np.float32)
+    )
+
+
+def test_null_vectors_raise():
+    col = pa.chunked_array(
+        [pa.array([[1.0, 2.0], None], type=pa.list_(pa.float32(), 2))]
+    )
+    with pytest.raises(ValueError, match="null vectors"):
+        _vector_column_to_numpy(col)
+
+
+def test_empty_column_returns_empty_matrix():
+    col = pa.chunked_array([pa.array([], type=pa.list_(pa.float32(), 2))])
+    assert _vector_column_to_numpy(col).shape == (0, 0)
+
+
+def test_l2_distance_parity():
+    rows = [[0.0, 0.0], [3.0, 4.0]]
+    col = _fixed_size_list_chunked(rows, 2)
+    dists = _compute_vector_distances(col, [0.0, 0.0], "l2")
+    np.testing.assert_allclose(dists, [0.0, 5.0], rtol=1e-6)


### PR DESCRIPTION
When distributed vector search falls back to a flat scan (fragments without an index), it computes distances in NumPy, and `_vector_column_to_numpy` turned the vector column into a matrix by calling `to_pylist()` first. For a `FixedSizeList` column of N vectors that builds N Python lists of floats before copying them into NumPy — the slowest possible way, and it's on the hot path.

This adds a fast path that reshapes the column's contiguous child buffer straight into an `(N, dim)` float32 matrix. It only kicks in for a non-empty, null-free `FixedSizeList` whose buffer isn't offset; anything else — variable-size lists, nulls, sliced buffers — falls through to the original `to_pylist` path unchanged, so behavior is identical and only the common case gets faster.

Added unit tests for the fast path (parity with the generic path), the variable-list and empty cases, null rejection, and an end-to-end L2 distance check.
