### PR TITLE
chore: update pylance dependency to v9.0.0b20

### DIFF
--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -1284,8 +1284,7 @@ def create_index(
 
     if not replace and _index_exists(dataset_obj, name):
         raise ValueError(
-            f"Index with name '{name}' already exists. Set replace=True "
-            "to replace it."
+            f"Index with name '{name}' already exists. Set replace=True to replace it."
         )
 
     fragments = dataset_obj.get_fragments()

--- a/lance_ray/utils.py
+++ b/lance_ray/utils.py
@@ -238,9 +238,7 @@ def resolve_namespace_table(
             )
             location = describe_response.location
             if location is None:
-                raise ValueError(
-                    "Namespace did not return a 'location' for the table"
-                )
+                raise ValueError("Namespace did not return a 'location' for the table")
             if describe_response.storage_options:
                 merged_storage_options.update(describe_response.storage_options)
             return location, merged_storage_options

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=8.0.0b11",
+    "pylance>=9.0.0b20",
     "lance-namespace",
     "packaging",
     "pyarrow>=17.0.0",

--- a/tests/test_distributed_indexing.py
+++ b/tests/test_distributed_indexing.py
@@ -1567,9 +1567,7 @@ def test_build_distributed_vector_index(tmp_path, index_type):
     assert len(indices) > 0, "No indices found after distributed vector index build"
 
     # Find the index with the name we specified
-    vec_index = next(
-        (idx for idx in indices if idx.name == f"idx_{index_type}"), None
-    )
+    vec_index = next((idx for idx in indices if idx.name == f"idx_{index_type}"), None)
     assert vec_index is not None, f"Index with name idx_{index_type} not found"
     assert vec_index.index_type == index_type, (
         f"Expected {index_type} vector index, got {vec_index.index_type}"

--- a/uv.lock
+++ b/uv.lock
@@ -221,7 +221,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -326,19 +326,19 @@ wheels = [
 
 [[package]]
 name = "lance-namespace"
-version = "0.8.4"
+version = "0.8.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/8f/8a03395587a78cfaf92f7307ad931f61eb515af67705c704bd6c7af2f745/lance_namespace-0.8.4.tar.gz", hash = "sha256:1a54ad49e7ace25a629c5f2c99d393629742eceeeb16ba2f51a771ccb350e284", size = 11282, upload-time = "2026-06-10T19:07:21.919Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/12/f7ab93b29be3edbf5fc3610714bf2d06088e7f4524bfb38dfd6852458b08/lance_namespace-0.8.6.tar.gz", hash = "sha256:18232e721c8188145f4ec9389cc2dfbeeabf54a619d94885ea1b3375bee9f4af", size = 11529, upload-time = "2026-06-12T17:36:41.651Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/4b/218c67cafb707024069925ce86534588861a464aaa327f7a457b94eed3c2/lance_namespace-0.8.4-py3-none-any.whl", hash = "sha256:8b347eef4b7c7187a1b52f388b5dcc345fed0bf4ea87728188dcb11a52619d0b", size = 13111, upload-time = "2026-06-10T19:07:22.6Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1b/5b1668ee2dc8910965f390640359112a31157092fcf8e000b89c79b58708/lance_namespace-0.8.6-py3-none-any.whl", hash = "sha256:571eae34f9aad70e5b05020416c2860889b9ec82993ccd0eb015e7b39c3ea309", size = 13383, upload-time = "2026-06-12T17:36:43.456Z" },
 ]
 
 [[package]]
 name = "lance-namespace-urllib3-client"
-version = "0.8.4"
+version = "0.8.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -346,9 +346,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/55/4a7cc7e5d19bda170c896a6adff2ec925c533df812b91bce2bc8f7aea30b/lance_namespace_urllib3_client-0.8.4.tar.gz", hash = "sha256:1a292a83509ab79475da967b78839e9ead4ab973064d37d1ba1575b23ffdacef", size = 228485, upload-time = "2026-06-10T19:07:19.863Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/80/fb224b4a89c1c1638cde949cb6cce6c3aca7759effbfea46a3d9c3960b21/lance_namespace_urllib3_client-0.8.6.tar.gz", hash = "sha256:b6fb1d306e74a7576e5309919020be744527de484a63dbf5eed10f8b368548df", size = 228772, upload-time = "2026-06-12T17:36:42.609Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/f7/70dd2fc1f9ef462d3802b4cffcd64f2b9233a9907d6071e8694338492608/lance_namespace_urllib3_client-0.8.4-py3-none-any.whl", hash = "sha256:37ee1d74614fae6358f50e3589ac26c29379ffb1346f09c4f5ec8953f823cefd", size = 369807, upload-time = "2026-06-10T19:07:21.001Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/90/1e27de15cd1b16785a1c7312beb0a59e75c8344a815f600f58173a565bd1/lance_namespace_urllib3_client-0.8.6-py3-none-any.whl", hash = "sha256:9d78249c3fb15aa3d15d668f78f04a275af3d08d800a7027492f37996ac4968b", size = 369950, upload-time = "2026-06-12T17:36:40.438Z" },
 ]
 
 [[package]]
@@ -387,7 +387,7 @@ requires-dist = [
     { name = "more-itertools", marker = "python_full_version < '3.12'", specifier = ">=2.6.0" },
     { name = "packaging" },
     { name = "pyarrow", specifier = ">=17.0.0" },
-    { name = "pylance", specifier = ">=8.0.0b11" },
+    { name = "pylance", specifier = ">=9.0.0b20" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
@@ -1024,7 +1024,7 @@ wheels = [
 
 [[package]]
 name = "pylance"
-version = "8.0.0b11"
+version = "9.0.0b20"
 source = { registry = "https://pypi.fury.io/lance-format" }
 dependencies = [
     { name = "lance-namespace" },
@@ -1033,12 +1033,9 @@ dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://pypi.fury.io/lance-format/-/ver_GL5dn/pylance-8.0.0b11-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:2f2e66c6a7039ba51ac6174d0336b4f38a58351706e16b8b21a6c71f06cd1f20" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1pVrmn/pylance-8.0.0b11-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f85711b2f468acfe20ad2542639b82e9658ed301d72f5cfde82e2e40ef431b15" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1qcBDw/pylance-8.0.0b11-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:602af5469141d0c6667d902f6819cd2b7b5ce40193190be6a030adc753a36fe7" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1V5g0y/pylance-8.0.0b11-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:b6b89f48f198b3fe59ad795bac614a1cc8892e20f2ba2acd1f958a18d05e4b32" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_7rhla/pylance-8.0.0b11-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:4c8b16c860345f3c519dc28dd4dab111bdc2c104795c1c7fb3f245d798f64792" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1f0tKO/pylance-8.0.0b11-cp39-abi3-win_amd64.whl", hash = "sha256:66297c0a3708e4b6921d6430153d2cb89f7a618110bf8d119cb9986a81a6371c" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_19WHrD/pylance-9.0.0b20-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:72abbc3475e947d3dd9d36a212327042eb8b81ce8110a4857b0b13a141406fd9" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_2cYjMf/pylance-9.0.0b20-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ec135b793a2334d9bc4770c1e3d3f04159cf918c505860595a171682f775533" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1HOMXu/pylance-9.0.0b20-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6a0257927a706f610b4981b29642d65b07c8e41d4d2753f9be33bcba98ea13da" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- bump the Pylance dependency to `pylance>=9.0.0b20`
- regenerate `uv.lock` with the updated dependency resolution
- apply the formatting updates required by the current Ruff formatter

## Verification

- `make lock` passed
- `make lint` passed (using the existing lock without syncing Pylance because this release does not publish a Linux x86_64 wheel)

Triggered by [`refs/tags/v9.0.0-beta.20`](https://github.com/lance-format/lance/releases/tag/v9.0.0-beta.20).
