### PR TITLE
refactor: collapse redundant branch in add_columns_from transform

### DIFF
--- a/lance_ray/io.py
+++ b/lance_ray/io.py
@@ -799,9 +799,8 @@ def add_columns_from(
             result = transform(batch_dict)
             if isinstance(result, pa.RecordBatch):
                 new_cols = pa.Table.from_batches([result])
-            elif isinstance(result, pa.Table | dict):
-                new_cols = result
             else:
+                # Already a pa.Table or dict (normalized below).
                 new_cols = result
         else:
             reader = pa.RecordBatchReader.from_batches(


### PR DESCRIPTION
In `add_columns_from`, the callable-transform branch checked whether the transform's result was a `pa.Table` or `dict` and assigned `new_cols = result`, then the `else` did exactly the same thing. The `isinstance` check had no effect — both arms were identical — and the result is normalized further down regardless.

Collapsed the two arms into a single `else`. No behavior change; the `RecordBatch` case above it is untouched.
