### PR TITLE
fix(index): propagate sample_rate and max_iters

### DIFF
--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -1032,13 +1032,16 @@ def _train_pq_for_field_path(
     num_subvectors: Optional[int],
     sample_rate: int,
     num_bits: int,
+    max_iters: Optional[int],
 ) -> Any:
-    return builder.train_pq(
-        ivf_model,
-        num_subvectors=num_subvectors,
-        sample_rate=sample_rate,
-        num_bits=num_bits,
-    )
+    train_kwargs: dict[str, Any] = {
+        "num_subvectors": num_subvectors,
+        "sample_rate": sample_rate,
+        "num_bits": num_bits,
+    }
+    if max_iters is not None:
+        train_kwargs["max_iters"] = max_iters
+    return builder.train_pq(ivf_model, **train_kwargs)
 
 
 def _normalize_index_type(index_type: Any) -> str:
@@ -1122,6 +1125,7 @@ def _handle_vector_fragment_index(
     num_sub_vectors: Optional[int],
     ivf_centroids: pa.Array | pa.FixedSizeListArray | pa.FixedShapeTensorArray | None,
     pq_codebook: pa.Array | pa.FixedSizeListArray | pa.FixedShapeTensorArray | None,
+    sample_rate: int = 256,
     storage_options: Optional[dict[str, str]] = None,
     block_size: Optional[int] = None,
     namespace_impl: Optional[str] = None,
@@ -1171,6 +1175,7 @@ def _handle_vector_fragment_index(
                 ivf_centroids=resolved_ivf_centroids,
                 pq_codebook=resolved_pq_codebook,
                 num_sub_vectors=num_sub_vectors,
+                sample_rate=sample_rate,
                 storage_options=storage_options,
                 train=True,
                 fragment_ids=fragment_ids,
@@ -1353,6 +1358,7 @@ def create_index(
     ivf_centroids_artifact = ivf_centroids
     pq_codebook_artifact = pq_codebook
     index_build_kwargs = dict(kwargs)
+    max_iters = index_build_kwargs.get("max_iters")
     if rabitq_model is not None:
         index_build_kwargs["rabitq_model"] = rabitq_model
 
@@ -1381,11 +1387,14 @@ def create_index(
         dimension,
         sample_rate,
     )
-    ivf_model = builder.train_ivf(
-        num_partitions=requested_num_partitions,
-        distance_type=metric_lower,
-        sample_rate=sample_rate,
-    )
+    ivf_train_kwargs: dict[str, Any] = {
+        "num_partitions": requested_num_partitions,
+        "distance_type": metric_lower,
+        "sample_rate": sample_rate,
+    }
+    if max_iters is not None:
+        ivf_train_kwargs["max_iters"] = max_iters
+    ivf_model = builder.train_ivf(**ivf_train_kwargs)
     ivf_centroids_artifact = ivf_model.centroids
     num_partitions = ivf_model.num_partitions
     logger.info(
@@ -1409,6 +1418,7 @@ def create_index(
             num_subvectors=requested_num_sub_vectors,
             sample_rate=sample_rate,
             num_bits=pq_num_bits,
+            max_iters=max_iters,
         )
         pq_codebook_artifact = pq_model.codebook
         num_sub_vectors = pq_model.num_subvectors
@@ -1476,6 +1486,7 @@ def create_index(
             metric=metric_lower,
             num_partitions=num_partitions,
             num_sub_vectors=num_sub_vectors,
+            sample_rate=sample_rate,
             ivf_centroids=shared_ivf_centroids,
             pq_codebook=shared_pq_codebook,
             storage_options=merged_storage_options,

--- a/tests/test_vector_index_options.py
+++ b/tests/test_vector_index_options.py
@@ -178,8 +178,8 @@ def test_map_async_with_pool_closes_and_joins_pool(monkeypatch):
     ]
 
 
-def test_create_index_uses_sample_rate_and_num_bits_for_global_training(monkeypatch):
-    """sample_rate and num_bits should drive global training and worker build."""
+def test_create_index_passes_global_training_options_to_segment_build(monkeypatch):
+    """Global training options must reach driver training and segment builds."""
 
     captured = {}
     fake_dataset = _FakeDataset()
@@ -200,33 +200,18 @@ def test_create_index_uses_sample_rate_and_num_bits_for_global_training(monkeypa
             captured["train_pq"] = kwargs
             return SimpleNamespace(codebook="pq_codebook", num_subvectors=4)
 
-    def fake_handle_vector_fragment_index(**kwargs):
-        captured["fragment_handler_kwargs"] = kwargs
-        return lambda fragment_ids: {"status": "success", "fragment_ids": fragment_ids}
-
     def fake_put_vector_index_artifacts(ivf_centroids, pq_codebook):
         captured["put_artifacts"] = (ivf_centroids, pq_codebook)
         return "ivf_ref", "pq_ref"
 
     def fake_map_async_with_pool(**kwargs):
         captured["map_kwargs"] = kwargs
-        kwargs["create_fragment_handler"]()
-        return [
-            {
-                "status": "success",
-                "fragment_ids": [0, 1],
-                "segment_index": "segment",
-            }
-        ]
+        fragment_handler = kwargs["create_fragment_handler"]()
+        return [fragment_handler([0, 1])]
 
     monkeypatch.setattr(index_mod, "_check_pylance_version", lambda: None)
     monkeypatch.setattr(index_mod, "IndicesBuilder", FakeIndicesBuilder)
     monkeypatch.setattr(index_mod, "LanceDataset", lambda *args, **kwargs: fake_dataset)
-    monkeypatch.setattr(
-        index_mod,
-        "_handle_vector_fragment_index",
-        fake_handle_vector_fragment_index,
-    )
     monkeypatch.setattr(
         index_mod,
         "_put_vector_index_artifacts_in_object_store",
@@ -244,17 +229,21 @@ def test_create_index_uses_sample_rate_and_num_bits_for_global_training(monkeypa
         num_sub_vectors=4,
         num_bits=4,
         sample_rate=8,
+        max_iters=3,
     )
 
     assert updated_dataset is fake_dataset
     assert captured["train_ivf"]["sample_rate"] == 8
+    assert captured["train_ivf"]["max_iters"] == 3
     assert captured["train_pq"]["sample_rate"] == 8
     assert captured["train_pq"]["num_bits"] == 4
+    assert captured["train_pq"]["max_iters"] == 3
     assert captured["put_artifacts"] == ("ivf_centroids", "pq_codebook")
-    assert captured["fragment_handler_kwargs"]["ivf_centroids"] == "ivf_ref"
-    assert captured["fragment_handler_kwargs"]["pq_codebook"] == "pq_ref"
-    assert captured["fragment_handler_kwargs"]["num_bits"] == 4
-    assert "sample_rate" not in captured["fragment_handler_kwargs"]
+    assert fake_dataset.vector_index_kwargs["ivf_centroids"] == "ivf_ref"
+    assert fake_dataset.vector_index_kwargs["pq_codebook"] == "pq_ref"
+    assert fake_dataset.vector_index_kwargs["sample_rate"] == 8
+    assert fake_dataset.vector_index_kwargs["num_bits"] == 4
+    assert fake_dataset.vector_index_kwargs["max_iters"] == 3
     assert fake_dataset.commit_kwargs["segments"] == ["segment"]
 
 


### PR DESCRIPTION
## Summary

- Forward `sample_rate` from the distributed vector index entry point to each segment build.
- Apply an explicitly supplied `max_iters` to global IVF and PQ training on the driver.
- Cover both options across driver training and worker segment construction.

## Root cause

`sample_rate` was consumed by the distributed entry point and was not forwarded
to `create_index_uncommitted`.  `max_iters` continued to reach workers through
`**kwargs`, but was omitted from the driver's global training calls.

## Testing

- `uv run pytest tests/test_vector_index_options.py -q -o addopts=''`
- Local Ray IVF_SQ build and ANN query
