### PR TITLE
chore: update pylance dependency to v10.0.0b1

### DIFF
--- a/lance_ray/compaction.py
+++ b/lance_ray/compaction.py
@@ -140,7 +140,9 @@ def compact_files(
     # Step 1: Create the compaction plan
     # Compaction.plan requires a dict; CompactionOptions is a TypedDict, so
     # an empty instance stands in for "all defaults" when the caller omits it.
-    compaction_plan = Compaction.plan(dataset, compaction_options or CompactionOptions())
+    compaction_plan = Compaction.plan(
+        dataset, compaction_options or CompactionOptions()
+    )
 
     logger.info(f"Compaction plan created with {compaction_plan.num_tasks()} tasks")
 

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -105,9 +105,7 @@ def _distribute_fragments_balanced(
 
     # Greedy assignment: assign each fragment to the segment with minimum workload
     for frag_info in fragment_info:
-        min_workload_idx = min(
-            range(num_segments), key=lambda i: segment_workloads[i]
-        )
+        min_workload_idx = min(range(num_segments), key=lambda i: segment_workloads[i])
         segment_batches[min_workload_idx].append(frag_info["id"])
         segment_workloads[min_workload_idx] += frag_info["size"]
 

--- a/lance_ray/utils.py
+++ b/lance_ray/utils.py
@@ -238,9 +238,7 @@ def resolve_namespace_table(
             )
             location = describe_response.location
             if location is None:
-                raise ValueError(
-                    "Namespace did not return a 'location' for the table"
-                )
+                raise ValueError("Namespace did not return a 'location' for the table")
             if describe_response.storage_options:
                 merged_storage_options.update(describe_response.storage_options)
             return location, merged_storage_options

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance==9.0.0rc1",
+    "pylance>=10.0.0b1",
     "lance-namespace",
     "packaging",
     "pyarrow>=17.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -221,7 +221,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -387,7 +387,7 @@ requires-dist = [
     { name = "more-itertools", marker = "python_full_version < '3.12'", specifier = ">=2.6.0" },
     { name = "packaging" },
     { name = "pyarrow", specifier = ">=17.0.0" },
-    { name = "pylance", specifier = "==9.0.0rc1" },
+    { name = "pylance", specifier = ">=10.0.0b1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
@@ -1024,7 +1024,7 @@ wheels = [
 
 [[package]]
 name = "pylance"
-version = "9.0.0rc1"
+version = "10.0.0b1"
 source = { registry = "https://pypi.fury.io/lance-format" }
 dependencies = [
     { name = "lance-namespace" },
@@ -1033,12 +1033,12 @@ dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://pypi.fury.io/lance-format/-/ver_vEHBE/pylance-9.0.0rc1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f0b6b02a1808bb3072ee7fe4e36614cae6f86302513e73ec7f55b2234a963b24" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1Jipm4/pylance-9.0.0rc1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30f0ebf0d88034301819eb964f9236ce555aaa58e7ab89c5975a3e2250bbb405" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_IvKxo/pylance-9.0.0rc1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:44609ea2615ea6e684b85478d1694af2026458f61cf7895ecc75e238bfd17aa8" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_2hidj1/pylance-9.0.0rc1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:182167a8dba9eeabffbffd53bd5b8548613d4d459b7cd7b34a840dd00cbb806f" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_1dFx3r/pylance-9.0.0rc1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:8a63b11e814b7eab758bcaf0d6f97eb05ea86203d9fb0af718c462c24c7d6c9c" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_2a8dSh/pylance-9.0.0rc1-cp310-abi3-win_amd64.whl", hash = "sha256:2ff8b953ae2b0550490c1a7efd210aa91bc223d200ffac28849056cfd7436d97" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_zU1gg/pylance-10.0.0b1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:2fd111bd554bccc915e00ec0ab9ed97646872d37f411fea1844fa604843e65be" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_oAnFD/pylance-10.0.0b1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4595d1a804ae310ba088e7458b72e085c915c8ea1775fa334582341864ed869" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_17jvHV/pylance-10.0.0b1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e54a4b2178ec0e7723d47c913c506316dd457e15af1b82f821925258515091e0" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_VZS6E/pylance-10.0.0b1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:b2cfab58acecbd6e8f53ff5ef3b14d3674126497d09628432b31e7a614b2b1a4" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_2asQsR/pylance-10.0.0b1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1b64f74af97da417fa94f305a8882d94484d2b355bd8d7fe953dbdf854d3c4e1" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1u6UJ0/pylance-10.0.0b1-cp310-abi3-win_amd64.whl", hash = "sha256:cee29a500960040fa1ed21437bc5ffdde92b148407fdf488516f8e66bb89f9f6" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Update the Pylance dependency requirement to `pylance>=10.0.0b1`.
- Refresh `uv.lock` to resolve Pylance 10.0.0b1.
- Apply the formatting changes required by the current lint toolchain.

## Verification

- `make lint` passes.

Triggered by [`refs/tags/v10.0.0-beta.1`](https://github.com/lance-format/lance/releases/tag/v10.0.0-beta.1).
