### PR TITLE
feat(index): support distributed ZoneMap index

### DIFF
--- a/docs/src/distributed-indexing.md
+++ b/docs/src/distributed-indexing.md
@@ -7,7 +7,7 @@ Lance-Ray provides distributed index building functionality that leverages Ray's
 
 ### Scalar Indexing
 
-`create_scalar_index()` - Distributedly create scalar index using ray. Currently only Inverted/FTS/BTREE/BITMAP are supported. Will add more index type support in the future.
+`create_scalar_index()` - Distributedly create scalar index using ray. Currently only Inverted/FTS/BTREE/BITMAP/ZONEMAP are supported. Will add more index type support in the future.
 
 #### How It Works
 The `create_scalar_index` function allows you to create scalar indices for Lance datasets using the Ray distributed computing framework. This function distributes the index building process across multiple Ray worker nodes, with each node responsible for creating uncommitted index segments for a subset of dataset fragments. These segments are then committed as a single index.
@@ -69,7 +69,7 @@ def create_scalar_index(
 | `ray_remote_args` | `Dict[str, Any]`, optional | Ray task options (e.g., `num_cpus`, `resources`) |
 | `**kwargs` | `Any` | Additional arguments passed to `create_scalar_index` |
 
-**Note:** For distributed scalar indexing, currently only `"INVERTED"`, `"FTS"`, `"BTREE"` and `"BITMAP"` index types are supported.
+**Note:** For distributed scalar indexing, currently only `"INVERTED"`, `"FTS"`, `"BTREE"`, `"BITMAP"` and `"ZONEMAP"` index types are supported.
 
 #### Return Value
 
@@ -486,7 +486,7 @@ except ValueError as e:
 
 ### Important Notes
 
-- **Index Type Support**: For distributed indexing, currently only `"INVERTED"`/`"FTS"`/`"BTREE"`/`"BITMAP"` index types are supported, even though the function signature accepts other index types.
+- **Index Type Support**: For distributed indexing, currently only `"INVERTED"`/`"FTS"`/`"BTREE"`/`"BITMAP"`/`"ZONEMAP"` index types are supported, even though the function signature accepts other index types.
 - **Default Behavior**: The `replace` parameter defaults to `True`, meaning existing indices with the same name will be replaced without warning. Set `replace=False` to prevent accidental overwrites.
 - **Fragment Selection**: Use `fragment_ids` parameter to build indices on specific fragments only. This is useful for incremental index building or testing.
 - **Error Handling**: When `replace=False` and an index with the same name exists, a `ValueError` or `RuntimeError` will be raised depending on the execution context.

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -531,7 +531,6 @@ def create_scalar_index(
                 f"{sorted(supported_distributed_types)} index types, "
                 f"not '{index_type}'"
             )
-
     elif not isinstance(index_type, IndexConfig):
         raise ValueError(
             "index_type must be a string literal or IndexConfig object, got "

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -215,7 +215,7 @@ def _build_rabitq_model(*, dimension: int, num_bits: int = 1) -> str:
     return indices.build_rq_model(dimension=dimension, num_bits=num_bits)
 
 
-_SCALAR_SEGMENT_INDEX_TYPES = {"BTREE", "BITMAP", "INVERTED", "FTS"}
+_SCALAR_SEGMENT_INDEX_TYPES = {"BTREE", "BITMAP", "INVERTED", "FTS", "ZONEMAP"}
 
 
 def _scalar_index_type_name(index_type: str | IndexConfig) -> str | None:
@@ -524,13 +524,21 @@ def create_scalar_index(
                 f"Index type must be one of {valid_index_types}, not '{index_type}'"
             )
 
-        supported_distributed_types = {"INVERTED", "FTS", "BTREE", "BITMAP"}
+        supported_distributed_types = {"INVERTED", "FTS", "BTREE", "BITMAP", "ZONEMAP"}
         if index_type not in supported_distributed_types:
             raise ValueError(
                 "Distributed indexing currently supports "
                 f"{sorted(supported_distributed_types)} index types, "
                 f"not '{index_type}'"
             )
+
+        if index_type == "ZONEMAP":
+            zonemap_min_version = version.parse("9.0.0b1")
+            if version.parse(lance.__version__) < zonemap_min_version:
+                raise RuntimeError(
+                    f"Distributed ZONEMAP indexing requires pylance >= 9.0.0b1, "
+                    f"but found {lance.__version__}. Please upgrade pylance."
+                )
     elif not isinstance(index_type, IndexConfig):
         raise ValueError(
             "index_type must be a string literal or IndexConfig object, got "
@@ -588,7 +596,7 @@ def create_scalar_index(
                         f"Column {column} must be string type for {index_type} "
                         f"index, got {value_type}"
                     )
-            case "BTREE":
+            case "BTREE" | "ZONEMAP":
                 is_supported = (
                     pa.types.is_integer(value_type)
                     or pa.types.is_floating(value_type)
@@ -596,8 +604,8 @@ def create_scalar_index(
                 )
                 if not is_supported:
                     raise TypeError(
-                        f"Column {column} must be numeric or string type for BTREE "
-                        f"index, got {value_type}"
+                        f"Column {column} must be numeric or string type for "
+                        f"{index_type} index, got {value_type}"
                     )
             case _:
                 # For other index types, skip strict validation to maintain compatibility

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -532,13 +532,6 @@ def create_scalar_index(
                 f"not '{index_type}'"
             )
 
-        if index_type == "ZONEMAP":
-            zonemap_min_version = version.parse("9.0.0b1")
-            if version.parse(lance.__version__) < zonemap_min_version:
-                raise RuntimeError(
-                    f"Distributed ZONEMAP indexing requires pylance >= 9.0.0b1, "
-                    f"but found {lance.__version__}. Please upgrade pylance."
-                )
     elif not isinstance(index_type, IndexConfig):
         raise ValueError(
             "index_type must be a string literal or IndexConfig object, got "

--- a/tests/test_distributed_indexing.py
+++ b/tests/test_distributed_indexing.py
@@ -1185,22 +1185,6 @@ class TestDistributedBTreeIndexing:
         )
 
 
-def check_zonemap_version_compatibility():
-    """Check if lance version supports distributed ZONEMAP indexing (>= 9.0.0b1)."""
-    try:
-        lance_version = version.parse(lance.__version__)
-        zonemap_min_version = version.parse("9.0.0b1")
-        return lance_version >= zonemap_min_version
-    except (AttributeError, Exception):
-        return False
-
-
-@pytest.mark.skipif(
-    not check_zonemap_version_compatibility(),
-    reason="Distributed ZONEMAP indexing requires pylance >= 9.0.0b1. Current version: {}".format(
-        getattr(lance, "__version__", "unknown")
-    ),
-)
 class TestDistributedZoneMapIndexing:
     """Distributed ZONEMAP indexing tests."""
 

--- a/tests/test_distributed_indexing.py
+++ b/tests/test_distributed_indexing.py
@@ -1206,9 +1206,7 @@ class TestDistributedZoneMapIndexing:
         indices = updated_dataset.describe_indices()
         assert len(indices) > 0, "No indices found after distributed ZONEMAP build"
 
-        our_index = next(
-            (idx for idx in indices if idx.name == "zonemap_id_idx"), None
-        )
+        our_index = next((idx for idx in indices if idx.name == "zonemap_id_idx"), None)
         assert our_index is not None, "ZONEMAP index not found by name"
         assert our_index.index_type == "ZoneMap", (
             f"Expected ZoneMap index, got {our_index.index_type}"

--- a/tests/test_distributed_indexing.py
+++ b/tests/test_distributed_indexing.py
@@ -1185,6 +1185,117 @@ class TestDistributedBTreeIndexing:
         )
 
 
+def check_zonemap_version_compatibility():
+    """Check if lance version supports distributed ZONEMAP indexing (>= 9.0.0b1)."""
+    try:
+        lance_version = version.parse(lance.__version__)
+        zonemap_min_version = version.parse("9.0.0b1")
+        return lance_version >= zonemap_min_version
+    except (AttributeError, Exception):
+        return False
+
+
+@pytest.mark.skipif(
+    not check_zonemap_version_compatibility(),
+    reason="Distributed ZONEMAP indexing requires pylance >= 9.0.0b1. Current version: {}".format(
+        getattr(lance, "__version__", "unknown")
+    ),
+)
+class TestDistributedZoneMapIndexing:
+    """Distributed ZONEMAP indexing tests."""
+
+    def test_distributed_zonemap_index_basic(self, temp_dir):
+        """Build a distributed ZONEMAP index on an int column and verify index type."""
+        ds = generate_multi_fragment_dataset(
+            temp_dir, num_fragments=3, rows_per_fragment=500
+        )
+
+        updated_dataset = lr.create_scalar_index(
+            uri=ds.uri,
+            column="id",
+            index_type="ZONEMAP",
+            name="zonemap_id_idx",
+            replace=False,
+            num_workers=3,
+        )
+
+        indices = updated_dataset.describe_indices()
+        assert len(indices) > 0, "No indices found after distributed ZONEMAP build"
+
+        our_index = next(
+            (idx for idx in indices if idx.name == "zonemap_id_idx"), None
+        )
+        assert our_index is not None, "ZONEMAP index not found by name"
+        assert our_index.index_type == "ZoneMap", (
+            f"Expected ZoneMap index, got {our_index.index_type}"
+        )
+
+    def test_zonemap_query_results_match_baseline(self, temp_dir):
+        """ZONEMAP-indexed range queries must return the same rows as a non-indexed scan."""
+        with_index = generate_multi_fragment_dataset(
+            Path(temp_dir) / "with_zonemap",
+            num_fragments=3,
+            rows_per_fragment=500,
+        )
+        without_index = generate_multi_fragment_dataset(
+            Path(temp_dir) / "without_zonemap",
+            num_fragments=3,
+            rows_per_fragment=500,
+        )
+
+        updated_dataset = lr.create_scalar_index(
+            uri=with_index.uri,
+            column="id",
+            index_type="ZONEMAP",
+            name="zonemap_range_idx",
+            replace=False,
+            num_workers=3,
+        )
+
+        for filter_expr in [
+            "id = 250",
+            "id >= 200 AND id < 800",
+            "id < 500",
+            "id > 999",
+        ]:
+            indexed = updated_dataset.scanner(
+                filter=filter_expr, columns=["id"]
+            ).to_table()
+            baseline = without_index.scanner(
+                filter=filter_expr, columns=["id"]
+            ).to_table()
+            assert indexed.num_rows == baseline.num_rows, (
+                f"Row count mismatch for '{filter_expr}': "
+                f"indexed={indexed.num_rows}, baseline={baseline.num_rows}"
+            )
+            if indexed.num_rows > 0:
+                assert sorted(indexed.column("id").to_pylist()) == sorted(
+                    baseline.column("id").to_pylist()
+                ), f"Result mismatch for '{filter_expr}'"
+
+    def test_distributed_zonemap_index_string_column(self, temp_dir):
+        """Build a distributed ZONEMAP index on a string column."""
+        ds = generate_multi_fragment_dataset(
+            temp_dir, num_fragments=3, rows_per_fragment=200
+        )
+
+        updated_dataset = lr.create_scalar_index(
+            uri=ds.uri,
+            column="text",
+            index_type="ZONEMAP",
+            name="zonemap_text_idx",
+            replace=False,
+            num_workers=3,
+        )
+
+        indices = updated_dataset.describe_indices()
+        our_index = next(
+            (idx for idx in indices if idx.name == "zonemap_text_idx"), None
+        )
+        assert our_index is not None, "ZONEMAP string index not found by name"
+        assert our_index.index_type == "ZoneMap"
+
+
 class TestDistributedBitmapIndexing:
     """Distributed BITMAP indexing tests."""
 


### PR DESCRIPTION
Closes #5213

## Summary

- Add `"ZONEMAP"` to `_SCALAR_SEGMENT_INDEX_TYPES` so the segment workflow (`create_index_uncommitted` -> `commit_existing_index_segments`) is chosen, matching how BTREE and BITMAP are built
- Add `"ZONEMAP"` to `supported_distributed_types`, removing the `ValueError` that previously blocked it
- Extend the `"BTREE"` column-type validation case to `"BTREE" | "ZONEMAP"` with the same supported types: int, float, and string
- Bump minimum pylance dependency from `8.0.0b11` -> `9.0.0b10`
- Add `TestDistributedZoneMapIndexing` with three tests:
  - `test_distributed_zonemap_index_basic` — build on int column, verify `index_type == "ZoneMap"`
  - `test_zonemap_query_results_match_baseline` — range filter results match non-indexed baseline
  - `test_distributed_zonemap_index_string_column` — build on string column

## Verification

```bash
# ZoneMap-specific tests (require pylance >= 9.0.0b1)
python -m pytest tests/test_distributed_indexing.py::TestDistributedZoneMapIndexing -v
# 3 passed

# Full indexing suite
python -m pytest tests/test_distributed_indexing.py -q
# 66 passed, 1 skipped
```
