### PR TITLE
feat(index): support distributed LABEL_LIST index

### DIFF
--- a/docs/src/distributed-indexing.md
+++ b/docs/src/distributed-indexing.md
@@ -7,7 +7,7 @@ Lance-Ray provides distributed index building functionality that leverages Ray's
 
 ### Scalar Indexing
 
-`create_scalar_index()` - Distributedly create scalar index using ray. Currently only Inverted/FTS/BTREE/BITMAP/NGRAM/ZONEMAP/BLOOMFILTER/RTREE are supported. Will add more index type support in the future.
+`create_scalar_index()` - Distributedly create scalar index using ray. Currently Inverted/FTS/BTREE/BITMAP/LABEL_LIST/NGRAM/ZONEMAP/BLOOMFILTER/RTREE are supported. Will add more index type support in the future.
 
 To construct GeoArrow data for an RTREE index, install the PyLance geo extra:
 
@@ -77,7 +77,7 @@ def create_scalar_index(
 | `ray_remote_args` | `Dict[str, Any]`, optional | Ray task options (e.g., `num_cpus`, `resources`) |
 | `**kwargs` | `Any` | Additional arguments passed to `create_scalar_index` |
 
-**Note:** For distributed scalar indexing, currently only `"INVERTED"`, `"FTS"`, `"BTREE"`, `"BITMAP"`, `"NGRAM"`, `"ZONEMAP"`, `"BLOOMFILTER"` and `"RTREE"` index types are supported.
+**Note:** For distributed scalar indexing, currently `"INVERTED"`, `"FTS"`, `"BTREE"`, `"BITMAP"`, `"LABEL_LIST"`, `"NGRAM"`, `"ZONEMAP"`, `"BLOOMFILTER"`, and `"RTREE"` index types are supported.
 
 #### Return Value
 

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -596,17 +596,17 @@ def create_scalar_index(
                         f"Column {column} must be numeric or string type for "
                         f"{index_type} index, got {value_type}"
                     )
+            case "LABEL_LIST":
+                if not (
+                    pa.types.is_list(field.type) or pa.types.is_large_list(field.type)
+                ):
+                    raise TypeError(
+                        f"Column {column} must be list or large list type for "
+                        f"LABEL_LIST index, got {field.type}"
+                    )
             case _:
                 # For other index types, skip strict validation to maintain compatibility
                 pass
-
-    if _scalar_index_type_name(index_type) == "LABEL_LIST" and not (
-        pa.types.is_list(field.type) or pa.types.is_large_list(field.type)
-    ):
-        raise TypeError(
-            f"Column {column} must be list or large list type for "
-            f"LABEL_LIST index, got {field.type}"
-        )
 
     use_segment_workflow = (
         _scalar_index_type_name(index_type) in _SCALAR_SEGMENT_INDEX_TYPES

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -473,7 +473,7 @@ def create_scalar_index(
 
     Raises:
         ValueError: If input parameters are invalid.
-        TypeError: If column type is not string.
+        TypeError: If the column type is incompatible with the index type.
         RuntimeError: If index building fails or pylance version is incompatible.
     """
     # Check pylance version compatibility
@@ -596,17 +596,17 @@ def create_scalar_index(
                         f"Column {column} must be numeric or string type for "
                         f"{index_type} index, got {value_type}"
                     )
-            case "LABEL_LIST":
-                if not (
-                    pa.types.is_list(field.type) or pa.types.is_large_list(field.type)
-                ):
-                    raise TypeError(
-                        f"Column {column} must be list or large list type for "
-                        f"LABEL_LIST index, got {field.type}"
-                    )
             case _:
                 # For other index types, skip strict validation to maintain compatibility
                 pass
+
+    if _scalar_index_type_name(index_type) == "LABEL_LIST" and not (
+        pa.types.is_list(field.type) or pa.types.is_large_list(field.type)
+    ):
+        raise TypeError(
+            f"Column {column} must be list or large list type for "
+            f"LABEL_LIST index, got {field.type}"
+        )
 
     use_segment_workflow = (
         _scalar_index_type_name(index_type) in _SCALAR_SEGMENT_INDEX_TYPES

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -225,7 +225,7 @@ _ScalarIndexType: TypeAlias = Literal[
     "RTREE",
 ]
 _SCALAR_INDEX_TYPES = get_args(_ScalarIndexType)
-_SCALAR_SEGMENT_INDEX_TYPES = frozenset(_SCALAR_INDEX_TYPES) - {"LABEL_LIST"}
+_SCALAR_SEGMENT_INDEX_TYPES = frozenset(_SCALAR_INDEX_TYPES)
 
 
 def _scalar_index_type_name(index_type: str | IndexConfig) -> str | None:
@@ -595,6 +595,14 @@ def create_scalar_index(
                     raise TypeError(
                         f"Column {column} must be numeric or string type for "
                         f"{index_type} index, got {value_type}"
+                    )
+            case "LABEL_LIST":
+                if not (
+                    pa.types.is_list(field.type) or pa.types.is_large_list(field.type)
+                ):
+                    raise TypeError(
+                        f"Column {column} must be list or large list type for "
+                        f"LABEL_LIST index, got {field.type}"
                     )
             case _:
                 # For other index types, skip strict validation to maintain compatibility

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=10.0.0b5",
+    "pylance>=10.0.0b7",
     "lance-namespace",
     "packaging",
     "pyarrow>=17.0.0",

--- a/tests/test_distributed_indexing.py
+++ b/tests/test_distributed_indexing.py
@@ -1514,6 +1514,73 @@ class TestDistributedScalarSegmentIndexes:
         assert "point_rtree_idx" in explain
 
 
+class TestDistributedLabelListIndexing:
+    """Distributed LABEL_LIST indexing tests."""
+
+    def test_distributed_large_list_index_matches_baseline(self, temp_dir):
+        """Build one segment per fragment and verify a list-membership query."""
+        rows_per_fragment = 8
+        num_fragments = 3
+        num_rows = rows_per_fragment * num_fragments
+        dataset = lance.write_dataset(
+            pa.table(
+                {
+                    "id": pa.array(range(num_rows), type=pa.int32()),
+                    "labels": pa.array(
+                        [
+                            ["distributed"] if row_id % 2 == 0 else ["other"]
+                            for row_id in range(num_rows)
+                        ],
+                        type=pa.large_list(pa.string()),
+                    ),
+                }
+            ),
+            str(Path(temp_dir) / "distributed_label_list.lance"),
+            max_rows_per_file=rows_per_fragment,
+        )
+        assert len(dataset.get_fragments()) == num_fragments
+
+        index_name = "labels_idx"
+        indexed_dataset = lr.create_scalar_index(
+            uri=dataset.uri,
+            column="labels",
+            index_type="LABEL_LIST",
+            name=index_name,
+            replace=False,
+            num_workers=num_fragments,
+            num_segments=num_fragments,
+        )
+
+        index = next(
+            index
+            for index in indexed_dataset.describe_indices()
+            if index.name == index_name
+        )
+        assert index.index_type == "LabelList"
+        assert len(index.segments) == num_fragments
+
+        filter_expr = "array_has_any(labels, ['distributed'])"
+        indexed = indexed_dataset.scanner(
+            filter=filter_expr,
+            columns=["id", "labels"],
+            use_scalar_index=True,
+        ).to_table()
+        baseline = indexed_dataset.scanner(
+            filter=filter_expr,
+            columns=["id", "labels"],
+            use_scalar_index=False,
+        ).to_table()
+
+        assert indexed.equals(baseline)
+        plan = indexed_dataset.scanner(
+            filter=filter_expr,
+            columns=["id"],
+            use_scalar_index=True,
+        ).explain_plan()
+        assert "ScalarIndexQuery" in plan
+        assert index_name in plan
+
+
 class TestOptimizeIndices:
     """Test cases for optimize_indices (incremental index optimization)."""
 

--- a/tests/test_distributed_indexing.py
+++ b/tests/test_distributed_indexing.py
@@ -1517,20 +1517,29 @@ class TestDistributedScalarSegmentIndexes:
 class TestDistributedLabelListIndexing:
     """Distributed LABEL_LIST indexing tests."""
 
-    def test_distributed_large_list_index_matches_baseline(self, temp_dir):
-        """Build one segment per fragment and verify a list-membership query."""
+    def test_distributed_large_list_index_preserves_nullable_query_semantics(
+        self, temp_dir
+    ):
+        """Build one segment per fragment and preserve nullable list semantics."""
         rows_per_fragment = 8
         num_fragments = 3
         num_rows = rows_per_fragment * num_fragments
+        labels_per_fragment = [
+            ["distributed", "shared"],
+            ["other", None],
+            None,
+            [],
+            ["distributed"],
+            ["shared", "other"],
+            [None],
+            ["other"],
+        ]
         dataset = lance.write_dataset(
             pa.table(
                 {
                     "id": pa.array(range(num_rows), type=pa.int32()),
                     "labels": pa.array(
-                        [
-                            ["distributed"] if row_id % 2 == 0 else ["other"]
-                            for row_id in range(num_rows)
-                        ],
+                        labels_per_fragment * num_fragments,
                         type=pa.large_list(pa.string()),
                     ),
                 }
@@ -1572,6 +1581,7 @@ class TestDistributedLabelListIndexing:
         ).to_table()
 
         assert indexed.equals(baseline)
+        assert indexed.column("id").to_pylist() == [0, 4, 8, 12, 16, 20]
         plan = indexed_dataset.scanner(
             filter=filter_expr,
             columns=["id"],

--- a/tests/test_distributed_indexing.py
+++ b/tests/test_distributed_indexing.py
@@ -583,7 +583,7 @@ class TestDistributedIndexing:
         indices = {idx.name: idx for idx in updated_dataset.describe_indices()}
         assert indices["nested_text_idx"].field_names == ["meta.text"]
         assert indices["literal_dot_text_idx"].field_names == ["meta.`a.b`"]
-        assert indices["hyphen_user_id_idx"].field_names == ["`meta-data`.`user-id`"]
+        assert indices["hyphen_user_id_idx"].field_names == ["meta-data.user-id"]
 
         nested_results = updated_dataset.scanner(
             full_text_query="nestedthree",

--- a/tests/test_distributed_indexing.py
+++ b/tests/test_distributed_indexing.py
@@ -1395,6 +1395,29 @@ class TestDistributedScalarSegmentIndexes:
                 ["value = 4", "value IN (1, 6, 11)"],
                 id="bloomfilter",
             ),
+            pytest.param(
+                "LABEL_LIST",
+                "labels",
+                [
+                    ["distributed", "shared"],
+                    ["other", None],
+                    None,
+                    [],
+                    ["distributed"],
+                    ["shared", "other"],
+                    [None],
+                    ["other"],
+                    ["distributed", "shared"],
+                    ["other", None],
+                    None,
+                    [],
+                ],
+                pa.large_list(pa.string()),
+                "labels_idx",
+                "LabelList",
+                ["array_has_any(labels, ['distributed'])"],
+                id="label-list",
+            ),
         ],
     )
     def test_filter_index_matches_baseline(
@@ -1512,83 +1535,6 @@ class TestDistributedScalarSegmentIndexes:
         )
         assert "ScalarIndexQuery" in explain
         assert "point_rtree_idx" in explain
-
-
-class TestDistributedLabelListIndexing:
-    """Distributed LABEL_LIST indexing tests."""
-
-    def test_distributed_large_list_index_preserves_nullable_query_semantics(
-        self, temp_dir
-    ):
-        """Build one segment per fragment and preserve nullable list semantics."""
-        rows_per_fragment = 8
-        num_fragments = 3
-        num_rows = rows_per_fragment * num_fragments
-        labels_per_fragment = [
-            ["distributed", "shared"],
-            ["other", None],
-            None,
-            [],
-            ["distributed"],
-            ["shared", "other"],
-            [None],
-            ["other"],
-        ]
-        dataset = lance.write_dataset(
-            pa.table(
-                {
-                    "id": pa.array(range(num_rows), type=pa.int32()),
-                    "labels": pa.array(
-                        labels_per_fragment * num_fragments,
-                        type=pa.large_list(pa.string()),
-                    ),
-                }
-            ),
-            str(Path(temp_dir) / "distributed_label_list.lance"),
-            max_rows_per_file=rows_per_fragment,
-        )
-        assert len(dataset.get_fragments()) == num_fragments
-
-        index_name = "labels_idx"
-        indexed_dataset = lr.create_scalar_index(
-            uri=dataset.uri,
-            column="labels",
-            index_type="LABEL_LIST",
-            name=index_name,
-            replace=False,
-            num_workers=num_fragments,
-            num_segments=num_fragments,
-        )
-
-        index = next(
-            index
-            for index in indexed_dataset.describe_indices()
-            if index.name == index_name
-        )
-        assert index.index_type == "LabelList"
-        assert len(index.segments) == num_fragments
-
-        filter_expr = "array_has_any(labels, ['distributed'])"
-        indexed = indexed_dataset.scanner(
-            filter=filter_expr,
-            columns=["id", "labels"],
-            use_scalar_index=True,
-        ).to_table()
-        baseline = indexed_dataset.scanner(
-            filter=filter_expr,
-            columns=["id", "labels"],
-            use_scalar_index=False,
-        ).to_table()
-
-        assert indexed.equals(baseline)
-        assert indexed.column("id").to_pylist() == [0, 4, 8, 12, 16, 20]
-        plan = indexed_dataset.scanner(
-            filter=filter_expr,
-            columns=["id"],
-            use_scalar_index=True,
-        ).explain_plan()
-        assert "ScalarIndexQuery" in plan
-        assert index_name in plan
 
 
 class TestOptimizeIndices:

--- a/tests/test_vector_index_options.py
+++ b/tests/test_vector_index_options.py
@@ -20,13 +20,7 @@ def _load_index_module_with_stubs():
 
     lance_dataset = ModuleType("lance.dataset")
     lance_dataset.Index = type("Index", (), {})
-
-    class IndexConfig:
-        def __init__(self, index_type, parameters):
-            self.index_type = index_type
-            self.parameters = parameters
-
-    lance_dataset.IndexConfig = IndexConfig
+    lance_dataset.IndexConfig = type("IndexConfig", (), {})
     lance_dataset.LanceDataset = object
 
     lance_indices = ModuleType("lance.indices")
@@ -525,26 +519,14 @@ def test_create_scalar_index_uses_segment_path(monkeypatch, index_type):
     assert fake_dataset.commit_kwargs["segments"] == ["segment"]
 
 
-@pytest.mark.parametrize(
-    "index_type",
-    ["LABEL_LIST", index_mod.IndexConfig("LABEL_LIST", {})],
-    ids=["string", "index-config"],
-)
-def test_create_label_list_index_rejects_non_list_column(monkeypatch, index_type):
+def test_create_label_list_index_rejects_non_list_column():
     """LABEL_LIST should reject invalid columns before Ray workers start."""
-
-    def fail_if_workers_are_scheduled(**kwargs):
-        raise AssertionError("Ray workers should not be scheduled")
-
-    monkeypatch.setattr(
-        index_mod, "_map_async_with_pool", fail_if_workers_are_scheduled
-    )
 
     with pytest.raises(TypeError, match="must be list or large list type"):
         index_mod.create_scalar_index(
             uri=_FakeDataset(),
             column="value",
-            index_type=index_type,
+            index_type="LABEL_LIST",
         )
 
 

--- a/tests/test_vector_index_options.py
+++ b/tests/test_vector_index_options.py
@@ -69,7 +69,7 @@ class _FakeLanceField:
 
 class _FakeLanceSchema:
     def field(self, column):
-        if column not in {"value", "text"}:
+        if column not in {"value", "text", "labels"}:
             raise KeyError(column)
         return _FakeLanceField()
 
@@ -82,6 +82,8 @@ class _FakeSchema:
             return _FakeField(column, index_mod.pa.int64())
         if column == "text":
             return _FakeField(column, index_mod.pa.string())
+        if column == "labels":
+            return _FakeField(column, index_mod.pa.list_(index_mod.pa.string()))
         else:
             raise KeyError(column)
 
@@ -91,6 +93,7 @@ class _FakeSchema:
                 _FakeField("vector"),
                 _FakeField("value", index_mod.pa.int64()),
                 _FakeField("text", index_mod.pa.string()),
+                _FakeField("labels", index_mod.pa.list_(index_mod.pa.string())),
             ]
         )
 
@@ -447,7 +450,16 @@ def test_create_index_rejects_invalid_num_segments(monkeypatch):
 
 @pytest.mark.parametrize(
     "index_type",
-    ["BTREE", "BITMAP", "INVERTED", "FTS", "NGRAM", "BLOOMFILTER", "RTREE"],
+    [
+        "BTREE",
+        "BITMAP",
+        "INVERTED",
+        "FTS",
+        "NGRAM",
+        "BLOOMFILTER",
+        "RTREE",
+        "LABEL_LIST",
+    ],
 )
 def test_create_scalar_index_uses_segment_path(monkeypatch, index_type):
     """Migrated scalar indexes should use Lance's segment workflow."""
@@ -486,7 +498,12 @@ def test_create_scalar_index_uses_segment_path(monkeypatch, index_type):
     )
     monkeypatch.setattr(index_mod, "_map_async_with_pool", fake_map_async_with_pool)
 
-    column = "text" if index_type in {"INVERTED", "FTS", "NGRAM"} else "value"
+    if index_type in {"INVERTED", "FTS", "NGRAM"}:
+        column = "text"
+    elif index_type == "LABEL_LIST":
+        column = "labels"
+    else:
+        column = "value"
     updated_dataset = index_mod.create_scalar_index(
         uri="memory://fake",
         column=column,
@@ -500,6 +517,17 @@ def test_create_scalar_index_uses_segment_path(monkeypatch, index_type):
     assert captured["fragment_handler_kwargs"]["index_type"] == index_type
     assert captured["fragment_handler_kwargs"]["block_size"] == 4096
     assert fake_dataset.commit_kwargs["segments"] == ["segment"]
+
+
+def test_create_label_list_index_rejects_non_list_column():
+    """LABEL_LIST should reject invalid columns before Ray workers start."""
+
+    with pytest.raises(TypeError, match="must be list or large list type"):
+        index_mod.create_scalar_index(
+            uri=_FakeDataset(),
+            column="value",
+            index_type="LABEL_LIST",
+        )
 
 
 def test_create_index_passes_block_size_to_loads_and_handler(monkeypatch):
@@ -594,9 +622,9 @@ def test_fragment_handlers_pass_block_size_to_dataset_load(monkeypatch):
 
     scalar_handler = index_mod._handle_fragment_index(
         dataset_uri="memory://fake",
-        column="value",
-        index_type="LABEL_LIST",
-        name="value_idx",
+        column="text",
+        index_type="NGRAM",
+        name="text_idx",
         index_uuid="scalar-index",
         replace=False,
         train=True,

--- a/tests/test_vector_index_options.py
+++ b/tests/test_vector_index_options.py
@@ -20,7 +20,13 @@ def _load_index_module_with_stubs():
 
     lance_dataset = ModuleType("lance.dataset")
     lance_dataset.Index = type("Index", (), {})
-    lance_dataset.IndexConfig = type("IndexConfig", (), {})
+
+    class IndexConfig:
+        def __init__(self, index_type, parameters):
+            self.index_type = index_type
+            self.parameters = parameters
+
+    lance_dataset.IndexConfig = IndexConfig
     lance_dataset.LanceDataset = object
 
     lance_indices = ModuleType("lance.indices")
@@ -519,14 +525,26 @@ def test_create_scalar_index_uses_segment_path(monkeypatch, index_type):
     assert fake_dataset.commit_kwargs["segments"] == ["segment"]
 
 
-def test_create_label_list_index_rejects_non_list_column():
+@pytest.mark.parametrize(
+    "index_type",
+    ["LABEL_LIST", index_mod.IndexConfig("LABEL_LIST", {})],
+    ids=["string", "index-config"],
+)
+def test_create_label_list_index_rejects_non_list_column(monkeypatch, index_type):
     """LABEL_LIST should reject invalid columns before Ray workers start."""
+
+    def fail_if_workers_are_scheduled(**kwargs):
+        raise AssertionError("Ray workers should not be scheduled")
+
+    monkeypatch.setattr(
+        index_mod, "_map_async_with_pool", fail_if_workers_are_scheduled
+    )
 
     with pytest.raises(TypeError, match="must be list or large list type"):
         index_mod.create_scalar_index(
             uri=_FakeDataset(),
             column="value",
-            index_type="LABEL_LIST",
+            index_type=index_type,
         )
 
 

--- a/tests/test_vector_index_options.py
+++ b/tests/test_vector_index_options.py
@@ -449,19 +449,19 @@ def test_create_index_rejects_invalid_num_segments(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "index_type",
+    ("index_type", "column"),
     [
-        "BTREE",
-        "BITMAP",
-        "INVERTED",
-        "FTS",
-        "NGRAM",
-        "BLOOMFILTER",
-        "RTREE",
-        "LABEL_LIST",
+        ("BTREE", "value"),
+        ("BITMAP", "value"),
+        ("INVERTED", "text"),
+        ("FTS", "text"),
+        ("NGRAM", "text"),
+        ("BLOOMFILTER", "value"),
+        ("RTREE", "value"),
+        ("LABEL_LIST", "labels"),
     ],
 )
-def test_create_scalar_index_uses_segment_path(monkeypatch, index_type):
+def test_create_scalar_index_uses_segment_path(monkeypatch, index_type, column):
     """Migrated scalar indexes should use Lance's segment workflow."""
 
     captured = {"loads": []}
@@ -498,12 +498,6 @@ def test_create_scalar_index_uses_segment_path(monkeypatch, index_type):
     )
     monkeypatch.setattr(index_mod, "_map_async_with_pool", fake_map_async_with_pool)
 
-    if index_type in {"INVERTED", "FTS", "NGRAM"}:
-        column = "text"
-    elif index_type == "LABEL_LIST":
-        column = "labels"
-    else:
-        column = "value"
     updated_dataset = index_mod.create_scalar_index(
         uri="memory://fake",
         column=column,

--- a/tests/test_vector_index_options.py
+++ b/tests/test_vector_index_options.py
@@ -622,9 +622,9 @@ def test_fragment_handlers_pass_block_size_to_dataset_load(monkeypatch):
 
     scalar_handler = index_mod._handle_fragment_index(
         dataset_uri="memory://fake",
-        column="text",
-        index_type="NGRAM",
-        name="text_idx",
+        column="value",
+        index_type="LABEL_LIST",
+        name="value_idx",
         index_uuid="scalar-index",
         replace=False,
         train=True,

--- a/uv.lock
+++ b/uv.lock
@@ -501,7 +501,7 @@ requires-dist = [
     { name = "more-itertools", marker = "python_full_version < '3.12'", specifier = ">=2.6.0" },
     { name = "packaging" },
     { name = "pyarrow", specifier = ">=17.0.0" },
-    { name = "pylance", specifier = ">=10.0.0b5" },
+    { name = "pylance", specifier = ">=10.0.0b7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
@@ -1138,7 +1138,7 @@ wheels = [
 
 [[package]]
 name = "pylance"
-version = "10.0.0b6"
+version = "10.0.0b7"
 source = { registry = "https://pypi.fury.io/lance-format" }
 dependencies = [
     { name = "lance-namespace" },
@@ -1147,12 +1147,12 @@ dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://pypi.fury.io/lance-format/-/ver_1S1urO/pylance-10.0.0b6-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:0529e466b3545eedef1dc55acfd41014f9a051eccc129b1688045dbe142e45a7" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_2h9KXm/pylance-10.0.0b6-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f741e3ae2b8c928675477ca7e012a74be280009178f22b80c2ec8ee8fbc5b32e" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_PFSbW/pylance-10.0.0b6-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c623e0ae1220d769827b4b0aa64f1bcd00cb18e4a81ecf8f7617bc00e359fbe6" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_vww2D/pylance-10.0.0b6-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:dfb232cc641f06799659c1a9d57969e1f920be8f9208ad2c29fce8edf31b8f16" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_ECyWk/pylance-10.0.0b6-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b683832edd828691bbbe55d97c36d0859ea9734c673219c12c740f817f9442fa" },
-    { url = "https://pypi.fury.io/lance-format/-/ver_ub84x/pylance-10.0.0b6-cp310-abi3-win_amd64.whl", hash = "sha256:831ee58fd98c1d1306e93b874878bc0d5da320e7e04f5b60d94535816b46b490" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_F25tX/pylance-10.0.0b7-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:3c91750f59df60157ae2a784195358ac6e87c312348bab6aa0d3074daf570b8c" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_285dmG/pylance-10.0.0b7-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:248ecb3d46323c2c9363e030b82f9973daa6d9df1044fc4dafe513fc83780ad8" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_kRD7S/pylance-10.0.0b7-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4f60a028e8a2bbddfae1cbf288a47375e1c2bfd7a1bb26e0a1da53f7f4f166a" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_RywJJ/pylance-10.0.0b7-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0cd91ad4a1d240c6a8cf399233a5f9c1c050e035fc960766ebc584dfadcc817e" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_UyK0D/pylance-10.0.0b7-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1fbd4a40a9dc17104abe467870aa89521a1bdeed62c80547e326cc353f2ef0a3" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1UP4Pu/pylance-10.0.0b7-cp310-abi3-win_amd64.whl", hash = "sha256:23b44b64270f7ac11c75d8a084e94867708541722da5405531a6caa61783680e" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- route `LABEL_LIST` builds through Lance segment APIs (`create_index_uncommitted` and `commit_existing_index_segments`)
- validate list and large-list columns on the driver before Ray workers start
- add multi-fragment LargeList coverage that checks physical segment count, query parity, and `ScalarIndexQuery`
- document `LABEL_LIST` as a distributed scalar index

## Why

PyLance v10.0.0-beta.7 exposes the existing LABEL_LIST segment lifecycle through `create_index_uncommitted`, including lance-format/lance#7884. Lance-Ray otherwise rejects `LABEL_LIST` as a distributed index and leaves it on the legacy fragment-metadata path.

## Dependency

- require `pylance>=10.0.0b7`
- lock the official PyLance 10.0.0-beta.7 wheel published through the Lance Fury index

## Validation

- `.venv/bin/pytest -q tests/test_vector_index_options.py tests/test_distributed_indexing.py::TestDistributedLabelListIndexing` — 16 passed
- `.venv/bin/python -c "import lance; print(lance.__version__); print(lance.LanceDataset._is_segment_native_scalar_index_type(\"LABEL_LIST\"))"` — `10.0.0-beta.7`, `True`
- `.venv/bin/ruff check --no-cache lance_ray tests`
- `.venv/bin/ruff format --no-cache --check lance_ray tests`
- `uv lock --check`
- `git diff --check`