### PR TITLE
fix(index): preserve scalar index on failed replacement

### DIFF
--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -231,6 +231,7 @@ def _handle_scalar_segment_index(
     column: str,
     index_type: str | IndexConfig,
     name: str,
+    replace: bool,
     train: bool,
     storage_options: Optional[dict[str, str]] = None,
     block_size: Optional[int] = None,
@@ -273,7 +274,7 @@ def _handle_scalar_segment_index(
                 column=column,
                 index_type=index_type,
                 name=name,
-                replace=False,
+                replace=replace,
                 train=train,
                 storage_options=storage_options,
                 fragment_ids=fragment_ids,
@@ -599,23 +600,21 @@ def create_scalar_index(
     if name is None:
         name = f"{column}_idx"
 
-    if replace:
-        if _index_exists(dataset, name):
+    if _index_exists(dataset, name):
+        if not replace:
+            raise ValueError(
+                f"Index with name '{name}' already exists. Set replace=True "
+                "to replace it."
+            )
+        if not use_segment_workflow:
             # Lance 4.0.0: fragment_ids + replace=True may hit an unimplemented path.
-            # Implement replace semantics at the driver by dropping the index first.
+            # Keep the existing driver-side replacement behavior for the legacy workflow.
             dataset.drop_index(name)
             dataset = LanceDataset(
                 uri,
                 **_dataset_load_kwargs(
                     merged_storage_options, namespace_kwargs, block_size
                 ),
-            )
-
-    else:
-        if _index_exists(dataset, name):
-            raise ValueError(
-                f"Index with name '{name}' already exists. Set replace=True "
-                "to replace it."
             )
 
     fragments = dataset.get_fragments()
@@ -661,6 +660,7 @@ def create_scalar_index(
                 column=column,
                 index_type=index_type,
                 name=name,
+                replace=replace,
                 train=train,
                 storage_options=merged_storage_options,
                 block_size=block_size,

--- a/tests/test_distributed_indexing.py
+++ b/tests/test_distributed_indexing.py
@@ -754,6 +754,44 @@ class TestDistributedIndexing:
             f"No results found for search term '{search_term}' after index replacement"
         )
 
+    def test_failed_replace_keeps_existing_index(
+        self, multi_fragment_lance_dataset, monkeypatch
+    ):
+        """A failed replacement must not remove the previously committed index."""
+        index_name = "test_replace_failure_keeps_existing_index"
+
+        lr.create_scalar_index(
+            uri=multi_fragment_lance_dataset,
+            column="text",
+            index_type="INVERTED",
+            name=index_name,
+            num_workers=2,
+        )
+
+        monkeypatch.setattr(
+            "lance_ray.index._map_async_with_pool",
+            lambda **_: [
+                {
+                    "status": "error",
+                    "fragment_ids": [0],
+                    "error": "injected worker failure",
+                }
+            ],
+        )
+
+        with pytest.raises(RuntimeError, match="injected worker failure"):
+            lr.create_scalar_index(
+                uri=multi_fragment_lance_dataset,
+                column="text",
+                index_type="INVERTED",
+                name=index_name,
+                replace=True,
+                num_workers=2,
+            )
+
+        indices = lance.dataset(multi_fragment_lance_dataset).describe_indices()
+        assert index_name in [index.name for index in indices]
+
     def test_build_distributed_index_auto_adjust_workers(self, temp_dir):
         """Test that num_workers is automatically adjusted if it exceeds fragment count."""
         # Create dataset with only 2 fragments


### PR DESCRIPTION
## Summary

- Preserve an existing distributed scalar segment index until replacement segments build successfully.
- Align scalar segment replacement with the distributed vector index workflow.
- Add a regression test for worker failure during replacement.

## Root cause

The driver removed an existing scalar index before dispatching workers, leaving no usable index if a worker failed.

## Testing

- `python -m pytest -o addopts='' tests/test_distributed_indexing.py::TestDistributedIndexing::test_build_distributed_index_replace_true_overwrite_existing tests/test_distributed_indexing.py::TestDistributedIndexing::test_failed_replace_keeps_existing_index tests/test_vector_index_options.py::test_create_scalar_index_uses_segment_path -vv`
- `ruff check lance_ray/index.py tests/test_distributed_indexing.py`
