### PR TITLE
feat: add continue_on_error to compact_database

### DIFF
--- a/lance_ray/compaction.py
+++ b/lance_ray/compaction.py
@@ -213,6 +213,7 @@ def compact_database(
     num_workers: int = 4,
     storage_options: Optional[dict[str, str]] = None,
     ray_remote_args: Optional[dict[str, Any]] = None,
+    continue_on_error: bool = False,
 ) -> list[dict[str, Any]]:
     """
     Compact all tables under a given database (namespace) using distributed Ray workers.
@@ -231,16 +232,23 @@ def compact_database(
         num_workers: Number of Ray workers per table (default: 4).
         storage_options: Storage options for the datasets.
         ray_remote_args: Options for Ray tasks (e.g. num_cpus, resources).
+        continue_on_error: If False (default), the first table that fails to
+            compact aborts the whole run with ``RuntimeError``. If True, failures
+            are recorded per table and the remaining tables are still compacted.
 
     Returns:
         A list of dicts, one per table, with keys:
         - ``"table_id"``: ``list[str]`` – full table identifier (database + table name).
         - ``"metrics"``: :class:`~lance.lance.CompactionMetrics` or ``None`` –
-          compaction result for that table, or ``None`` if no compaction was needed.
+          compaction result for that table, or ``None`` if no compaction was needed
+          or the table failed.
+        - ``"error"``: ``str`` – only present (and only when ``continue_on_error``
+          is True) for tables whose compaction failed.
 
     Raises:
         ValueError: If database is empty or namespace_impl is not provided.
-        RuntimeError: If listing tables fails or any table compaction fails.
+        RuntimeError: If listing tables fails, or if a table compaction fails
+            while ``continue_on_error`` is False.
 
     Example:
         >>> results = compact_database(
@@ -307,6 +315,10 @@ def compact_database(
             results.append({"table_id": table_id, "metrics": metrics})
         except Exception as e:
             logger.exception("Compaction failed for table %s: %s", table_id, e)
-            raise RuntimeError(f"Compaction failed for table {table_id}: {e}") from e
+            if not continue_on_error:
+                raise RuntimeError(
+                    f"Compaction failed for table {table_id}: {e}"
+                ) from e
+            results.append({"table_id": table_id, "metrics": None, "error": str(e)})
 
     return results

--- a/tests/test_distributed_compaction.py
+++ b/tests/test_distributed_compaction.py
@@ -530,6 +530,68 @@ class TestCompactDatabase:
         request = args[0] if args else kwargs.get("request")
         assert request is not None and request.id == ["my_db"]
 
+    def _mock_two_table_namespace(self):
+        mock_response = MagicMock()
+        mock_response.tables = ["table_a", "table_b"]
+        mock_response.page_token = None
+        mock_namespace = MagicMock()
+        mock_namespace.list_tables.return_value = mock_response
+        return mock_namespace
+
+    def test_compact_database_continue_on_error_records_failures(self):
+        """continue_on_error=True records per-table failures and keeps going."""
+        mock_namespace = self._mock_two_table_namespace()
+
+        def fake_compact_files(*, table_id, **kwargs):
+            if table_id == ["my_db", "table_a"]:
+                raise RuntimeError("boom")
+            return MagicMock()
+
+        with (
+            patch(
+                "lance_ray.compaction.get_or_create_namespace",
+                return_value=mock_namespace,
+            ),
+            patch(
+                "lance_ray.compaction.compact_files",
+                side_effect=fake_compact_files,
+            ),
+        ):
+            results = lr.compact_database(
+                database=["my_db"],
+                namespace_impl="dir",
+                namespace_properties={"root": "/tmp"},
+                continue_on_error=True,
+            )
+
+        assert len(results) == 2
+        by_id = {tuple(r["table_id"]): r for r in results}
+        assert by_id[("my_db", "table_a")]["metrics"] is None
+        assert "boom" in by_id[("my_db", "table_a")]["error"]
+        assert by_id[("my_db", "table_b")]["metrics"] is not None
+        assert "error" not in by_id[("my_db", "table_b")]
+
+    def test_compact_database_aborts_on_first_error_by_default(self):
+        """Default (continue_on_error=False) aborts the whole run on failure."""
+        mock_namespace = self._mock_two_table_namespace()
+
+        with (
+            patch(
+                "lance_ray.compaction.get_or_create_namespace",
+                return_value=mock_namespace,
+            ),
+            patch(
+                "lance_ray.compaction.compact_files",
+                side_effect=RuntimeError("boom"),
+            ),
+            pytest.raises(RuntimeError, match="Compaction failed for table"),
+        ):
+            lr.compact_database(
+                database=["my_db"],
+                namespace_impl="dir",
+                namespace_properties={"root": "/tmp"},
+            )
+
     def test_compact_database_two_tables_both_compacted(self, temp_dir):
         """compact_database compacts all tables under the given database."""
         import lance_namespace as ln


### PR DESCRIPTION
`compact_database` walks every table under a namespace and compacts each one, but the first table that failed aborted the whole run — so one bad table meant none of the tables after it got compacted.

This adds a `continue_on_error` flag (default `False`, so existing behavior is unchanged). When it's on, a failing table is recorded in the returned list as `{"table_id": ..., "metrics": None, "error": <message>}` and the remaining tables still compact; a failed table is told apart from one that simply needed no compaction by the presence of the `error` key, and the full traceback still goes to the log. Cross-table parallelism is left out on purpose, since each `compact_files` already runs its own Ray pool and running tables concurrently would risk oversubscribing the cluster.

Added unit tests for both paths — failures recorded with the run continuing, and the default aborting on the first failure.
