### PR TITLE
chore: don't let `trigger-update` run on forks, as it will fail there

### DIFF
--- a/.github/workflows/pylance-release-timer.yml
+++ b/.github/workflows/pylance-release-timer.yml
@@ -28,6 +28,9 @@ concurrency:
 jobs:
   trigger-update:
     runs-on: ubuntu-latest
+    # Only run in the upstream repo; forks lack LANCE_RELEASE_TOKEN and would
+    # fail this job on every scheduled tick.
+    if: github.repository == 'lance-format/lance-ray'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
I'm receiving loads (basically hourly or more) of error notifications on a failed CI job such as this one (https://github.com/jonasdedden/lance-ray/actions/runs/31603920768). This job can't succeed on forks, as `secrets.LANCE_RELEASE_TOKEN` is missing there. This PR disables it for forks.