### PR TITLE
feat(index): add num_segments for distributed index builds

### DIFF
--- a/docs/src/distributed-indexing.md
+++ b/docs/src/distributed-indexing.md
@@ -480,9 +480,9 @@ except ValueError as e:
 
 ### Performance Considerations
 
-- For very large datasets, it's recommended to use more powerful CPU/memory ray worker nodes. Increasing `num_workers` can improve index building speed, but requires more computational nodes.
-- Too many num_workers can cause large number of partitions, which cause FTS queries slowness as lots of index partitions need to be loaded when searching.
-- If `num_workers` is greater than the number of fragments, it will be automatically adjusted to match the fragment count
+- For very large datasets, use Ray worker nodes with sufficient CPU and memory. Increasing `num_workers` can improve index build speed when there are enough segment batches to process, but requires more cluster resources.
+- `num_segments` determines the number of index segments. More segments can slow FTS queries because more index segments need to be loaded during search.
+- `num_segments` is capped at the number of fragments, and `num_workers` is capped at the number of non-empty segment batches.
 
 ### Important Notes
 

--- a/docs/src/distributed-indexing.md
+++ b/docs/src/distributed-indexing.md
@@ -36,6 +36,7 @@ def create_scalar_index(
     fragment_ids: Optional[list[int]] = None,
     index_uuid: Optional[str] = None,
     num_workers: int = 4,
+    num_segments: Optional[int] = None,
     storage_options: Optional[dict[str, str]] = None,
     block_size: Optional[int] = None,
     namespace_impl: Optional[str] = None,
@@ -59,7 +60,8 @@ def create_scalar_index(
 | `train` | `bool`, optional | Whether to train the index, default is `True` |
 | `fragment_ids` | `list[int]`, optional | Optional list of fragment IDs to build index on |
 | `index_uuid` | `str`, optional | Optional fragment UUID for distributed indexing |
-| `num_workers` | `int`, optional | Number of Ray worker nodes to use, default is 4 |
+| `num_workers` | `int`, optional | Maximum number of Ray Pool workers to use, default is 4 |
+| `num_segments` | `int`, optional | Number of fragment batches / index segments to create. Defaults to `num_workers` for backwards compatibility |
 | `storage_options` | `Dict[str, str]`, optional | Storage options for the dataset |
 | `block_size` | `int`, optional | Block size in bytes to use when loading the dataset |
 | `namespace_impl` | `str`, optional | The namespace implementation type (e.g., `"rest"`, `"dir"`) |
@@ -98,6 +100,7 @@ def create_index(
     *,
     replace: bool = True,
     num_workers: int = 4,
+    num_segments: Optional[int] = None,
     storage_options: Optional[dict[str, str]] = None,
     block_size: Optional[int] = None,
     namespace_impl: Optional[str] = None,
@@ -124,7 +127,8 @@ def create_index(
 | `index_type` | `str` | Vector index type (e.g., `"IVF_PQ"`, `"IVF_RQ"`, `"IVF_SQ"`, `"IVF_FLAT"`) |
 | `name` | `str`, optional | Index name, auto-generated if not provided |
 | `replace` | `bool`, optional | Whether to replace existing index, default is `True` |
-| `num_workers` | `int`, optional | Number of Ray workers to use, default is 4 |
+| `num_workers` | `int`, optional | Maximum number of Ray Pool workers to use, default is 4 |
+| `num_segments` | `int`, optional | Number of fragment batches / index segments to create. Defaults to `num_workers` for backwards compatibility |
 | `storage_options` | `Dict[str, str]`, optional | Storage options for the dataset. These are merged with the storage options returned by the namespace (if any). |
 | `block_size` | `int`, optional | Block size in bytes to use when loading the dataset |
 | `namespace_impl` | `str`, optional | The namespace implementation type (e.g., `"rest"`, `"dir"`) |

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -448,7 +448,7 @@ def create_scalar_index(
         train: Whether to train the index (default: True).
         fragment_ids: Optional list of fragment IDs to build index on.
         index_uuid: Optional fragment UUID for distributed indexing.
-        num_workers: Number of Ray workers to use (keyword-only).
+        num_workers: Maximum number of Ray Pool workers to use (keyword-only).
         num_segments: Number of fragment batches / index segments to create
             (keyword-only). Defaults to num_workers for backwards compatibility.
         storage_options: Storage options for the dataset (keyword-only).
@@ -645,6 +645,14 @@ def create_scalar_index(
         fragments, num_segments=requested_num_segments, logger=logger
     )
     pool_workers = min(num_workers, len(fragment_batches))
+    if pool_workers < num_workers:
+        logger.info(
+            "Limiting Ray Pool workers to %d (requested %d) because there are "
+            "only %d non-empty segment batches",
+            pool_workers,
+            num_workers,
+            len(fragment_batches),
+        )
 
     def create_fragment_handler() -> Any:
         if use_segment_workflow:
@@ -1220,7 +1228,7 @@ def create_index(
             "IVF_HNSW_PQ")
         name: Name of the index (generated if None)
         replace: Whether to replace existing index with the same name (default: True)
-        num_workers: Number of Ray workers to use (keyword-only)
+        num_workers: Maximum number of Ray Pool workers to use (keyword-only)
         num_segments: Number of fragment batches / index segments to create
             (keyword-only). Defaults to num_workers for backwards compatibility.
         storage_options: Storage options for the dataset (keyword-only)
@@ -1414,6 +1422,14 @@ def create_index(
         fragments, num_segments=requested_num_segments, logger=logger
     )
     pool_workers = min(num_workers, len(fragment_batches))
+    if pool_workers < num_workers:
+        logger.info(
+            "Limiting Ray Pool workers to %d (requested %d) because there are "
+            "only %d non-empty segment batches",
+            pool_workers,
+            num_workers,
+            len(fragment_batches),
+        )
 
     logger.info(
         "Phase 2: Distributing vector index build across %d segment batches "

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -54,30 +54,30 @@ def _index_exists(dataset: LanceDataset, name: str) -> bool:
 
 
 def _distribute_fragments_balanced(
-    fragments: list[Any], num_workers: int, logger: logging.Logger
+    fragments: list[Any], num_segments: int, logger: logging.Logger
 ) -> list[list[int]]:
-    """Distribute fragments across workers using a balanced algorithm.
+    """Distribute fragments across index segments using a balanced algorithm.
 
     This function implements a greedy algorithm that assigns fragments to the
-    worker with the currently smallest total workload, helping to balance the
-    processing time across workers.
+    segment with the currently smallest total workload, helping to balance the
+    processing time across segment batches.
 
     Parameters
     ----------
     fragments : list
         List of Lance fragment objects.
-    num_workers : int
-        Number of workers to distribute fragments across.
+    num_segments : int
+        Number of segment batches to distribute fragments across.
     logger : logging.Logger
         Logger instance for debugging information.
 
     Returns
     -------
     list[list[int]]
-        Each inner list contains fragment IDs for one worker.
+        Each inner list contains fragment IDs for one segment batch.
     """
     if not fragments:
-        return [[] for _ in range(num_workers)]
+        return [[] for _ in range(num_segments)]
 
     fragment_info: list[dict[str, int]] = []
     for fragment in fragments:
@@ -100,35 +100,36 @@ def _distribute_fragments_balanced(
     # This helps with better load balancing using the greedy algorithm
     fragment_info.sort(key=lambda x: x["size"], reverse=True)
 
-    worker_batches: list[list[int]] = [[] for _ in range(num_workers)]
-    worker_workloads = [0] * num_workers
+    segment_batches: list[list[int]] = [[] for _ in range(num_segments)]
+    segment_workloads = [0] * num_segments
 
-    # Greedy assignment: assign each fragment to the worker with minimum workload
+    # Greedy assignment: assign each fragment to the segment with minimum workload
     for frag_info in fragment_info:
-        # Find the worker with the minimum current workload
-        min_workload_idx = min(range(num_workers), key=lambda i: worker_workloads[i])
-        worker_batches[min_workload_idx].append(frag_info["id"])
-        worker_workloads[min_workload_idx] += frag_info["size"]
+        min_workload_idx = min(
+            range(num_segments), key=lambda i: segment_workloads[i]
+        )
+        segment_batches[min_workload_idx].append(frag_info["id"])
+        segment_workloads[min_workload_idx] += frag_info["size"]
 
     total_size = sum(info["size"] for info in fragment_info)
     logger.info("Fragment distribution statistics:")
     logger.info("  Total fragments: %d", len(fragment_info))
     logger.info("  Total size: %d", total_size)
-    logger.info("  Workers: %d", num_workers)
+    logger.info("  Segments: %d", num_segments)
 
     for i, (batch, workload) in enumerate(
-        zip(worker_batches, worker_workloads, strict=False)
+        zip(segment_batches, segment_workloads, strict=False)
     ):
         percentage = (workload / total_size * 100) if total_size > 0 else 0
         logger.info(
-            "  Worker %d: %d fragments, workload: %d (%.1f%%)",
+            "  Segment %d: %d fragments, workload: %d (%.1f%%)",
             i,
             len(batch),
             workload,
             percentage,
         )
 
-    non_empty_batches = [batch for batch in worker_batches if batch]
+    non_empty_batches = [batch for batch in segment_batches if batch]
     return non_empty_batches
 
 
@@ -162,6 +163,16 @@ def _map_async_with_pool(
         pool.join()
 
     return results
+
+
+def _resolve_num_segments(num_workers: int, num_segments: Optional[int]) -> int:
+    if num_workers <= 0:
+        raise ValueError(f"num_workers must be positive, got {num_workers}")
+    if num_segments is None:
+        return num_workers
+    if num_segments <= 0:
+        raise ValueError(f"num_segments must be positive, got {num_segments}")
+    return num_segments
 
 
 def _is_ray_object_ref(value: Any) -> bool:
@@ -414,6 +425,7 @@ def create_scalar_index(
     fragment_ids: Optional[list[int]] = None,
     index_uuid: Optional[str] = None,
     num_workers: int = 4,
+    num_segments: Optional[int] = None,
     storage_options: Optional[dict[str, str]] = None,
     block_size: Optional[int] = None,
     namespace_impl: Optional[str] = None,
@@ -437,6 +449,8 @@ def create_scalar_index(
         fragment_ids: Optional list of fragment IDs to build index on.
         index_uuid: Optional fragment UUID for distributed indexing.
         num_workers: Number of Ray workers to use (keyword-only).
+        num_segments: Number of fragment batches / index segments to create
+            (keyword-only). Defaults to num_workers for backwards compatibility.
         storage_options: Storage options for the dataset (keyword-only).
         block_size: Block size in bytes to use when loading the dataset (keyword-only).
         namespace_impl: The namespace implementation type (e.g., "rest", "dir").
@@ -486,8 +500,7 @@ def create_scalar_index(
     if not column:
         raise ValueError("Column name cannot be empty")
 
-    if num_workers <= 0:
-        raise ValueError(f"num_workers must be positive, got {num_workers}")
+    requested_num_segments = _resolve_num_segments(num_workers, num_segments)
 
     if block_size is not None and block_size <= 0:
         raise ValueError(f"block_size must be positive, got {block_size}")
@@ -621,11 +634,17 @@ def create_scalar_index(
     else:
         fragment_ids_to_use = [fragment.fragment_id for fragment in fragments]
 
-    if num_workers > len(fragment_ids_to_use):
-        num_workers = len(fragment_ids_to_use)
-        logger.info("Adjusted num_workers to %d to match fragment count", num_workers)
+    if requested_num_segments > len(fragment_ids_to_use):
+        requested_num_segments = len(fragment_ids_to_use)
+        logger.info(
+            "Adjusted num_segments to %d to match fragment count",
+            requested_num_segments,
+        )
 
-    fragment_batches = _distribute_fragments_balanced(fragments, num_workers, logger)
+    fragment_batches = _distribute_fragments_balanced(
+        fragments, num_segments=requested_num_segments, logger=logger
+    )
+    pool_workers = min(num_workers, len(fragment_batches))
 
     def create_fragment_handler() -> Any:
         if use_segment_workflow:
@@ -660,15 +679,17 @@ def create_scalar_index(
         )
 
     logger.info(
-        "Phase 1: Distributing scalar index build across %d workers for %d fragments",
+        "Phase 1: Distributing scalar index build across %d segment batches "
+        "using up to %d workers for %d fragments",
         len(fragment_batches),
+        pool_workers,
         len(fragment_ids_to_use),
     )
 
     results = _map_async_with_pool(
         create_fragment_handler=create_fragment_handler,
         fragment_batches=fragment_batches,
-        num_workers=num_workers,
+        num_workers=pool_workers,
         ray_remote_args=ray_remote_args,
         error_prefix="Failed to complete distributed index building",
     )
@@ -705,9 +726,10 @@ def create_scalar_index(
             name,
         )
         logger.info(
-            "Fragments: %d, Workers: %d",
+            "Fragments: %d, Segments: %d, Workers: %d",
             len(fragment_ids_to_use),
             len(fragment_batches),
+            pool_workers,
         )
         return updated_dataset
 
@@ -748,10 +770,11 @@ def create_scalar_index(
         name,
     )
     logger.info(
-        "Index ID: %s, Fragments: %d, Workers: %d",
+        "Index ID: %s, Fragments: %d, Segments: %d, Workers: %d",
         index_id,
         len(fragment_ids_to_use),
         len(fragment_batches),
+        pool_workers,
     )
     return updated_dataset
 
@@ -1165,6 +1188,7 @@ def create_index(
     *,
     replace: bool = True,
     num_workers: int = 4,
+    num_segments: Optional[int] = None,
     storage_options: Optional[dict[str, str]] = None,
     block_size: Optional[int] = None,
     namespace_impl: Optional[str] = None,
@@ -1197,6 +1221,8 @@ def create_index(
         name: Name of the index (generated if None)
         replace: Whether to replace existing index with the same name (default: True)
         num_workers: Number of Ray workers to use (keyword-only)
+        num_segments: Number of fragment batches / index segments to create
+            (keyword-only). Defaults to num_workers for backwards compatibility.
         storage_options: Storage options for the dataset (keyword-only)
         block_size: Block size in bytes to use when loading the dataset (keyword-only)
         ray_remote_args: Options for Ray tasks (keyword-only)
@@ -1222,8 +1248,7 @@ def create_index(
     if not column:
         raise ValueError("Column name cannot be empty")
 
-    if num_workers <= 0:
-        raise ValueError(f"num_workers must be positive, got {num_workers}")
+    requested_num_segments = _resolve_num_segments(num_workers, num_segments)
 
     if sample_rate <= 0:
         raise ValueError(f"sample_rate must be positive, got {sample_rate}")
@@ -1294,9 +1319,12 @@ def create_index(
 
     fragment_ids_to_use = [fragment.fragment_id for fragment in fragments]
 
-    if num_workers > len(fragment_ids_to_use):
-        num_workers = len(fragment_ids_to_use)
-        logger.info("Adjusted num_workers to %d to match fragment count", num_workers)
+    if requested_num_segments > len(fragment_ids_to_use):
+        requested_num_segments = len(fragment_ids_to_use)
+        logger.info(
+            "Adjusted num_segments to %d to match fragment count",
+            requested_num_segments,
+        )
 
     ivf_centroids_artifact = ivf_centroids
     pq_codebook_artifact = pq_codebook
@@ -1383,12 +1411,15 @@ def create_index(
         )
 
     fragment_batches = _distribute_fragments_balanced(
-        fragments, num_workers=num_workers, logger=logger
+        fragments, num_segments=requested_num_segments, logger=logger
     )
+    pool_workers = min(num_workers, len(fragment_batches))
 
     logger.info(
-        "Phase 2: Distributing vector index build across %d workers for %d fragments",
+        "Phase 2: Distributing vector index build across %d segment batches "
+        "using up to %d workers for %d fragments",
         len(fragment_batches),
+        pool_workers,
         len(fragment_ids_to_use),
     )
 
@@ -1422,7 +1453,7 @@ def create_index(
     results = _map_async_with_pool(
         create_fragment_handler=create_fragment_handler,
         fragment_batches=fragment_batches,
-        num_workers=num_workers,
+        num_workers=pool_workers,
         ray_remote_args=ray_remote_args,
         error_prefix="Failed to complete distributed vector index building",
     )
@@ -1457,10 +1488,11 @@ def create_index(
         name,
     )
     logger.info(
-        "Index ID: %s, Fragments: %d, Workers: %d",
+        "Index ID: %s, Fragments: %d, Segments: %d, Workers: %d",
         index_id,
         len(fragment_ids_to_use),
         len(fragment_batches),
+        pool_workers,
     )
 
     return updated_dataset

--- a/tests/test_distributed_indexing.py
+++ b/tests/test_distributed_indexing.py
@@ -795,6 +795,7 @@ class TestDistributedIndexing:
             index_type="INVERTED",
             name="new_api_test_idx",
             num_workers=2,
+            num_segments=4,
             remove_stop_words=False,
         )
 
@@ -815,6 +816,7 @@ class TestDistributedIndexing:
         assert our_index.index_type == "Inverted", (
             f"Expected Inverted index, got {our_index.index_type}"
         )
+        assert len(our_index.segments) == 4
 
         # Test that the index works for searching
         sample_data = updated_dataset.take([0], columns=["text"])
@@ -1543,6 +1545,7 @@ def test_build_distributed_vector_index(tmp_path, index_type):
             index_type=index_type,
             name=f"idx_{index_type}",
             num_workers=2,
+            num_segments=4,
             num_partitions=4,
             num_sub_vectors=16,
             sample_rate=16,
@@ -1574,6 +1577,7 @@ def test_build_distributed_vector_index(tmp_path, index_type):
     assert vec_index.index_type == index_type, (
         f"Expected {index_type} vector index, got {vec_index.index_type}"
     )
+    assert len(vec_index.segments) == 4
 
     # Run a simple nearest-neighbor query to ensure the index is usable.
     q = [random.gauss(0, 1) for _ in range(128)]

--- a/tests/test_vector_index_options.py
+++ b/tests/test_vector_index_options.py
@@ -439,6 +439,20 @@ def test_create_index_rejects_non_positive_sample_rate(monkeypatch):
         )
 
 
+def test_create_index_rejects_invalid_num_segments(monkeypatch):
+    """Invalid segment counts should fail before training starts."""
+
+    monkeypatch.setattr(index_mod, "_check_pylance_version", lambda: None)
+
+    with pytest.raises(ValueError, match="num_segments must be positive, got 0"):
+        index_mod.create_index(
+            uri=_FakeDataset(),
+            column="vector",
+            index_type="IVF_PQ",
+            num_segments=0,
+        )
+
+
 @pytest.mark.parametrize("index_type", ["BTREE", "BITMAP", "INVERTED", "FTS"])
 def test_create_scalar_index_uses_segment_path(monkeypatch, index_type):
     """Migrated scalar indexes should use Lance's segment workflow."""


### PR DESCRIPTION
## Background
Distributed index builds previously used `num_workers` for two different concerns: the number of fragment batches / index segments to create, and the maximum Ray Pool worker concurrency. These values do not always need to match. For example, a caller may want more index segments for the resulting index layout while keeping worker concurrency lower to fit available cluster resources. Coupling the two means increasing segment count also requires increasing concurrent workers, or limiting workers also limits segment count.

## Summary
- add a `num_segments` option to distributed `create_index` and `create_scalar_index`
- keep `num_workers` as the maximum Ray Pool worker concurrency
- default `num_segments` to `num_workers` for backwards compatibility
- update distributed indexing docs and integration coverage for scalar/vector segment counts

## Testing
- `uv run pytest tests/test_vector_index_options.py`
- `uv run pytest tests/test_distributed_indexing.py::TestDistributedIndexing::test_distributed_fts_index_new_api tests/test_distributed_indexing.py::test_build_distributed_vector_index`
- `uv run ruff check lance_ray/index.py tests/test_vector_index_options.py tests/test_distributed_indexing.py`
