### PR TITLE
fix(index): pass PQ num_bits through distributed build

### DIFF
--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -851,6 +851,7 @@ class _NestedVectorIndicesBuilder:
         *,
         sample_rate: int = 256,
         max_iters: int = 50,
+        num_bits: int = 8,
         fragment_ids: Optional[list[int]] = None,
     ) -> Any:
         from lance.indices.pq import PqModel
@@ -858,7 +859,7 @@ class _NestedVectorIndicesBuilder:
 
         num_rows = _count_rows_for_fragments(self.dataset, fragment_ids)
         num_subvectors = _normalize_pq_params(num_subvectors, self.dimension)
-        _verify_pq_sample_rate(num_rows, sample_rate)
+        _verify_pq_sample_rate(num_rows, sample_rate, num_bits)
         codebook = indices.train_pq_model(
             self.dataset._ds,
             self.column,
@@ -869,8 +870,9 @@ class _NestedVectorIndicesBuilder:
             max_iters,
             ivf_model.centroids,
             fragment_ids,
+            num_bits=num_bits,
         )
-        return PqModel(num_subvectors, codebook)
+        return PqModel(num_subvectors, codebook, num_bits=num_bits)
 
 
 def _count_rows_for_fragments(
@@ -959,13 +961,14 @@ def _normalize_pq_params(num_subvectors: Optional[int], dimension: int) -> int:
     return num_subvectors
 
 
-def _verify_pq_sample_rate(num_rows: int, sample_rate: int) -> None:
+def _verify_pq_sample_rate(num_rows: int, sample_rate: int, num_bits: int = 8) -> None:
     _verify_base_sample_rate(sample_rate)
-    if 256 * sample_rate > num_rows:
+    required_rows = (2**num_bits) * sample_rate
+    if required_rows > num_rows:
         raise ValueError(
             "There are not enough rows in the dataset to create PQ codebook with "
-            f"a sample rate of {sample_rate}. {sample_rate * 256} rows needed and "
-            f"there are {num_rows}"
+            f"a sample rate of {sample_rate} and num_bits of {num_bits}. "
+            f"{required_rows} rows needed and there are {num_rows}"
         )
 
 
@@ -986,11 +989,13 @@ def _train_pq_for_field_path(
     *,
     num_subvectors: Optional[int],
     sample_rate: int,
+    num_bits: int,
 ) -> Any:
     return builder.train_pq(
         ivf_model,
         num_subvectors=num_subvectors,
         sample_rate=sample_rate,
+        num_bits=num_bits,
     )
 
 
@@ -1203,6 +1208,7 @@ def create_index(
         metric: Distance metric to use (default: "l2")
         num_partitions: Number of IVF partitions (optional)
         num_sub_vectors: Number of PQ sub-vectors (optional)
+        num_bits: Number of bits used to encode each PQ centroid (default: 8)
         sample_rate: Number of rows sampled per IVF partition and PQ centroid (default: 256)
         ivf_centroids: Pre-computed IVF centroids (optional)
         pq_codebook: Pre-computed PQ codebook (optional)
@@ -1284,8 +1290,7 @@ def create_index(
 
     if not replace and _index_exists(dataset_obj, name):
         raise ValueError(
-            f"Index with name '{name}' already exists. Set replace=True "
-            "to replace it."
+            f"Index with name '{name}' already exists. Set replace=True to replace it."
         )
 
     fragments = dataset_obj.get_fragments()
@@ -1343,9 +1348,12 @@ def create_index(
 
     if needs_pq:
         requested_num_sub_vectors = num_sub_vectors
+        pq_num_bits = index_build_kwargs.get("num_bits", 8)
         logger.info(
-            "Training PQ codebook: requested_num_sub_vectors=%s, sample_rate=%d",
+            "Training PQ codebook: requested_num_sub_vectors=%s, "
+            "num_bits=%d, sample_rate=%d",
             requested_num_sub_vectors,
+            pq_num_bits,
             sample_rate,
         )
         pq_model = _train_pq_for_field_path(
@@ -1353,6 +1361,7 @@ def create_index(
             ivf_model,
             num_subvectors=requested_num_sub_vectors,
             sample_rate=sample_rate,
+            num_bits=pq_num_bits,
         )
         pq_codebook_artifact = pq_model.codebook
         num_sub_vectors = pq_model.num_subvectors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=8.0.0b11",
+    "pylance==9.0.0rc1",
     "lance-namespace",
     "packaging",
     "pyarrow>=17.0.0",

--- a/tests/test_distributed_indexing.py
+++ b/tests/test_distributed_indexing.py
@@ -1534,6 +1534,10 @@ def test_build_distributed_vector_index(tmp_path, index_type):
     dataset_uri = generate_multi_fragment_vector_dataset(
         tmp_path, num_fragments=4, rows_per_fragment=1024, dim=128
     )
+    build_kwargs = {"num_sub_vectors": 16, "sample_rate": 16}
+    if index_type == "IVF_PQ":
+        build_kwargs.update(num_bits=4, sample_rate=4)
+    index_name = f"idx_{index_type}"
 
     # Build distributed vector index using the high-level Ray entrypoint.
     try:
@@ -1541,11 +1545,10 @@ def test_build_distributed_vector_index(tmp_path, index_type):
             uri=dataset_uri,
             column="vector",
             index_type=index_type,
-            name=f"idx_{index_type}",
+            name=index_name,
             num_workers=2,
             num_partitions=4,
-            num_sub_vectors=16,
-            sample_rate=16,
+            **build_kwargs,
         )
     except RuntimeError as exc:
         # Older pylance builds may not yet support creating empty distributed
@@ -1567,10 +1570,8 @@ def test_build_distributed_vector_index(tmp_path, index_type):
     assert len(indices) > 0, "No indices found after distributed vector index build"
 
     # Find the index with the name we specified
-    vec_index = next(
-        (idx for idx in indices if idx.name == f"idx_{index_type}"), None
-    )
-    assert vec_index is not None, f"Index with name idx_{index_type} not found"
+    vec_index = next((idx for idx in indices if idx.name == index_name), None)
+    assert vec_index is not None, f"Index with name {index_name} not found"
     assert vec_index.index_type == index_type, (
         f"Expected {index_type} vector index, got {vec_index.index_type}"
     )
@@ -1589,7 +1590,12 @@ def test_build_distributed_vector_index(tmp_path, index_type):
         columns=["id"],
     ).explain_plan()
     assert "ANNSubIndex" in plan
-    assert f"idx_{index_type}" in plan
+    assert index_name in plan
+
+    if index_type == "IVF_PQ":
+        stats = updated_dataset.stats.index_stats(index_name)
+        assert stats["indices"]
+        assert all(index["sub_index"]["nbits"] == 4 for index in stats["indices"])
 
 
 @pytest.mark.parametrize("index_type", ["IVF_FLAT", "IVF_PQ"])

--- a/tests/test_vector_index_options.py
+++ b/tests/test_vector_index_options.py
@@ -178,8 +178,8 @@ def test_map_async_with_pool_closes_and_joins_pool(monkeypatch):
     ]
 
 
-def test_create_index_uses_sample_rate_for_global_training(monkeypatch):
-    """The public sample_rate option should drive both IVF and PQ training."""
+def test_create_index_uses_sample_rate_and_num_bits_for_global_training(monkeypatch):
+    """sample_rate and num_bits should drive global training and worker build."""
 
     captured = {}
     fake_dataset = _FakeDataset()
@@ -242,15 +242,18 @@ def test_create_index_uses_sample_rate_for_global_training(monkeypatch):
         num_workers=2,
         num_partitions=4,
         num_sub_vectors=4,
+        num_bits=4,
         sample_rate=8,
     )
 
     assert updated_dataset is fake_dataset
     assert captured["train_ivf"]["sample_rate"] == 8
     assert captured["train_pq"]["sample_rate"] == 8
+    assert captured["train_pq"]["num_bits"] == 4
     assert captured["put_artifacts"] == ("ivf_centroids", "pq_codebook")
     assert captured["fragment_handler_kwargs"]["ivf_centroids"] == "ivf_ref"
     assert captured["fragment_handler_kwargs"]["pq_codebook"] == "pq_ref"
+    assert captured["fragment_handler_kwargs"]["num_bits"] == 4
     assert "sample_rate" not in captured["fragment_handler_kwargs"]
     assert fake_dataset.commit_kwargs["segments"] == ["segment"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -326,19 +326,19 @@ wheels = [
 
 [[package]]
 name = "lance-namespace"
-version = "0.8.4"
+version = "0.8.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/8f/8a03395587a78cfaf92f7307ad931f61eb515af67705c704bd6c7af2f745/lance_namespace-0.8.4.tar.gz", hash = "sha256:1a54ad49e7ace25a629c5f2c99d393629742eceeeb16ba2f51a771ccb350e284", size = 11282, upload-time = "2026-06-10T19:07:21.919Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/12/f7ab93b29be3edbf5fc3610714bf2d06088e7f4524bfb38dfd6852458b08/lance_namespace-0.8.6.tar.gz", hash = "sha256:18232e721c8188145f4ec9389cc2dfbeeabf54a619d94885ea1b3375bee9f4af", size = 11529, upload-time = "2026-06-12T17:36:41.651Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/4b/218c67cafb707024069925ce86534588861a464aaa327f7a457b94eed3c2/lance_namespace-0.8.4-py3-none-any.whl", hash = "sha256:8b347eef4b7c7187a1b52f388b5dcc345fed0bf4ea87728188dcb11a52619d0b", size = 13111, upload-time = "2026-06-10T19:07:22.6Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1b/5b1668ee2dc8910965f390640359112a31157092fcf8e000b89c79b58708/lance_namespace-0.8.6-py3-none-any.whl", hash = "sha256:571eae34f9aad70e5b05020416c2860889b9ec82993ccd0eb015e7b39c3ea309", size = 13383, upload-time = "2026-06-12T17:36:43.456Z" },
 ]
 
 [[package]]
 name = "lance-namespace-urllib3-client"
-version = "0.8.4"
+version = "0.8.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -346,9 +346,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/55/4a7cc7e5d19bda170c896a6adff2ec925c533df812b91bce2bc8f7aea30b/lance_namespace_urllib3_client-0.8.4.tar.gz", hash = "sha256:1a292a83509ab79475da967b78839e9ead4ab973064d37d1ba1575b23ffdacef", size = 228485, upload-time = "2026-06-10T19:07:19.863Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/80/fb224b4a89c1c1638cde949cb6cce6c3aca7759effbfea46a3d9c3960b21/lance_namespace_urllib3_client-0.8.6.tar.gz", hash = "sha256:b6fb1d306e74a7576e5309919020be744527de484a63dbf5eed10f8b368548df", size = 228772, upload-time = "2026-06-12T17:36:42.609Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/f7/70dd2fc1f9ef462d3802b4cffcd64f2b9233a9907d6071e8694338492608/lance_namespace_urllib3_client-0.8.4-py3-none-any.whl", hash = "sha256:37ee1d74614fae6358f50e3589ac26c29379ffb1346f09c4f5ec8953f823cefd", size = 369807, upload-time = "2026-06-10T19:07:21.001Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/90/1e27de15cd1b16785a1c7312beb0a59e75c8344a815f600f58173a565bd1/lance_namespace_urllib3_client-0.8.6-py3-none-any.whl", hash = "sha256:9d78249c3fb15aa3d15d668f78f04a275af3d08d800a7027492f37996ac4968b", size = 369950, upload-time = "2026-06-12T17:36:40.438Z" },
 ]
 
 [[package]]
@@ -387,7 +387,7 @@ requires-dist = [
     { name = "more-itertools", marker = "python_full_version < '3.12'", specifier = ">=2.6.0" },
     { name = "packaging" },
     { name = "pyarrow", specifier = ">=17.0.0" },
-    { name = "pylance", specifier = ">=8.0.0b11" },
+    { name = "pylance", specifier = "==9.0.0rc1" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
@@ -1024,7 +1024,7 @@ wheels = [
 
 [[package]]
 name = "pylance"
-version = "8.0.0b11"
+version = "9.0.0rc1"
 source = { registry = "https://pypi.fury.io/lance-format" }
 dependencies = [
     { name = "lance-namespace" },
@@ -1033,12 +1033,12 @@ dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://pypi.fury.io/lance-format/-/ver_GL5dn/pylance-8.0.0b11-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:2f2e66c6a7039ba51ac6174d0336b4f38a58351706e16b8b21a6c71f06cd1f20" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1pVrmn/pylance-8.0.0b11-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f85711b2f468acfe20ad2542639b82e9658ed301d72f5cfde82e2e40ef431b15" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1qcBDw/pylance-8.0.0b11-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:602af5469141d0c6667d902f6819cd2b7b5ce40193190be6a030adc753a36fe7" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1V5g0y/pylance-8.0.0b11-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:b6b89f48f198b3fe59ad795bac614a1cc8892e20f2ba2acd1f958a18d05e4b32" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_7rhla/pylance-8.0.0b11-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:4c8b16c860345f3c519dc28dd4dab111bdc2c104795c1c7fb3f245d798f64792" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1f0tKO/pylance-8.0.0b11-cp39-abi3-win_amd64.whl", hash = "sha256:66297c0a3708e4b6921d6430153d2cb89f7a618110bf8d119cb9986a81a6371c" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_vEHBE/pylance-9.0.0rc1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f0b6b02a1808bb3072ee7fe4e36614cae6f86302513e73ec7f55b2234a963b24" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1Jipm4/pylance-9.0.0rc1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30f0ebf0d88034301819eb964f9236ce555aaa58e7ab89c5975a3e2250bbb405" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_IvKxo/pylance-9.0.0rc1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:44609ea2615ea6e684b85478d1694af2026458f61cf7895ecc75e238bfd17aa8" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_2hidj1/pylance-9.0.0rc1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:182167a8dba9eeabffbffd53bd5b8548613d4d459b7cd7b34a840dd00cbb806f" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1dFx3r/pylance-9.0.0rc1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:8a63b11e814b7eab758bcaf0d6f97eb05ea86203d9fb0af718c462c24c7d6c9c" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_2a8dSh/pylance-9.0.0rc1-cp310-abi3-win_amd64.whl", hash = "sha256:2ff8b953ae2b0550490c1a7efd210aa91bc223d200ffac28849056cfd7436d97" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Background
While building vector indexes with Ray distributed indexing, we found that `create_index(..., num_bits=4)` did not apply the requested bit width to global PQ training. Segment builds could receive `num_bits=4`, but the shared global PQ codebook was still trained through the default 8-bit path.

The PQ codebook is parameterized by `num_bits`: 4-bit PQ should use 16 centroids per sub-vector, while 8-bit PQ uses 256. If global training and worker segment builds disagree, the distributed index can reuse PQ artifacts that do not match the requested build settings, which can hurt quantization/index quality.

This depends on lance-format/lance#7583, which is included in `pylance` v9.0.0-rc.1. This PR now bumps the `pylance` dependency to that RC so the distributed PQ `num_bits` path is available through the released Python package.

## Summary
- pass the requested `num_bits` to global PQ training
- keep global PQ training and worker segment builds on the same PQ bit width
- update nested-vector PQ training and sample-size validation to use the configured PQ bit width
- update `pylance` to v9.0.0-rc.1 and refresh `uv.lock`

## Tests
- `uv run --frozen pytest tests/test_vector_index_options.py::test_create_index_uses_sample_rate_and_num_bits_for_global_training`
- `uv run --frozen pytest 'tests/test_distributed_indexing.py::test_build_distributed_vector_index[IVF_PQ]'`
- `uv run --frozen ruff check lance_ray/index.py tests/test_distributed_indexing.py tests/test_vector_index_options.py`
- `uv run --frozen ruff format --check lance_ray/index.py tests/test_distributed_indexing.py tests/test_vector_index_options.py`
- `uv lock --check`
- `uv run ruff check`