### PR TITLE
fix(index): support large_string columns for BTREE scalar indexes

### DIFF
--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -593,6 +593,7 @@ def create_scalar_index(
                     pa.types.is_integer(value_type)
                     or pa.types.is_floating(value_type)
                     or pa.types.is_string(value_type)
+                    or pa.types.is_large_string(value_type)
                 )
                 if not is_supported:
                     raise TypeError(

--- a/tests/test_distributed_indexing.py
+++ b/tests/test_distributed_indexing.py
@@ -1685,3 +1685,42 @@ def test_distributed_nested_vector_index_and_search(tmp_path, index_type):
 
     assert result.num_rows == 5
     assert result.column("id").to_pylist()[0] == 0
+
+
+@pytest.fixture
+def large_string_dataset(temp_dir):
+    """Create a multi-fragment dataset whose indexed column is large_string."""
+    path = Path(temp_dir) / "large_string.lance"
+    table = pa.table(
+        {
+            "id": pa.array(range(8), type=pa.int64()),
+            "large_text": pa.array(
+                [f"value-{i:02d}" for i in range(8)], type=pa.large_string()
+            ),
+        }
+    )
+    lance.write_dataset(table, str(path), max_rows_per_file=2)
+    return str(path)
+
+
+def test_build_distributed_btree_index_on_large_string(large_string_dataset):
+    """BTREE indexes must accept large_string columns.
+
+    This exercises the real pylance build (lance-format/lance#7525) rather than
+    a mocked worker, so it fails if the pinned pylance cannot index large_string.
+    """
+    updated_dataset = lr.create_scalar_index(
+        uri=large_string_dataset,
+        column="large_text",
+        index_type="BTREE",
+        num_workers=2,
+    )
+
+    indices = {idx.name: idx for idx in updated_dataset.describe_indices()}
+    assert "large_text_idx" in indices
+    assert indices["large_text_idx"].field_names == ["large_text"]
+
+    results = updated_dataset.scanner(
+        filter="large_text = 'value-03'", columns=["id"]
+    ).to_table()
+    assert results.column("id").to_pylist() == [3]


### PR DESCRIPTION
## Summary

Accept `large_string` columns for distributed `BTREE` scalar indexes.

lance-format/lance#7525 added `large_string` support in pylance, but lance-ray still rejected those columns in its own driver-side type check, so the distributed build never started.

The check stays on the driver: with the default `replace=True`, the existing index is dropped before any worker runs, so validation has to happen before that drop.

## Verification

```bash
.venv/bin/python -m pytest --no-cov -q \
  tests/test_vector_index_options.py \
  tests/test_distributed_indexing.py::test_build_distributed_btree_index_on_large_string
# 15 passed
```

The new integration test builds the index end to end against the pinned pylance (`9.0.0rc1`) instead of only mocking the worker.
