### PR TITLE
chore: update pylance dependency to v10.0.0b7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "ray[data]>=2.41.0",
-    "pylance>=9.0.0",
+    "pylance>=10.0.0b7",
     "lance-namespace",
     "packaging",
     "pyarrow>=17.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -387,7 +387,7 @@ requires-dist = [
     { name = "more-itertools", marker = "python_full_version < '3.12'", specifier = ">=2.6.0" },
     { name = "packaging" },
     { name = "pyarrow", specifier = ">=17.0.0" },
-    { name = "pylance", specifier = ">=9.0.0" },
+    { name = "pylance", specifier = ">=10.0.0b7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
@@ -1024,8 +1024,8 @@ wheels = [
 
 [[package]]
 name = "pylance"
-version = "9.0.0"
-source = { registry = "https://pypi.org/simple" }
+version = "10.0.0b7"
+source = { registry = "https://pypi.fury.io/lance-format" }
 dependencies = [
     { name = "lance-namespace" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1033,12 +1033,12 @@ dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/be/45733acd64801991852aac8e658601fd8fc12f76ceb81e57fca690896b90/pylance-9.0.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:8257213501d3298c5b6a344d60938e4bbe4de9f00cd3265371a56d1dc3dd15ca", size = 68377982, upload-time = "2026-07-24T16:53:45.247Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/3e/1ef707cb215cc7268c63ad84a91344ad6313d3984b343eeb19a9b708698e/pylance-9.0.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:804eedfa1fda2e703cca8580c76f0b44a1b849b725a8908c06f8acfca811732f", size = 71844362, upload-time = "2026-07-24T16:56:07.6Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/fb/a499e5c53ddb75c7de44100fd2bb1f7cc735966200d20292eed7af9ef552/pylance-9.0.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a0b75595e3766c1d5f4c90abdc52337b4de60f1a52d123a4f8c4e5bcbbbfa8f", size = 75663088, upload-time = "2026-07-24T17:10:31.283Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/80/0714e09f64a68dbdf62558955e737a7436df763b9834a6aba506861b5352/pylance-9.0.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d2f69c5c390ae3710c35a429905fe15f769951777fafb1b72a359e035ec121f7", size = 71866858, upload-time = "2026-07-24T16:56:35.937Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/3c/78d3a6d6ca0d843b7c3ac0c30d9cd2cf4635b0c2cabe6ec66583d5bfc1a1/pylance-9.0.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:836268a7832d62f3d5ccbe1c3fca239621971d90297bcfff14a70b3cb6842aa8", size = 75642656, upload-time = "2026-07-24T17:13:11.879Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/c1/dc9c9a31e171530ec0add024d922488c046437d32a7087c29e254a7eacc7/pylance-9.0.0-cp310-abi3-win_amd64.whl", hash = "sha256:96441d27a5ed3805300388ccf8f31835cd280c98751f80b6a1a11dcd6808fc43", size = 81668288, upload-time = "2026-07-24T17:05:38.707Z" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_F25tX/pylance-10.0.0b7-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:3c91750f59df60157ae2a784195358ac6e87c312348bab6aa0d3074daf570b8c" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_285dmG/pylance-10.0.0b7-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:248ecb3d46323c2c9363e030b82f9973daa6d9df1044fc4dafe513fc83780ad8" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_kRD7S/pylance-10.0.0b7-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4f60a028e8a2bbddfae1cbf288a47375e1c2bfd7a1bb26e0a1da53f7f4f166a" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_RywJJ/pylance-10.0.0b7-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0cd91ad4a1d240c6a8cf399233a5f9c1c050e035fc960766ebc584dfadcc817e" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_UyK0D/pylance-10.0.0b7-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1fbd4a40a9dc17104abe467870aa89521a1bdeed62c80547e326cc353f2ef0a3" },
+    { url = "https://pypi.fury.io/lance-format/-/ver_1UP4Pu/pylance-10.0.0b7-cp310-abi3-win_amd64.whl", hash = "sha256:23b44b64270f7ac11c75d8a084e94867708541722da5405531a6caa61783680e" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bump the Pylance dependency from `>=9.0.0` to `>=10.0.0b7`.
- Refresh `uv.lock` with the Pylance 10.0.0 beta 7 artifacts.
- Verify the repository passes `make lint`.

Triggered by [`refs/tags/v10.0.0-beta.7`](https://github.com/lance-format/lance/releases/tag/v10.0.0-beta.7).
