### PR TITLE
fix(compaction): handle omitted compaction_options in compact_files

### DIFF
--- a/lance_ray/compaction.py
+++ b/lance_ray/compaction.py
@@ -146,7 +146,9 @@ def compact_files(
     logger.info("Starting distributed compaction")
 
     # Step 1: Create the compaction plan
-    compaction_plan = Compaction.plan(dataset, compaction_options)
+    # Compaction.plan requires a dict; CompactionOptions is a TypedDict, so
+    # an empty instance stands in for "all defaults" when the caller omits it.
+    compaction_plan = Compaction.plan(dataset, compaction_options or CompactionOptions())
 
     logger.info(f"Compaction plan created with {compaction_plan.num_tasks()} tasks")
 

--- a/tests/test_distributed_compaction.py
+++ b/tests/test_distributed_compaction.py
@@ -106,6 +106,29 @@ class TestDistributedCompaction:
         assert fragments[0].count_rows() == 20, "Fragment should have 20 rows"
         assert dataset.count_rows() == 20, "Should still have 20 total rows"
 
+    def test_compaction_without_options(self, temp_dir):
+        """
+        Test that compact_files works when compaction_options is omitted.
+
+        Regression test: the default None used to be passed straight into
+        Compaction.plan, which rejects non-dict values with
+        "TypeError: 'None' is not an instance of 'dict'".
+        """
+        dataset_path = Path(temp_dir) / "test_dataset_default_options"
+
+        fragments = [
+            pd.DataFrame({"id": range(i * 10, (i + 1) * 10)}) for i in range(2)
+        ]
+        dataset = create_dataset_with_fragments(dataset_path, fragments)
+        assert len(dataset.get_fragments()) == 2
+
+        metrics = lr.compact_files(uri=str(dataset_path), num_workers=1)
+
+        assert metrics is not None, "Two small fragments should be compacted"
+        assert metrics.fragments_removed == 2
+        dataset = lance.dataset(str(dataset_path))
+        assert dataset.count_rows() == 20
+
     def test_deletion_compaction(self, temp_dir):
         """
         Test compaction that materializes deletions.


### PR DESCRIPTION
## Summary

`compact_files()` declares `compaction_options: Optional[CompactionOptions] = None`, but passes the value straight into `Compaction.plan(dataset, compaction_options)`. `Compaction.plan`'s binding requires a dict, so calling `compact_files()` without explicitly passing `compaction_options` always fails with:

```
TypeError: 'None' is not an instance of 'dict'
```

Fixes #5224.

## Change

- Substitute an empty `CompactionOptions()` when the caller omits the argument (`CompactionOptions` is a `TypedDict`, so an empty instance means "all defaults").
- Add `test_compaction_without_options`, a regression test exercising the default-argument path — existing tests all passed `compaction_options` explicitly, which is why this never surfaced.

## Testing

```
pytest tests/test_distributed_compaction.py -k "basic_compaction or without_options"
2 passed
```