### PR TITLE
feat(index): support distributed IVF_RQ vector indexes

### DIFF
--- a/docs/src/distributed-indexing.md
+++ b/docs/src/distributed-indexing.md
@@ -110,6 +110,7 @@ def create_index(
     sample_rate: int = 256,
     ivf_centroids: Optional["pyarrow.Array"] = None,
     pq_codebook: Optional["pyarrow.Array"] = None,
+    rabitq_model: Optional[str] = None,
     **kwargs: Any,
 ) -> "lance.LanceDataset":
 ```
@@ -136,7 +137,13 @@ def create_index(
 | `sample_rate` | `int`, optional | Number of rows sampled per IVF partition and PQ centroid, default is 256 |
 | `ivf_centroids` | `pyarrow.Array`, optional | Pre-computed IVF centroids (advanced) |
 | `pq_codebook` | `pyarrow.Array`, optional | Pre-computed PQ codebook for PQ-based indices (advanced) |
+| `rabitq_model` | `str`, optional | Pre-built RaBitQ model for IVF_RQ. If omitted for IVF_RQ, Lance-Ray builds one shared model on the driver |
 | `**kwargs` | `Any` | Additional arguments to pass through to Lance index creation |
+
+For `IVF_RQ`, Lance-Ray builds one shared RaBitQ rotation model on the driver
+when `rabitq_model` is not provided, then passes that same model to every
+fragment worker. To pin or reuse a model yourself, pass the JSON string returned
+by `lance.lance.indices.build_rq_model(...)` as `rabitq_model`.
 
 #### Return Value
 
@@ -324,6 +331,21 @@ updated_dataset = lr.create_index(
     name="idx_ivf_rq",
     num_workers=4,
     num_partitions=256,
+)
+
+# Or provide a pre-built shared RaBitQ model explicitly.
+from lance.lance import indices
+
+rabitq_model = indices.build_rq_model(dimension=128, num_bits=1)
+updated_dataset = lr.create_index(
+    uri="path/to/dataset.lance",
+    column="vector",
+    index_type="IVF_RQ",
+    name="idx_ivf_rq",
+    num_workers=4,
+    num_partitions=256,
+    num_bits=1,
+    rabitq_model=rabitq_model,
 )
 
 # Build a distributed IVF_FLAT index

--- a/docs/src/distributed-indexing.md
+++ b/docs/src/distributed-indexing.md
@@ -138,12 +138,19 @@ def create_index(
 | `ivf_centroids` | `pyarrow.Array`, optional | Pre-computed IVF centroids (advanced) |
 | `pq_codebook` | `pyarrow.Array`, optional | Pre-computed PQ codebook for PQ-based indices (advanced) |
 | `rabitq_model` | `str`, optional | Pre-built RaBitQ model for IVF_RQ. If omitted for IVF_RQ, Lance-Ray builds one shared model on the driver |
+| `num_bits` | `int`, optional | RaBitQ bits per vector dimension for IVF_RQ, default is 1. Passed through to Lance for validation |
 | `**kwargs` | `Any` | Additional arguments to pass through to Lance index creation |
 
 For `IVF_RQ`, Lance-Ray builds one shared RaBitQ rotation model on the driver
 when `rabitq_model` is not provided, then passes that same model to every
 fragment worker. To pin or reuse a model yourself, pass the JSON string returned
 by `lance.lance.indices.build_rq_model(...)` as `rabitq_model`.
+
+The RaBitQ model dimension is the vector column width and must be divisible by
+8. `num_bits` controls how many RaBitQ code bits are used per vector dimension:
+larger values can increase quantized-code fidelity at the cost of more index
+storage and memory. The default is 1, matching Lance's IVF_RQ default, and
+supported values are validated by Lance.
 
 #### Return Value
 

--- a/docs/src/distributed-indexing.md
+++ b/docs/src/distributed-indexing.md
@@ -80,8 +80,12 @@ The function returns an updated Lance dataset with the newly created index.
 #### Supported Index Types
 The following vector index types are supported for distributed building:
 - `IVF_FLAT`
-- `IVF_SQ`
 - `IVF_PQ`
+- `IVF_RQ`
+- `IVF_SQ`
+- `IVF_HNSW_FLAT`
+- `IVF_HNSW_PQ`
+- `IVF_HNSW_SQ`
 
 #### `create_index`
 
@@ -116,7 +120,7 @@ def create_index(
 |-----------|------|-------------|
 | `uri` | `str` or `lance.LanceDataset`, optional | Lance dataset object, or its URI. Either `uri` OR (`namespace_impl` + `table_id`) must be provided when using URI mode. If you pass a `lance.LanceDataset` object, namespace parameters are ignored. |
 | `column` | `str` | Vector column name to index |
-| `index_type` | `str` | Vector index type (e.g., `"IVF_PQ"`, `"IVF_SQ"`, `"IVF_FLAT"`) |
+| `index_type` | `str` | Vector index type (e.g., `"IVF_PQ"`, `"IVF_RQ"`, `"IVF_SQ"`, `"IVF_FLAT"`) |
 | `name` | `str`, optional | Index name, auto-generated if not provided |
 | `replace` | `bool`, optional | Whether to replace existing index, default is `True` |
 | `num_workers` | `int`, optional | Number of Ray workers to use, default is 4 |
@@ -285,7 +289,7 @@ updated_dataset.scanner(filter="id = 100", columns=["id", "text"]).to_table()
 updated_dataset.scanner(filter="id >= 200 AND id < 800", columns=["id", "text"]).to_table()
 ```
 
-### Vector Index (IVF_PQ / IVF_SQ / IVF_FLAT)
+### Vector Index (IVF_PQ / IVF_RQ / IVF_SQ / IVF_FLAT)
 ```python
 import lance_ray as lr
 
@@ -308,6 +312,16 @@ updated_dataset = lr.create_index(
     column="vector",
     index_type="IVF_SQ",
     name="idx_ivf_sq",
+    num_workers=4,
+    num_partitions=256,
+)
+
+# Build a distributed IVF_RQ index
+updated_dataset = lr.create_index(
+    uri="path/to/dataset.lance",
+    column="vector",
+    index_type="IVF_RQ",
+    name="idx_ivf_rq",
     num_workers=4,
     num_partitions=256,
 )

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -192,7 +192,13 @@ def _put_vector_index_artifacts_in_object_store(
 
 
 def _build_rabitq_model(*, dimension: int, num_bits: int = 1) -> str:
-    """Build one shared RaBitQ rotation model for distributed IVF_RQ shards."""
+    """Build one shared RaBitQ rotation model for distributed IVF_RQ shards.
+
+    ``dimension`` is the vector width and must satisfy Lance's IVF_RQ
+    requirement that it is divisible by 8. ``num_bits`` controls the number of
+    RaBitQ code bits per vector dimension and defaults to Lance's IVF_RQ default
+    of 1; supported values are validated by ``lance.lance.indices.build_rq_model``.
+    """
     from lance.lance import indices
 
     return indices.build_rq_model(dimension=dimension, num_bits=num_bits)
@@ -1202,6 +1208,9 @@ def create_index(
         pq_codebook: Pre-computed PQ codebook (optional)
         rabitq_model: Pre-built RaBitQ model for IVF_RQ. If omitted, Lance-Ray
             builds one shared model on the driver and sends it to every worker.
+            The model dimension is the vector column width and must be divisible
+            by 8. The ``num_bits`` keyword controls RaBitQ bits per vector
+            dimension and defaults to 1.
         **kwargs: Additional arguments to pass to the fragment index build entrypoint.
 
     Returns:

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -191,6 +191,13 @@ def _put_vector_index_artifacts_in_object_store(
     )
 
 
+def _build_rabitq_model(*, dimension: int, num_bits: int = 1) -> str:
+    """Build one shared RaBitQ rotation model for distributed IVF_RQ shards."""
+    from lance.lance import indices
+
+    return indices.build_rq_model(dimension=dimension, num_bits=num_bits)
+
+
 _SCALAR_SEGMENT_INDEX_TYPES = {"BTREE", "BITMAP", "INVERTED", "FTS"}
 
 
@@ -1168,6 +1175,7 @@ def create_index(
     pq_codebook: Optional[
         pa.Array | pa.FixedSizeListArray | pa.FixedShapeTensorArray
     ] = None,
+    rabitq_model: Optional[str] = None,
     **kwargs: Any,
 ) -> "lance.LanceDataset":
     """Build distributed vector indices with Ray.
@@ -1192,7 +1200,9 @@ def create_index(
         sample_rate: Number of rows sampled per IVF partition and PQ centroid (default: 256)
         ivf_centroids: Pre-computed IVF centroids (optional)
         pq_codebook: Pre-computed PQ codebook (optional)
-        **kwargs: Additional arguments to pass to the fragment index build entrypoint
+        rabitq_model: Pre-built RaBitQ model for IVF_RQ. If omitted, Lance-Ray
+            builds one shared model on the driver and sends it to every worker.
+        **kwargs: Additional arguments to pass to the fragment index build entrypoint.
 
     Returns:
         Updated Lance dataset with the index created
@@ -1281,9 +1291,13 @@ def create_index(
 
     ivf_centroids_artifact = ivf_centroids
     pq_codebook_artifact = pq_codebook
+    index_build_kwargs = dict(kwargs)
+    if rabitq_model is not None:
+        index_build_kwargs["rabitq_model"] = rabitq_model
 
     pq_index_types = {"IVF_PQ", "IVF_HNSW_PQ"}
     needs_pq = index_type_name in pq_index_types
+    needs_rq = index_type_name == "IVF_RQ"
 
     # Always perform global IVF training up front so that all shards share the
     # same centroids and number of partitions. The Ray entrypoint owns the
@@ -1335,6 +1349,18 @@ def create_index(
         num_sub_vectors = pq_model.num_subvectors
         logger.info("PQ training completed: num_sub_vectors=%d", num_sub_vectors)
 
+    if needs_rq and index_build_kwargs.get("rabitq_model") is None:
+        num_bits = index_build_kwargs.get("num_bits", 1)
+        logger.info(
+            "Building shared RaBitQ model: dimension=%d, num_bits=%s",
+            dimension,
+            num_bits,
+        )
+        index_build_kwargs["rabitq_model"] = _build_rabitq_model(
+            dimension=dimension,
+            num_bits=num_bits,
+        )
+
     if ivf_centroids_artifact is None:
         raise ValueError(
             "ivf_centroids must be provided or trainable for IVF-based "
@@ -1381,7 +1407,7 @@ def create_index(
             namespace_impl=namespace_impl,
             namespace_properties=namespace_properties,
             table_id=table_id,
-            **kwargs,
+            **index_build_kwargs,
         )
 
     results = _map_async_with_pool(

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -751,6 +751,7 @@ def create_scalar_index(
 _VECTOR_INDEX_TYPES = {
     "IVF_FLAT",
     "IVF_PQ",
+    "IVF_RQ",
     "IVF_SQ",
     "IVF_HNSW_FLAT",
     "IVF_HNSW_PQ",
@@ -1177,7 +1178,8 @@ def create_index(
     Args:
         uri: Lance dataset or URI to build index on
         column: Column name to index
-        index_type: Type of index to build (e.g., "IVF_PQ", "IVF_HNSW_PQ")
+        index_type: Type of index to build (e.g., "IVF_PQ", "IVF_RQ",
+            "IVF_HNSW_PQ")
         name: Name of the index (generated if None)
         replace: Whether to replace existing index with the same name (default: True)
         num_workers: Number of Ray workers to use (keyword-only)

--- a/tests/test_vector_index_options.py
+++ b/tests/test_vector_index_options.py
@@ -255,6 +255,87 @@ def test_create_index_uses_sample_rate_for_global_training(monkeypatch):
     assert fake_dataset.commit_kwargs["segments"] == ["segment"]
 
 
+def test_create_index_supports_ivf_rq(monkeypatch):
+    """IVF_RQ should be accepted and should not trigger PQ training."""
+
+    captured = {}
+    fake_dataset = _FakeDataset()
+
+    class FakeIndicesBuilder:
+        dimension = 16
+
+        def __init__(self, dataset, column):
+            captured["builder_dataset"] = dataset
+            captured["builder_column"] = column
+
+        def train_ivf(self, **kwargs):
+            captured["train_ivf"] = kwargs
+            return SimpleNamespace(centroids="ivf_centroids", num_partitions=4)
+
+        def train_pq(self, ivf_model, **kwargs):
+            captured["train_pq"] = kwargs
+            raise AssertionError("IVF_RQ should not train a PQ codebook")
+
+    def fake_handle_vector_fragment_index(**kwargs):
+        captured["fragment_handler_kwargs"] = kwargs
+        return lambda fragment_ids: {
+            "status": "success",
+            "fragment_ids": fragment_ids,
+            "segment_index": "segment",
+        }
+
+    def fake_put_vector_index_artifacts(ivf_centroids, pq_codebook):
+        captured["put_artifacts"] = (ivf_centroids, pq_codebook)
+        return "ivf_ref", None
+
+    def fake_map_async_with_pool(**kwargs):
+        captured["map_kwargs"] = kwargs
+        kwargs["create_fragment_handler"]()
+        return [
+            {
+                "status": "success",
+                "fragment_ids": [0, 1],
+                "segment_index": "segment",
+            }
+        ]
+
+    monkeypatch.setattr(index_mod, "_check_pylance_version", lambda: None)
+    monkeypatch.setattr(index_mod, "IndicesBuilder", FakeIndicesBuilder)
+    monkeypatch.setattr(index_mod, "LanceDataset", lambda *args, **kwargs: fake_dataset)
+    monkeypatch.setattr(
+        index_mod,
+        "_handle_vector_fragment_index",
+        fake_handle_vector_fragment_index,
+    )
+    monkeypatch.setattr(
+        index_mod,
+        "_put_vector_index_artifacts_in_object_store",
+        fake_put_vector_index_artifacts,
+    )
+    monkeypatch.setattr(index_mod, "_map_async_with_pool", fake_map_async_with_pool)
+
+    updated_dataset = index_mod.create_index(
+        uri=fake_dataset,
+        column="vector",
+        index_type="IVF_RQ",
+        name="vector_idx",
+        num_workers=2,
+        num_partitions=4,
+        sample_rate=8,
+        rabitq_model="shared-rq-model",
+    )
+
+    assert updated_dataset is fake_dataset
+    assert captured["train_ivf"]["sample_rate"] == 8
+    assert "train_pq" not in captured
+    assert captured["put_artifacts"] == ("ivf_centroids", None)
+    assert captured["fragment_handler_kwargs"]["index_type"] == "IVF_RQ"
+    assert captured["fragment_handler_kwargs"]["ivf_centroids"] == "ivf_ref"
+    assert captured["fragment_handler_kwargs"]["pq_codebook"] is None
+    assert captured["fragment_handler_kwargs"]["rabitq_model"] == "shared-rq-model"
+    assert fake_dataset.commit_kwargs["segments"] == ["segment"]
+
+
 def test_create_index_rejects_non_positive_sample_rate(monkeypatch):
     """Invalid sample rates should fail before training starts."""
 

--- a/tests/test_vector_index_options.py
+++ b/tests/test_vector_index_options.py
@@ -256,7 +256,7 @@ def test_create_index_uses_sample_rate_for_global_training(monkeypatch):
 
 
 def test_create_index_supports_ivf_rq(monkeypatch):
-    """IVF_RQ should be accepted and should not trigger PQ training."""
+    """IVF_RQ should build and share a RaBitQ model when one is not provided."""
 
     captured = {}
     fake_dataset = _FakeDataset()
@@ -288,6 +288,13 @@ def test_create_index_supports_ivf_rq(monkeypatch):
         captured["put_artifacts"] = (ivf_centroids, pq_codebook)
         return "ivf_ref", None
 
+    def fake_build_rabitq_model(*, dimension, num_bits):
+        captured["build_rabitq_model"] = {
+            "dimension": dimension,
+            "num_bits": num_bits,
+        }
+        return "auto-rq-model"
+
     def fake_map_async_with_pool(**kwargs):
         captured["map_kwargs"] = kwargs
         kwargs["create_fragment_handler"]()
@@ -312,6 +319,93 @@ def test_create_index_supports_ivf_rq(monkeypatch):
         "_put_vector_index_artifacts_in_object_store",
         fake_put_vector_index_artifacts,
     )
+    monkeypatch.setattr(index_mod, "_build_rabitq_model", fake_build_rabitq_model)
+    monkeypatch.setattr(index_mod, "_map_async_with_pool", fake_map_async_with_pool)
+
+    updated_dataset = index_mod.create_index(
+        uri=fake_dataset,
+        column="vector",
+        index_type="IVF_RQ",
+        name="vector_idx",
+        num_workers=2,
+        num_partitions=4,
+        sample_rate=8,
+        num_bits=2,
+    )
+
+    assert updated_dataset is fake_dataset
+    assert captured["train_ivf"]["sample_rate"] == 8
+    assert "train_pq" not in captured
+    assert captured["build_rabitq_model"] == {"dimension": 16, "num_bits": 2}
+    assert captured["put_artifacts"] == ("ivf_centroids", None)
+    assert captured["fragment_handler_kwargs"]["index_type"] == "IVF_RQ"
+    assert captured["fragment_handler_kwargs"]["ivf_centroids"] == "ivf_ref"
+    assert captured["fragment_handler_kwargs"]["pq_codebook"] is None
+    assert captured["fragment_handler_kwargs"]["num_bits"] == 2
+    assert captured["fragment_handler_kwargs"]["rabitq_model"] == "auto-rq-model"
+    assert fake_dataset.commit_kwargs["segments"] == ["segment"]
+
+
+def test_create_index_uses_provided_ivf_rq_model(monkeypatch):
+    """A caller-provided RaBitQ model should be shared without rebuilding it."""
+
+    captured = {}
+    fake_dataset = _FakeDataset()
+
+    class FakeIndicesBuilder:
+        dimension = 16
+
+        def __init__(self, dataset, column):
+            captured["builder_dataset"] = dataset
+            captured["builder_column"] = column
+
+        def train_ivf(self, **kwargs):
+            captured["train_ivf"] = kwargs
+            return SimpleNamespace(centroids="ivf_centroids", num_partitions=4)
+
+        def train_pq(self, ivf_model, **kwargs):
+            raise AssertionError("IVF_RQ should not train a PQ codebook")
+
+    def fake_handle_vector_fragment_index(**kwargs):
+        captured["fragment_handler_kwargs"] = kwargs
+        return lambda fragment_ids: {
+            "status": "success",
+            "fragment_ids": fragment_ids,
+            "segment_index": "segment",
+        }
+
+    def fake_put_vector_index_artifacts(ivf_centroids, pq_codebook):
+        captured["put_artifacts"] = (ivf_centroids, pq_codebook)
+        return "ivf_ref", None
+
+    def fake_build_rabitq_model(**kwargs):
+        raise AssertionError("provided rabitq_model should be reused")
+
+    def fake_map_async_with_pool(**kwargs):
+        captured["map_kwargs"] = kwargs
+        kwargs["create_fragment_handler"]()
+        return [
+            {
+                "status": "success",
+                "fragment_ids": [0, 1],
+                "segment_index": "segment",
+            }
+        ]
+
+    monkeypatch.setattr(index_mod, "_check_pylance_version", lambda: None)
+    monkeypatch.setattr(index_mod, "IndicesBuilder", FakeIndicesBuilder)
+    monkeypatch.setattr(index_mod, "LanceDataset", lambda *args, **kwargs: fake_dataset)
+    monkeypatch.setattr(
+        index_mod,
+        "_handle_vector_fragment_index",
+        fake_handle_vector_fragment_index,
+    )
+    monkeypatch.setattr(
+        index_mod,
+        "_put_vector_index_artifacts_in_object_store",
+        fake_put_vector_index_artifacts,
+    )
+    monkeypatch.setattr(index_mod, "_build_rabitq_model", fake_build_rabitq_model)
     monkeypatch.setattr(index_mod, "_map_async_with_pool", fake_map_async_with_pool)
 
     updated_dataset = index_mod.create_index(
@@ -326,13 +420,8 @@ def test_create_index_supports_ivf_rq(monkeypatch):
     )
 
     assert updated_dataset is fake_dataset
-    assert captured["train_ivf"]["sample_rate"] == 8
-    assert "train_pq" not in captured
-    assert captured["put_artifacts"] == ("ivf_centroids", None)
-    assert captured["fragment_handler_kwargs"]["index_type"] == "IVF_RQ"
-    assert captured["fragment_handler_kwargs"]["ivf_centroids"] == "ivf_ref"
-    assert captured["fragment_handler_kwargs"]["pq_codebook"] is None
     assert captured["fragment_handler_kwargs"]["rabitq_model"] == "shared-rq-model"
+    assert captured["fragment_handler_kwargs"]["index_type"] == "IVF_RQ"
     assert fake_dataset.commit_kwargs["segments"] == ["segment"]
 
 


### PR DESCRIPTION
## What changed

- Add `IVF_RQ` to the distributed vector index type allowlist.
- Keep IVF_RQ on the IVF-only training path, without PQ codebook training.
- Document IVF_RQ in the distributed indexing guide.

## Testing

- `python3.10 -m pytest --noconftest -o addopts='' tests/test_vector_index_options.py -q`
