### PR TITLE
chore: update pylance dependency to v9.0.0b8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=8.0.0b11",
+    "pylance>=9.0.0b8",
     "lance-namespace",
     "packaging",
     "pyarrow>=17.0.0",


### PR DESCRIPTION
## Summary
- Update the `pylance` dependency requirement to `pylance>=9.0.0b8`.
- Triggered by upstream tag `refs/tags/v9.0.0-beta.8`: https://github.com/lance-format/lance/releases/tag/v9.0.0-beta.8

## Verification
- `make lock` attempted, but uv cannot resolve `pylance>=9.0.0b8` yet because the configured Lance Fury index currently exposes only `pylance<=9.0.0b7`.
- `make lint` attempted, but it stops at the same `make lock` prerequisite before Ruff runs.
- The upstream `v9.0.0-beta.8` wheel publish workflow was still in progress during this update, so `uv.lock` could not be regenerated yet.
