### PR TITLE
feat: forward stable row ID write configuration

### DIFF
--- a/lance_ray/datasink.py
+++ b/lance_ray/datasink.py
@@ -59,6 +59,7 @@ class _BaseLanceDatasink(Datasink):
         *args: Any,
         schema: Optional[pa.Schema] = None,
         mode: Literal["create", "append", "overwrite"] = "create",
+        enable_stable_row_ids: bool = False,
         storage_options: Optional[dict[str, Any]] = None,
         base_store_params: Optional[dict[str, dict[str, Any]]] = None,
         initial_bases: Optional[list[Any]] = None,
@@ -122,6 +123,7 @@ class _BaseLanceDatasink(Datasink):
 
         self.schema = schema
         self.mode = mode
+        self.enable_stable_row_ids = enable_stable_row_ids
         self.read_version: Optional[int] = None
         self.storage_options = merged_storage_options
         self.base_store_params = base_store_params
@@ -218,6 +220,7 @@ class _BaseLanceDatasink(Datasink):
                 op,
                 read_version=self.read_version,
                 storage_options=self.storage_options,
+                enable_stable_row_ids=self.enable_stable_row_ids,
                 **self.namespace_kwargs,
                 **base_store_params_kwargs,
             )
@@ -250,6 +253,8 @@ class LanceDatasink(_BaseLanceDatasink):
             efficient but require newer versions of lance to read.  The default is
             "legacy" which will use the legacy v1 version.  See the user guide
             for more details.
+        enable_stable_row_ids : bool, default False
+            Enable stable row IDs for the dataset and all written fragments.
         storage_options : Dict[str, Any], optional
             The storage options for the writer. Default is None.
         base_store_params : dict, optional
@@ -292,6 +297,7 @@ class LanceDatasink(_BaseLanceDatasink):
         min_rows_per_file: int = 1024 * 1024,
         max_rows_per_file: int = 64 * 1024 * 1024,
         data_storage_version: Optional[str] = None,
+        enable_stable_row_ids: bool = False,
         storage_options: Optional[dict[str, Any]] = None,
         base_store_params: Optional[dict[str, dict[str, Any]]] = None,
         initial_bases: Optional[list[Any]] = None,
@@ -316,6 +322,7 @@ class LanceDatasink(_BaseLanceDatasink):
             *args,
             schema=schema,
             mode=mode,
+            enable_stable_row_ids=enable_stable_row_ids,
             storage_options=storage_options,
             base_store_params=base_store_params,
             initial_bases=initial_bases,
@@ -369,6 +376,7 @@ class LanceDatasink(_BaseLanceDatasink):
             schema=self.schema,
             max_rows_per_file=self.max_rows_per_file,
             data_storage_version=self.data_storage_version,
+            enable_stable_row_ids=self.enable_stable_row_ids,
             storage_options=self.storage_options,
             base_store_params=self.base_store_params,
             initial_bases=self.initial_bases if self.mode == "create" else None,

--- a/lance_ray/fragment.py
+++ b/lance_ray/fragment.py
@@ -44,6 +44,7 @@ def write_fragment(
     max_bytes_per_file: Optional[int] = None,
     max_rows_per_group: int = 1024,  # Only useful for v1 writer.
     data_storage_version: Optional[str] = None,
+    enable_stable_row_ids: bool = False,
     storage_options: Optional[dict[str, Any]] = None,
     base_store_params: Optional[dict[str, dict[str, Any]]] = None,
     initial_bases: Optional[list[Any]] = None,
@@ -126,6 +127,7 @@ def write_fragment(
             max_rows_per_group=max_rows_per_group,
             max_bytes_per_file=max_bytes_per_file,
             data_storage_version=data_storage_version,
+            enable_stable_row_ids=enable_stable_row_ids,
             storage_options=storage_options,
             **write_kwargs,
             **initial_bases_kwargs,
@@ -280,6 +282,8 @@ class LanceFragmentWriter:
         The version of the data storage format to use. Newer versions are more
         efficient but require newer versions of lance to read.  The default
         (None) will use the 2.0 version.  See the user guide for more details.
+    enable_stable_row_ids : bool, default False
+        Enable stable row IDs for fragments written into a stable-row-ID dataset.
     use_legacy_format : optional, bool, default None
         Deprecated method for setting the data storage version. Use the
         `data_storage_version` parameter instead.
@@ -325,6 +329,7 @@ class LanceFragmentWriter:
         max_bytes_per_file: Optional[int] = None,
         max_rows_per_group: Optional[int] = None,  # Only useful for v1 writer.
         data_storage_version: Optional[str] = None,
+        enable_stable_row_ids: bool = False,
         use_legacy_format: Optional[bool] = False,
         storage_options: Optional[dict[str, Any]] = None,
         base_store_params: Optional[dict[str, dict[str, Any]]] = None,
@@ -363,6 +368,7 @@ class LanceFragmentWriter:
         self.max_rows_per_file = max_rows_per_file
         self.max_bytes_per_file = max_bytes_per_file
         self.data_storage_version = data_storage_version
+        self.enable_stable_row_ids = enable_stable_row_ids
         self.storage_options = storage_options
         self.base_store_params = base_store_params
         self.initial_bases = normalize_initial_bases(initial_bases)
@@ -406,6 +412,7 @@ class LanceFragmentWriter:
             max_rows_per_group=self.max_rows_per_group,
             max_bytes_per_file=self.max_bytes_per_file,
             data_storage_version=self.data_storage_version,
+            enable_stable_row_ids=self.enable_stable_row_ids,
             storage_options=self.storage_options,
             base_store_params=self.base_store_params,
             initial_bases=self.initial_bases,

--- a/lance_ray/io.py
+++ b/lance_ray/io.py
@@ -154,6 +154,7 @@ def write_lance(
     min_rows_per_file: int = 1024 * 1024,
     max_rows_per_file: int = 64 * 1024 * 1024,
     data_storage_version: Optional[str] = None,
+    enable_stable_row_ids: bool = False,
     storage_options: Optional[dict[str, Any]] = None,
     base_store_params: Optional[dict[str, dict[str, Any]]] = None,
     initial_bases: Optional[list[Any]] = None,
@@ -209,6 +210,8 @@ def write_lance(
             efficient but require newer versions of lance to read.  The default is
             "legacy" which will use the legacy v1 version.  See the user guide
             for more details.
+        enable_stable_row_ids: Enable stable row IDs for the dataset and all
+            fragments written by this operation. Default is False.
         storage_options: The storage options for the writer. Default is None.
         base_store_params: Runtime-only storage options keyed by registered
             base path URI. Used for BlobV2 references that live outside the
@@ -256,6 +259,7 @@ def write_lance(
             min_rows_per_file=min_rows_per_file,
             max_rows_per_file=max_rows_per_file,
             data_storage_version=data_storage_version,
+            enable_stable_row_ids=enable_stable_row_ids,
             storage_options=storage_options,
             base_store_params=base_store_params,
             initial_bases=initial_bases,
@@ -348,6 +352,7 @@ def write_lance(
             max_rows_per_file=max_rows_per_file,
             max_rows_per_group=min_rows_per_file,  # keep naming aligned with v1 semantics
             data_storage_version=data_storage_version,
+            enable_stable_row_ids=enable_stable_row_ids,
             storage_options=storage_options,
             base_store_params=base_store_params,
             initial_bases=fragment_initial_bases,
@@ -386,6 +391,7 @@ def write_lance(
                     op,
                     read_version=None,
                     storage_options=storage_options,
+                    enable_stable_row_ids=enable_stable_row_ids,
                     **base_store_params_kwargs,
                 )
                 first_commit_done = True
@@ -406,6 +412,7 @@ def write_lance(
                     op,
                     read_version=dest_version,
                     storage_options=storage_options,
+                    enable_stable_row_ids=enable_stable_row_ids,
                     **base_store_params_kwargs,
                 )
                 first_commit_done = True
@@ -434,6 +441,7 @@ def write_lance(
                     op,
                     read_version=None,
                     storage_options=storage_options,
+                    enable_stable_row_ids=enable_stable_row_ids,
                     **base_store_params_kwargs,
                 )
                 first_commit_done = True
@@ -445,6 +453,7 @@ def write_lance(
                 op,
                 read_version=dest_version,
                 storage_options=storage_options,
+                enable_stable_row_ids=enable_stable_row_ids,
                 **base_store_params_kwargs,
             )
             try:

--- a/tests/test_basic_read_write.py
+++ b/tests/test_basic_read_write.py
@@ -61,6 +61,17 @@ class TestWriteLance:
         assert path.exists()
         assert path.is_dir()
 
+    def test_write_lance_with_stable_row_ids(self, sample_dataset, temp_dir):
+        path = Path(temp_dir) / "stable_row_ids.lance"
+
+        lr.write_lance(
+            sample_dataset,
+            str(path),
+            enable_stable_row_ids=True,
+        )
+
+        assert lance.dataset(str(path)).has_stable_row_ids
+
     def test_write_lance_with_schema(self, temp_dir):
         """Test write with explicit schema."""
         path = Path(temp_dir) / "schema_write.lance"

--- a/tests/test_fragment.py
+++ b/tests/test_fragment.py
@@ -209,6 +209,52 @@ class TestLanceFragmentWriterCommitter:
         assert len(ds.get_fragments()) == 2
 
     @pytest.mark.filterwarnings("ignore::DeprecationWarning")
+    def test_fragment_writer_committer_enables_stable_row_ids(self, tmp_path: Path):
+        schema = pa.schema([pa.field("id", pa.int64())])
+
+        (
+            ray.data.range(10)
+            .map_batches(
+                LanceFragmentWriter(
+                    tmp_path,
+                    schema=schema,
+                    enable_stable_row_ids=True,
+                ),
+                batch_size=5,
+            )
+            .write_datasink(
+                LanceFragmentCommitter(
+                    tmp_path,
+                    enable_stable_row_ids=True,
+                )
+            )
+        )
+
+        dataset = lance.dataset(tmp_path)
+        assert dataset.has_stable_row_ids
+        before_table = dataset.to_table(columns=["id"], with_row_id=True)
+        before = dict(
+            zip(
+                before_table["id"].to_pylist(),
+                before_table["_rowid"].to_pylist(),
+                strict=True,
+            )
+        )
+
+        dataset.optimize.compact_files(target_rows_per_fragment=10)
+        compacted = lance.dataset(tmp_path)
+        after_table = compacted.to_table(columns=["id"], with_row_id=True)
+        after = dict(
+            zip(
+                after_table["id"].to_pylist(),
+                after_table["_rowid"].to_pylist(),
+                strict=True,
+            )
+        )
+
+        assert after == before
+
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_fragment_writer_with_transform(self, tmp_path: Path):
         """Test fragment writer with custom transform function."""
         schema = pa.schema(


### PR DESCRIPTION
## Summary

Forward PyLance's `enable_stable_row_ids` option through every Lance-Ray write path:

- `write_fragment`
- `LanceFragmentWriter`
- `LanceDatasink` and `LanceFragmentCommitter`
- non-streaming and streaming `write_lance`

The option remains disabled by default, so existing callers are unchanged.

## Why

Distributed writers could create and commit ordinary Lance fragments, but had no way to request stable row IDs even though PyLance supports the option at fragment-write and dataset-commit time. This prevents downstream datasets from retaining row identity across operations such as compaction.

## Validation

- `37 passed` in `tests/test_basic_read_write.py` and `tests/test_fragment.py`
- Production rewrite of 355,952,746 rows across 56,696 fragments
- Stable row IDs enabled on the committed dataset and preserved across the subsequent URL-index commit
- Source and target row count and Arrow schema matched exactly
- 1,000 deterministic samples matched exact image bytes and stored/computed MD5 values
- 1,000 stable-ID image reads completed with 16 workers at 42.47 images/s and 9.98 MiB/s

The production dataset's fresh remote URL-index initialization remained expensive; that is an index-distribution/cache concern separate from Lance-Ray's stable-row-ID write forwarding.
