### PR TITLE
feat: add update_columns_from API

### DIFF
--- a/docs/src/data-evolution.md
+++ b/docs/src/data-evolution.md
@@ -86,7 +86,10 @@ from different Lance datasets, or updating a different dataset than the one
 that was read, is rejected even when the version numbers match. If an operation
 replaces the lineage, such as materializing the Dataset, provide
 `read_version` explicitly; the update will not silently use the latest Lance
-version.
+version. If a reliable identity cannot be derived for an object-store dataset
+because no persistent UUID or non-sensitive backend discriminator is available,
+`update_columns_from` also requires an explicit `read_version` instead of
+performing unsafe automatic validation.
 
 Before fragment partitioning, the source is projected to `_rowaddr`, `_fragid`
 when present, and the columns listed in `columns`. Unused source columns are
@@ -102,7 +105,9 @@ bounded `RecordBatch` values rather than materialized as a full table.
 - `read_version`: Dataset version to update. Defaults to the unique Lance source
   version retained in the Ray Dataset's logical lineage. Required when the
   lineage is unavailable, such as after materializing the source. When lineage
-  is present, the source dataset identity must match the update target.
+  is present, the source dataset identity digest must match the update target.
+  An explicit value is also required when a reliable object-store identity
+  cannot be determined.
 - `ray_remote_args`: Optional Ray Data task options.
 - `storage_options`: Optional storage configuration dictionary.
 - `namespace_impl`, `namespace_properties`, `table_id`: Namespace resolution arguments.

--- a/docs/src/data-evolution.md
+++ b/docs/src/data-evolution.md
@@ -30,3 +30,80 @@ Add columns to an existing Lance dataset using Ray's distributed processing.
 - `concurrency`: Optional number of concurrent processes
 
 **Returns:** None
+
+## `update_columns_from`
+
+```python
+update_columns_from(
+    uri=None,
+    ds=None,
+    *,
+    columns,
+    read_version=None,
+    ray_remote_args=None,
+    storage_options=None,
+    namespace_impl=None,
+    namespace_properties=None,
+    table_id=None,
+    batch_size=1024,
+)
+```
+
+Update existing columns in a Lance dataset using row metadata. The input Ray
+Dataset must contain `_rowaddr` and every column listed in `columns`. If
+`_fragid` is absent, it is derived from `_rowaddr`; if supplied, it must match
+the fragment ID encoded in `_rowaddr`.
+
+```python
+import lance_ray as lr
+
+source = lr.read_lance("my_dataset.lance", with_metadata=True)
+source = source.map_batches(modify_status, batch_format="pandas")
+
+lr.update_columns_from(
+    "my_dataset.lance",
+    source,
+    columns=["status"],
+)
+```
+
+Unmatched source rows are ignored. This API updates existing columns only; it
+does not insert, delete, or upsert rows. Transform functions must preserve
+`_rowaddr`. An empty source is treated as a no-op and emits a warning.
+
+Each `_rowaddr` must be a non-null integer value and may appear only once; it
+is normalized to `uint64` before routing. Names in `columns` must also be
+unique, and every source update column must have the same Arrow type as the
+corresponding target column.
+
+The final update operation is committed once against the dataset version that
+was originally read. Commit conflicts are returned to the caller; safely
+retrying requires rerunning the update pipeline from the latest dataset version.
+`read_lance()` retains that version and a stable dataset identity in Ray's
+logical source lineage, so renaming or combining lazy Dataset branches does
+not change the update base. Combining rows from different Lance datasets, or
+updating a different dataset than the one that was read, is rejected even when
+the version numbers match. If an operation replaces the lineage, such as
+materializing the Dataset, provide `read_version` explicitly; the update will
+not silently use the latest Lance version.
+
+Before `groupby`, the source is projected to `_rowaddr`, `_fragid` when
+present, and the columns listed in `columns`. Unused source columns are not
+shuffled into fragment update workers.
+
+**Parameters:**
+
+- `uri`: Path to the Lance dataset. Either `uri` or namespace parameters are required.
+- `ds`: Ray Dataset containing `_rowaddr` and the columns to update. `_fragid`
+  is derived when absent and validated against `_rowaddr` when supplied.
+- `columns`: Existing columns to update.
+- `read_version`: Dataset version to update. Defaults to the unique Lance source
+  version retained in the Ray Dataset's logical lineage. Required when the
+  lineage is unavailable, such as after materializing the source. When lineage
+  is present, the source dataset identity must match the update target.
+- `ray_remote_args`: Optional Ray Data task options.
+- `storage_options`: Optional storage configuration dictionary.
+- `namespace_impl`, `namespace_properties`, `table_id`: Namespace resolution arguments.
+- `batch_size`: Batch size for the update reader. Must be positive.
+
+**Returns:** None

--- a/docs/src/data-evolution.md
+++ b/docs/src/data-evolution.md
@@ -79,13 +79,14 @@ corresponding target column.
 The final update operation is committed once against the dataset version that
 was originally read. Commit conflicts are returned to the caller; safely
 retrying requires rerunning the update pipeline from the latest dataset version.
-`read_lance()` retains that version and a stable dataset identity in Ray's
-logical source lineage, so renaming or combining lazy Dataset branches does
-not change the update base. Combining rows from different Lance datasets, or
-updating a different dataset than the one that was read, is rejected even when
-the version numbers match. If an operation replaces the lineage, such as
-materializing the Dataset, provide `read_version` explicitly; the update will
-not silently use the latest Lance version.
+`read_lance()` retains that version and an irreversible SHA-256 digest of the
+stable dataset identity in Ray's logical source lineage, so renaming or
+combining lazy Dataset branches does not change the update base. Combining rows
+from different Lance datasets, or updating a different dataset than the one
+that was read, is rejected even when the version numbers match. If an operation
+replaces the lineage, such as materializing the Dataset, provide
+`read_version` explicitly; the update will not silently use the latest Lance
+version.
 
 Before fragment partitioning, the source is projected to `_rowaddr`, `_fragid`
 when present, and the columns listed in `columns`. Unused source columns are

--- a/docs/src/data-evolution.md
+++ b/docs/src/data-evolution.md
@@ -87,9 +87,10 @@ the version numbers match. If an operation replaces the lineage, such as
 materializing the Dataset, provide `read_version` explicitly; the update will
 not silently use the latest Lance version.
 
-Before `groupby`, the source is projected to `_rowaddr`, `_fragid` when
-present, and the columns listed in `columns`. Unused source columns are not
-shuffled into fragment update workers.
+Before fragment partitioning, the source is projected to `_rowaddr`, `_fragid`
+when present, and the columns listed in `columns`. Unused source columns are
+not routed into fragment update workers, and each fragment is streamed as
+bounded `RecordBatch` values rather than materialized as a full table.
 
 **Parameters:**
 

--- a/docs/src/data-evolution.md
+++ b/docs/src/data-evolution.md
@@ -83,13 +83,16 @@ retrying requires rerunning the update pipeline from the latest dataset version.
 stable dataset identity in Ray's logical source lineage, so renaming or
 combining lazy Dataset branches does not change the update base. Combining rows
 from different Lance datasets, or updating a different dataset than the one
-that was read, is rejected even when the version numbers match. If an operation
-replaces the lineage, such as materializing the Dataset, provide
-`read_version` explicitly; the update will not silently use the latest Lance
-version. If a reliable identity cannot be derived for an object-store dataset
-because no persistent UUID or non-sensitive backend discriminator is available,
-`update_columns_from` also requires an explicit `read_version` instead of
-performing unsafe automatic validation.
+that was read, is rejected even when the version numbers match, but only while
+that source lineage remains present. If an operation replaces the lineage, such
+as materializing the Dataset, provide `read_version` explicitly; the update
+will not silently use the latest Lance version. An explicit `read_version`
+proves which target version is used, not which dataset produced the source
+rows, so after lineage is lost the caller must ensure that the source rows
+still correspond to that target dataset. If a reliable identity cannot be
+derived for an object-store dataset because no persistent UUID or non-sensitive
+backend discriminator is available, `update_columns_from` also requires an
+explicit `read_version` instead of performing unsafe automatic validation.
 
 Before fragment partitioning, the source is projected to `_rowaddr`, `_fragid`
 when present, and the columns listed in `columns`. Unused source columns are

--- a/lance_ray/__init__.py
+++ b/lance_ray/__init__.py
@@ -21,6 +21,7 @@ from .io import (
     add_columns_from,
     merge_columns_from,
     read_lance,
+    update_columns_from,
     write_lance,
 )
 from .pool import clear_global_pool, get_global_pool, init_global_pool, set_global_pool
@@ -37,6 +38,7 @@ __all__ = [
     "add_columns",
     "add_columns_from",
     "merge_columns_from",
+    "update_columns_from",
     "create_scalar_index",
     "create_index",
     "optimize_indices",

--- a/lance_ray/datasource.py
+++ b/lance_ray/datasource.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import hashlib
 import inspect
+import ntpath
 import os
+import re
 from collections.abc import Iterator
 from functools import partial
 from typing import TYPE_CHECKING, Any, Optional, cast
@@ -29,14 +31,33 @@ if TYPE_CHECKING:
 # Keep provenance there instead of the user-controlled Dataset metrics name.
 LANCE_SOURCE_VERSION_NAME_PREFIX = "LanceDatasource[lance_ray_source_version="
 LANCE_SOURCE_ID_MARKER = ";lance_ray_source_id="
+_WINDOWS_DRIVE_PATH = re.compile(r"^[A-Za-z]:[\\/]")
+_WINDOWS_FILE_URI_PATH = re.compile(r"^/[A-Za-z]:[\\/]")
+
+
+def _uri_scheme(uri: str) -> str:
+    if _WINDOWS_DRIVE_PATH.match(uri):
+        return ""
+    return urlsplit(uri).scheme.lower()
+
+
+def _normalize_windows_path(path: str) -> str:
+    if _WINDOWS_FILE_URI_PATH.match(path):
+        path = path[1:]
+    normalized = ntpath.normcase(ntpath.normpath(path)).replace("\\", "/")
+    return normalized if len(normalized) == 3 else normalized.rstrip("/")
 
 
 def normalize_dataset_uri(uri: str) -> str:
     """Return a comparable URI for dataset identity checks."""
+    if _WINDOWS_DRIVE_PATH.match(uri):
+        return _normalize_windows_path(uri)
     if "://" in uri:
         parsed = urlsplit(uri)
         if parsed.scheme == "file":
             path = unquote(parsed.path)
+            if _WINDOWS_FILE_URI_PATH.match(path):
+                return _normalize_windows_path(path)
             if parsed.netloc and parsed.netloc != "localhost":
                 path = f"//{parsed.netloc}{path}"
             return os.path.realpath(os.path.abspath(path)).rstrip(os.sep)
@@ -51,19 +72,40 @@ def _non_sensitive_backend_identity(
     if not storage_options:
         return None
 
-    for key in ("endpoint", "endpoint_url"):
+    endpoint_keys = (
+        "endpoint",
+        "endpoint_url",
+        "aws_endpoint",
+        "s3_endpoint",
+        "azure_endpoint",
+        "azure_storage_endpoint",
+        "oss_endpoint",
+        "tos_endpoint",
+    )
+    for key in endpoint_keys:
         value = storage_options.get(key)
         if not value:
             continue
         value = str(value)
-        if "://" in value:
-            parsed = urlsplit(value)
-            value = urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", ""))
-        return f"{key}:{value}"
+        has_scheme = "://" in value
+        parsed = urlsplit(value if has_scheme else f"//{value}")
+        hostname = parsed.hostname
+        if hostname is not None:
+            if ":" in hostname:
+                hostname = f"[{hostname}]"
+            port = parsed.port
+            netloc = hostname if port is None else f"{hostname}:{port}"
+            value = urlunsplit(
+                (parsed.scheme if has_scheme else "", netloc, parsed.path, "", "")
+            )
+            if not has_scheme:
+                value = value.removeprefix("//")
+        return f"endpoint:{value}"
 
-    region = storage_options.get("region")
-    if region:
-        return f"region:{region}"
+    for key in ("account_name", "azure_storage_account_name"):
+        value = storage_options.get(key)
+        if value:
+            return f"azure_account:{value}"
     return None
 
 
@@ -85,8 +127,11 @@ def _has_reliable_identity(
         return True
 
     identity_uri = str(getattr(lance_ds, "uri", "") or "")
-    scheme = urlsplit(identity_uri).scheme.lower()
-    return scheme in {"", "file"}
+    scheme = _uri_scheme(identity_uri)
+    # S3 and GCS bucket names identify the backend without credentials. Azure
+    # container names are account-scoped, so Azure still requires an account or
+    # endpoint discriminator when a native dataset UUID is unavailable.
+    return scheme in {"", "file", "s3", "gs"}
 
 
 def dataset_identity(
@@ -227,8 +272,7 @@ class LanceDatasource(Datasource):
 
         self._lance_ds: Optional[lance.LanceDataset] = None
         self._fragments: Optional[list[lance.LanceFragment]] = None
-        self._source_version: Optional[int] = None
-        self._source_identity: Optional[str] = None
+        self._source_provenance: Optional[tuple[int, Optional[str]]] = None
 
     @property
     def lance_dataset(self) -> lance.LanceDataset:
@@ -254,30 +298,33 @@ class LanceDatasource(Datasource):
         return self._lance_ds
 
     def _pin_source_provenance(self) -> None:
-        dataset = self.lance_dataset
-        if self._source_version is None:
-            self._source_version = dataset.version
-        if self._source_identity is None:
-            self._source_identity = dataset_identity_digest(
-                dataset,
-                storage_options=self._storage_options,
+        if self._source_provenance is None:
+            dataset = self.lance_dataset
+            self._source_provenance = (
+                dataset.version,
+                dataset_identity_digest(
+                    dataset,
+                    storage_options=self._storage_options,
+                ),
             )
 
     @property
     def source_version(self) -> int:
         """Return the Lance version fixed when this datasource is first used."""
-        if self._source_version is None:
+        if self._source_provenance is None:
             self._pin_source_provenance()
-        version = self._source_version
-        assert version is not None
-        return version
+        provenance = self._source_provenance
+        assert provenance is not None
+        return provenance[0]
 
     @property
     def source_identity(self) -> Optional[str]:
         """Return the dataset identity fixed when this datasource is first used."""
-        if self._source_identity is None:
+        if self._source_provenance is None:
             self._pin_source_provenance()
-        return self._source_identity
+        provenance = self._source_provenance
+        assert provenance is not None
+        return provenance[1]
 
     def pin_source_version(self) -> None:
         """Resolve the source snapshot before Ray starts lazy execution."""
@@ -340,6 +387,24 @@ class LanceDatasource(Datasource):
         table_id = self._table_id
         base_store_params = self._base_store_params
 
+        metadata_accepts_schema = (
+            "schema" in inspect.signature(BlockMetadata.__init__).parameters
+        )
+        block_schema: Optional[pa.Schema] = None
+        if metadata_accepts_schema:
+            schema_options = self._scanner_options.copy()
+            if self._with_metadata:
+                schema_options["with_row_address"] = True
+            block_schema = self.lance_dataset.scanner(**schema_options).projected_schema
+            if self._with_metadata and "_fragid" not in block_schema.names:
+                block_schema = block_schema.append(pa.field("_fragid", pa.uint64()))
+            if not self._with_metadata:
+                block_schema = pa.schema(
+                    field
+                    for field in block_schema
+                    if field.name not in {"_rowaddr", "_fragid"}
+                )
+
         for fragments in array_split(self.fragments, parallelism):
             if len(fragments) == 0:
                 continue
@@ -353,20 +418,15 @@ class LanceDatasource(Datasource):
             num_rows = scanner.count_rows()
 
             fragment_ids = [f.metadata.id for f in fragments]
-            input_files = tuple(
+            input_files = [
                 data_file.path
                 for fragment in fragments
                 for data_file in fragment.data_files()
-            )
+            ]
 
             # Ray 2.48+ no longer has the schema argument...
-            if "schema" in inspect.signature(BlockMetadata.__init__).parameters:
-                # TODO(chengsu): Take column projection into consideration for schema.
-                block_schema = fragments[0].schema
-                if self._with_metadata:
-                    block_schema = block_schema.append(
-                        pa.field("_rowaddr", pa.uint64())
-                    ).append(pa.field("_fragid", pa.uint64()))
+            if metadata_accepts_schema:
+                assert block_schema is not None
                 metadata = BlockMetadata(
                     num_rows=num_rows,
                     schema=block_schema,  # type: ignore[call-arg]

--- a/lance_ray/datasource.py
+++ b/lance_ray/datasource.py
@@ -34,6 +34,12 @@ LANCE_SOURCE_ID_MARKER = ";lance_ray_source_id="
 def normalize_dataset_uri(uri: str) -> str:
     """Return a comparable URI for dataset identity checks."""
     if "://" in uri:
+        parsed = urlsplit(uri)
+        if parsed.scheme == "file":
+            path = unquote(parsed.path)
+            if parsed.netloc and parsed.netloc != "localhost":
+                path = f"//{parsed.netloc}{path}"
+            return os.path.realpath(os.path.abspath(path)).rstrip(os.sep)
         return uri.rstrip("/")
     return os.path.realpath(os.path.abspath(uri)).rstrip(os.sep)
 

--- a/lance_ray/datasource.py
+++ b/lance_ray/datasource.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import inspect
 import os
 from collections.abc import Iterator
@@ -60,6 +61,13 @@ def dataset_identity(lance_ds: Any, uri: Optional[str] = None) -> str:
     if uuid_value:
         return f"uuid:{uuid_value}|uri:{normalized_uri}"
     return f"uri:{normalized_uri}"
+
+
+def dataset_identity_digest(lance_ds: Any, uri: Optional[str] = None) -> str:
+    """Return an irreversible digest of the stable dataset identity."""
+    return hashlib.sha256(
+        dataset_identity(lance_ds, uri=uri).encode("utf-8")
+    ).hexdigest()
 
 
 def parse_source_provenance(name: str) -> tuple[int, str] | None:
@@ -181,7 +189,7 @@ class LanceDatasource(Datasource):
         if self._source_version is None:
             self._source_version = dataset.version
         if self._source_identity is None:
-            self._source_identity = dataset_identity(dataset)
+            self._source_identity = dataset_identity_digest(dataset)
 
     @property
     def source_version(self) -> int:

--- a/lance_ray/datasource.py
+++ b/lance_ray/datasource.py
@@ -418,11 +418,11 @@ class LanceDatasource(Datasource):
             num_rows = scanner.count_rows()
 
             fragment_ids = [f.metadata.id for f in fragments]
-            input_files = [
+            input_files: tuple[str, ...] = tuple(
                 data_file.path
                 for fragment in fragments
                 for data_file in fragment.data_files()
-            ]
+            )
 
             # Ray 2.48+ no longer has the schema argument...
             if metadata_accepts_schema:

--- a/lance_ray/datasource.py
+++ b/lance_ray/datasource.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import inspect
+import os
 from collections.abc import Iterator
 from functools import partial
 from typing import TYPE_CHECKING, Any, Optional, cast
+from urllib.parse import quote, unquote
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -16,11 +18,65 @@ from ray.data.datasource.datasource import ReadTask
 from .utils import (
     array_split,
     get_namespace_kwargs,
-    get_or_create_namespace,
+    resolve_namespace_table,
 )
 
 if TYPE_CHECKING:
     import lance
+
+
+# Ray 2.41+ builds each logical Read source name from ``Datasource.get_name()``.
+# Keep provenance there instead of the user-controlled Dataset metrics name.
+LANCE_SOURCE_VERSION_NAME_PREFIX = "LanceDatasource[lance_ray_source_version="
+LANCE_SOURCE_ID_MARKER = ";lance_ray_source_id="
+
+
+def normalize_dataset_uri(uri: str) -> str:
+    """Return a comparable URI for dataset identity checks."""
+    if "://" in uri:
+        return uri.rstrip("/")
+    return os.path.realpath(os.path.abspath(uri)).rstrip(os.sep)
+
+
+def dataset_identity(lance_ds: Any, uri: Optional[str] = None) -> str:
+    """Return a stable identity for an opened Lance dataset.
+
+    Prefer a native dataset UUID when the installed PyLance exposes one, and
+    always include the normalized URI so copied datasets stay distinct.
+    Pass ``uri`` when the caller already resolved a canonical location, such
+    as a namespace table path, so source and target compare the same string.
+    """
+    identity_uri = uri if uri is not None else str(getattr(lance_ds, "uri", "") or "")
+    rust_ds = getattr(lance_ds, "_ds", None)
+    uuid_value: Any = None
+    if rust_ds is not None:
+        raw_uuid = getattr(rust_ds, "uuid", None)
+        uuid_value = raw_uuid() if callable(raw_uuid) else raw_uuid
+        if not identity_uri:
+            rust_uri = getattr(rust_ds, "uri", None)
+            rust_uri = rust_uri() if callable(rust_uri) else rust_uri
+            if rust_uri:
+                identity_uri = str(rust_uri)
+    normalized_uri = normalize_dataset_uri(identity_uri)
+    if uuid_value:
+        return f"uuid:{uuid_value}|uri:{normalized_uri}"
+    return f"uri:{normalized_uri}"
+
+
+def parse_source_provenance(name: str) -> tuple[int, str] | None:
+    """Parse version and dataset identity from a Ray logical source name."""
+    prefix = f"Read{LANCE_SOURCE_VERSION_NAME_PREFIX}"
+    if not name.startswith(prefix) or not name.endswith("]"):
+        return None
+    payload = name[len(prefix) : -1]
+    version_text, separator, identity_text = payload.partition(LANCE_SOURCE_ID_MARKER)
+    if not separator:
+        return None
+    try:
+        version = int(version_text)
+    except ValueError:
+        return None
+    return version, unquote(identity_text)
 
 
 class LanceDatasource(Datasource):
@@ -81,9 +137,6 @@ class LanceDatasource(Datasource):
         self._namespace_impl = namespace_impl
         self._namespace_properties = namespace_properties
 
-        # Construct namespace from impl and properties (cached per worker)
-        self._namespace = get_or_create_namespace(namespace_impl, namespace_properties)
-
         match = []
         match.extend(self.READ_FRAGMENTS_ERRORS_TO_RETRY)
         match.extend(DataContext.get_current().retried_io_errors)
@@ -98,6 +151,8 @@ class LanceDatasource(Datasource):
 
         self._lance_ds: Optional[lance.LanceDataset] = None
         self._fragments: Optional[list[lance.LanceFragment]] = None
+        self._source_version: Optional[int] = None
+        self._source_identity: Optional[str] = None
 
     @property
     def lance_dataset(self) -> lance.LanceDataset:
@@ -121,6 +176,53 @@ class LanceDatasource(Datasource):
                 **base_store_params_kwargs,
             )
         return self._lance_ds
+
+    def _pin_source_provenance(self) -> None:
+        dataset = self.lance_dataset
+        if self._source_version is None:
+            self._source_version = dataset.version
+        if self._source_identity is None:
+            resolved_uri: Optional[str]
+            try:
+                resolved_uri, _ = resolve_namespace_table(
+                    self._uri,
+                    dict(self._storage_options or {}),
+                    self._namespace_impl,
+                    self._namespace_properties,
+                    self._table_id,
+                )
+            except ValueError:
+                resolved_uri = None
+            self._source_identity = dataset_identity(dataset, uri=resolved_uri)
+
+    @property
+    def source_version(self) -> int:
+        """Return the Lance version fixed when this datasource is first used."""
+        if self._source_version is None:
+            self._pin_source_provenance()
+        version = self._source_version
+        assert version is not None
+        return version
+
+    @property
+    def source_identity(self) -> str:
+        """Return the dataset identity fixed when this datasource is first used."""
+        if self._source_identity is None:
+            self._pin_source_provenance()
+        identity = self._source_identity
+        assert identity is not None
+        return identity
+
+    def pin_source_version(self) -> None:
+        """Resolve the source snapshot before Ray starts lazy execution."""
+        self._pin_source_provenance()
+
+    def get_name(self) -> str:
+        """Return a logical source name carrying immutable snapshot provenance."""
+        return (
+            f"{LANCE_SOURCE_VERSION_NAME_PREFIX}{self.source_version}"
+            f"{LANCE_SOURCE_ID_MARKER}{quote(self.source_identity, safe='')}]"
+        )
 
     @property
     def fragments(self) -> list[lance.LanceFragment]:
@@ -162,7 +264,7 @@ class LanceDatasource(Datasource):
         # because namespace objects are not serializable. Workers will reconstruct
         # the namespace and provider using these serializable parameters.
         dataset_uri = self.lance_dataset.uri
-        dataset_version = self.lance_dataset.version
+        dataset_version = self.source_version
         dataset_storage_options = self._get_storage_options()
         serialized_manifest = self._get_serialized_manifest()
         namespace_impl = self._namespace_impl
@@ -192,9 +294,14 @@ class LanceDatasource(Datasource):
             # Ray 2.48+ no longer has the schema argument...
             if "schema" in inspect.signature(BlockMetadata.__init__).parameters:
                 # TODO(chengsu): Take column projection into consideration for schema.
+                block_schema = fragments[0].schema
+                if self._with_metadata:
+                    block_schema = block_schema.append(
+                        pa.field("_rowaddr", pa.uint64())
+                    ).append(pa.field("_fragid", pa.uint64()))
                 metadata = BlockMetadata(
                     num_rows=num_rows,
-                    schema=fragments[0].schema,  # type: ignore[call-arg]
+                    schema=block_schema,  # type: ignore[call-arg]
                     input_files=input_files,
                     size_bytes=None,
                     exec_stats=None,

--- a/lance_ray/datasource.py
+++ b/lance_ray/datasource.py
@@ -18,7 +18,6 @@ from ray.data.datasource.datasource import ReadTask
 from .utils import (
     array_split,
     get_namespace_kwargs,
-    resolve_namespace_table,
 )
 
 if TYPE_CHECKING:
@@ -182,18 +181,7 @@ class LanceDatasource(Datasource):
         if self._source_version is None:
             self._source_version = dataset.version
         if self._source_identity is None:
-            resolved_uri: Optional[str]
-            try:
-                resolved_uri, _ = resolve_namespace_table(
-                    self._uri,
-                    dict(self._storage_options or {}),
-                    self._namespace_impl,
-                    self._namespace_properties,
-                    self._table_id,
-                )
-            except ValueError:
-                resolved_uri = None
-            self._source_identity = dataset_identity(dataset, uri=resolved_uri)
+            self._source_identity = dataset_identity(dataset)
 
     @property
     def source_version(self) -> int:

--- a/lance_ray/datasource.py
+++ b/lance_ray/datasource.py
@@ -6,7 +6,7 @@ import os
 from collections.abc import Iterator
 from functools import partial
 from typing import TYPE_CHECKING, Any, Optional, cast
-from urllib.parse import quote, unquote
+from urllib.parse import quote, unquote, urlsplit, urlunsplit
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -38,7 +38,56 @@ def normalize_dataset_uri(uri: str) -> str:
     return os.path.realpath(os.path.abspath(uri)).rstrip(os.sep)
 
 
-def dataset_identity(lance_ds: Any, uri: Optional[str] = None) -> str:
+def _non_sensitive_backend_identity(
+    storage_options: Optional[dict[str, Any]],
+) -> Optional[str]:
+    """Return a stable, non-secret backend discriminator when one is available."""
+    if not storage_options:
+        return None
+
+    for key in ("endpoint", "endpoint_url"):
+        value = storage_options.get(key)
+        if not value:
+            continue
+        value = str(value)
+        if "://" in value:
+            parsed = urlsplit(value)
+            value = urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", ""))
+        return f"{key}:{value}"
+
+    region = storage_options.get("region")
+    if region:
+        return f"region:{region}"
+    return None
+
+
+def _dataset_uuid(lance_ds: Any) -> Any:
+    rust_ds = getattr(lance_ds, "_ds", None)
+    if rust_ds is None:
+        return None
+    raw_uuid = getattr(rust_ds, "uuid", None)
+    return raw_uuid() if callable(raw_uuid) else raw_uuid
+
+
+def _has_reliable_identity(
+    lance_ds: Any,
+    storage_options: Optional[dict[str, Any]],
+) -> bool:
+    if _dataset_uuid(lance_ds) is not None:
+        return True
+    if _non_sensitive_backend_identity(storage_options) is not None:
+        return True
+
+    identity_uri = str(getattr(lance_ds, "uri", "") or "")
+    scheme = urlsplit(identity_uri).scheme.lower()
+    return scheme in {"", "file"}
+
+
+def dataset_identity(
+    lance_ds: Any,
+    uri: Optional[str] = None,
+    storage_options: Optional[dict[str, Any]] = None,
+) -> str:
     """Return a stable identity for an opened Lance dataset.
 
     Prefer a native dataset UUID when the installed PyLance exposes one, and
@@ -47,30 +96,41 @@ def dataset_identity(lance_ds: Any, uri: Optional[str] = None) -> str:
     as a namespace table path, so source and target compare the same string.
     """
     identity_uri = uri if uri is not None else str(getattr(lance_ds, "uri", "") or "")
-    rust_ds = getattr(lance_ds, "_ds", None)
-    uuid_value: Any = None
-    if rust_ds is not None:
-        raw_uuid = getattr(rust_ds, "uuid", None)
-        uuid_value = raw_uuid() if callable(raw_uuid) else raw_uuid
+    uuid_value = _dataset_uuid(lance_ds)
+    if uuid_value is None:
+        rust_ds = getattr(lance_ds, "_ds", None)
         if not identity_uri:
             rust_uri = getattr(rust_ds, "uri", None)
             rust_uri = rust_uri() if callable(rust_uri) else rust_uri
             if rust_uri:
                 identity_uri = str(rust_uri)
     normalized_uri = normalize_dataset_uri(identity_uri)
+    identity_parts = []
     if uuid_value:
-        return f"uuid:{uuid_value}|uri:{normalized_uri}"
-    return f"uri:{normalized_uri}"
+        identity_parts.append(f"uuid:{uuid_value}")
+    identity_parts.append(f"uri:{normalized_uri}")
+    backend = _non_sensitive_backend_identity(storage_options)
+    if backend is not None:
+        identity_parts.append(f"backend:{backend}")
+    return "|".join(identity_parts)
 
 
-def dataset_identity_digest(lance_ds: Any, uri: Optional[str] = None) -> str:
+def dataset_identity_digest(
+    lance_ds: Any,
+    uri: Optional[str] = None,
+    storage_options: Optional[dict[str, Any]] = None,
+) -> Optional[str]:
     """Return an irreversible digest of the stable dataset identity."""
+    if not _has_reliable_identity(lance_ds, storage_options):
+        return None
     return hashlib.sha256(
-        dataset_identity(lance_ds, uri=uri).encode("utf-8")
+        dataset_identity(lance_ds, uri=uri, storage_options=storage_options).encode(
+            "utf-8"
+        )
     ).hexdigest()
 
 
-def parse_source_provenance(name: str) -> tuple[int, str] | None:
+def parse_source_provenance(name: str) -> tuple[int, Optional[str]] | None:
     """Parse version and dataset identity from a Ray logical source name."""
     prefix = f"Read{LANCE_SOURCE_VERSION_NAME_PREFIX}"
     if not name.startswith(prefix) or not name.endswith("]"):
@@ -83,7 +143,10 @@ def parse_source_provenance(name: str) -> tuple[int, str] | None:
         version = int(version_text)
     except ValueError:
         return None
-    return version, unquote(identity_text)
+    identity = unquote(identity_text)
+    if identity == "unavailable":
+        return version, None
+    return version, identity
 
 
 class LanceDatasource(Datasource):
@@ -189,7 +252,10 @@ class LanceDatasource(Datasource):
         if self._source_version is None:
             self._source_version = dataset.version
         if self._source_identity is None:
-            self._source_identity = dataset_identity_digest(dataset)
+            self._source_identity = dataset_identity_digest(
+                dataset,
+                storage_options=self._storage_options,
+            )
 
     @property
     def source_version(self) -> int:
@@ -201,13 +267,11 @@ class LanceDatasource(Datasource):
         return version
 
     @property
-    def source_identity(self) -> str:
+    def source_identity(self) -> Optional[str]:
         """Return the dataset identity fixed when this datasource is first used."""
         if self._source_identity is None:
             self._pin_source_provenance()
-        identity = self._source_identity
-        assert identity is not None
-        return identity
+        return self._source_identity
 
     def pin_source_version(self) -> None:
         """Resolve the source snapshot before Ray starts lazy execution."""
@@ -215,9 +279,11 @@ class LanceDatasource(Datasource):
 
     def get_name(self) -> str:
         """Return a logical source name carrying immutable snapshot provenance."""
+        identity = self.source_identity
+        identity_text = "unavailable" if identity is None else quote(identity, safe="")
         return (
             f"{LANCE_SOURCE_VERSION_NAME_PREFIX}{self.source_version}"
-            f"{LANCE_SOURCE_ID_MARKER}{quote(self.source_identity, safe='')}]"
+            f"{LANCE_SOURCE_ID_MARKER}{identity_text}]"
         )
 
     @property

--- a/lance_ray/io.py
+++ b/lance_ray/io.py
@@ -195,7 +195,7 @@ def read_lance(
 
 def _source_provenance_from_dataset_lineage(
     ds: Dataset,
-) -> tuple[int, str] | None:
+) -> tuple[int, Optional[str]] | None:
     """Return unique Lance version and identity when every logical source is Lance."""
     logical_plan = cast(_DatasetWithLogicalPlan, ds)._logical_plan
     sources = logical_plan.sources()
@@ -203,7 +203,7 @@ def _source_provenance_from_dataset_lineage(
         return None
 
     source_versions: set[int] = set()
-    source_identities: set[str] = set()
+    source_identities: set[Optional[str]] = set()
     for source in sources:
         provenance = parse_source_provenance(source.name)
         if provenance is None:
@@ -1562,6 +1562,7 @@ def update_columns_from(
     source_provenance = _source_provenance_from_dataset_lineage(ds)
     source_version = None if source_provenance is None else source_provenance[0]
     source_identity = None if source_provenance is None else source_provenance[1]
+    read_version_was_explicit = read_version is not None
     if read_version is None and source_version is not None:
         read_version = source_version
 
@@ -1626,7 +1627,15 @@ def update_columns_from(
         **namespace_kwargs,
     )
     if source_identity is not None:
-        target_identity = dataset_identity_digest(lance_ds, uri=uri)
+        target_identity = dataset_identity_digest(
+            lance_ds,
+            uri=uri,
+            storage_options=storage_options,
+        )
+        if target_identity is None:
+            raise ValueError(
+                "Target dataset identity could not be reliably determined."
+            )
         if source_identity != target_identity:
             raise ValueError(
                 "Input Dataset was read from a different Lance dataset "
@@ -1694,6 +1703,16 @@ def update_columns_from(
         raise ValueError(
             "'read_version' is required because the source Lance version "
             "is unavailable from the Ray Dataset's logical lineage."
+        )
+    if (
+        source_version is not None
+        and source_identity is None
+        and not read_version_was_explicit
+    ):
+        raise ValueError(
+            "A reliable dataset identity is unavailable from the Ray Dataset's "
+            "logical lineage. Pass 'read_version' explicitly to update the "
+            "target dataset."
         )
 
     update_tasks = [

--- a/lance_ray/io.py
+++ b/lance_ray/io.py
@@ -1326,8 +1326,8 @@ def _update_fragment_with_refs(
         db_path = os.path.join(temp_dir, "rowaddrs.sqlite")
         connection = sqlite3.connect(db_path)
         try:
-            # Keep SQLite's page cache and temporary index on disk so duplicate
-            # detection does not reintroduce a fragment-sized memory bound.
+            # Bound SQLite's page cache per worker; aggregate memory still scales
+            # with concurrent fragment update tasks.
             connection.execute("PRAGMA journal_mode=OFF")
             connection.execute("PRAGMA synchronous=OFF")
             connection.execute("PRAGMA temp_store=FILE")
@@ -1378,14 +1378,16 @@ def _update_fragment_with_refs(
                     connection.commit()
 
             connection.execute("CREATE INDEX rowaddrs_value_idx ON rowaddrs (value)")
-            duplicate = connection.execute(
-                "SELECT value FROM rowaddrs GROUP BY value HAVING COUNT(*) > 1 LIMIT 1"
-            ).fetchone()
-            if duplicate is not None:
-                duplicate_rowaddr = int.from_bytes(duplicate[0], "big")
+            duplicates = connection.execute(
+                "SELECT value FROM rowaddrs GROUP BY value HAVING COUNT(*) > 1"
+            ).fetchall()
+            if duplicates:
+                duplicate_rowaddrs = [
+                    int.from_bytes(row[0], "big") for row in duplicates
+                ]
                 raise ValueError(
                     f"Duplicate _rowaddr values in fragment {frag_id}: "
-                    f"[{duplicate_rowaddr}]"
+                    f"{duplicate_rowaddrs}"
                 )
         finally:
             connection.close()
@@ -1565,6 +1567,11 @@ def update_columns_from(
     source_provenance = _source_provenance_from_dataset_lineage(ds)
     source_version = None if source_provenance is None else source_provenance[0]
     source_identity = None if source_provenance is None else source_provenance[1]
+    if read_version is None and source_provenance is None:
+        raise ValueError(
+            "'read_version' is required because the source Lance version "
+            "is unavailable from the Ray Dataset's logical lineage."
+        )
     read_version_was_explicit = read_version is not None
     if read_version is None and source_version is not None:
         read_version = source_version
@@ -1702,11 +1709,6 @@ def update_columns_from(
             "No rows to update; update_columns_from completed without changes."
         )
         return
-    if read_version is None:
-        raise ValueError(
-            "'read_version' is required because the source Lance version "
-            "is unavailable from the Ray Dataset's logical lineage."
-        )
     if (
         source_version is not None
         and source_identity is None

--- a/lance_ray/io.py
+++ b/lance_ray/io.py
@@ -1433,10 +1433,16 @@ def update_columns_from(
 
         return table.append_column("_fragid", derived_fragids)
 
-    normalized_ds = ds.map_batches(
+    normalized_ds = ds.select_columns(projected_columns).map_batches(
         _validate_and_derive_fragid,
         batch_format="pyarrow",
     )
+
+    if read_version is None:
+        raise ValueError(
+            "'read_version' is required because the source Lance version "
+            "is unavailable from the Ray Dataset's logical lineage."
+        )
 
     lance_ds = LanceDataset(
         uri=uri,
@@ -1487,13 +1493,7 @@ def update_columns_from(
             "No rows to update; update_columns_from completed without changes."
         )
         return
-    if read_version is None:
-        raise ValueError(
-            "'read_version' is required because the source Lance version "
-            "is unavailable from the Ray Dataset's logical lineage."
-        )
-
-    ds = normalized_ds.select_columns(projected_columns)
+    ds = normalized_ds
 
     _uri = uri
     _storage_options = storage_options

--- a/lance_ray/io.py
+++ b/lance_ray/io.py
@@ -32,7 +32,7 @@ from ray.util.multiprocessing import Pool
 from .datasink import LanceDatasink
 from .datasource import (
     LanceDatasource,
-    dataset_identity,
+    dataset_identity_digest,
     parse_source_provenance,
 )
 from .fragment import prepare_fragment_write_options
@@ -1626,7 +1626,7 @@ def update_columns_from(
         **namespace_kwargs,
     )
     if source_identity is not None:
-        target_identity = dataset_identity(lance_ds, uri=uri)
+        target_identity = dataset_identity_digest(lance_ds, uri=uri)
         if source_identity != target_identity:
             raise ValueError(
                 "Input Dataset was read from a different Lance dataset "

--- a/lance_ray/io.py
+++ b/lance_ray/io.py
@@ -1465,8 +1465,11 @@ def update_columns_from(
         read_version: Dataset version to update. Defaults to the unique Lance
             source version retained in the Ray Dataset's logical lineage. It is
             required when that lineage is unavailable, such as after
-            materializing the source. When lineage is present, the source
-            dataset identity must match the update target.
+            materializing the source. An explicit version identifies the target
+            version but does not prove the source rows came from that dataset;
+            the caller must ensure source provenance when lineage is lost. When
+            lineage is present, the source dataset identity must match the
+            update target.
         ray_remote_args: Options passed to the Ray partition and fragment-update tasks.
         storage_options: Storage options used to open the dataset.
         namespace_impl: Namespace implementation type, such as ``"dir"`` or

--- a/lance_ray/io.py
+++ b/lance_ray/io.py
@@ -2,9 +2,10 @@
 I/O operations for Lance-Ray integration.
 """
 
+import logging
 import pickle
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Literal, Optional, cast
+from typing import TYPE_CHECKING, Any, Literal, Optional, Protocol, cast
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -12,10 +13,15 @@ import ray
 from lance.dataset import LanceDataset, LanceOperation
 from lance.udf import BatchUDF
 from ray.data import Dataset, read_datasource
+from ray.data.block import DataBatch
 from ray.util.multiprocessing import Pool
 
 from .datasink import LanceDatasink
-from .datasource import LanceDatasource
+from .datasource import (
+    LanceDatasource,
+    dataset_identity,
+    parse_source_provenance,
+)
 from .fragment import prepare_fragment_write_options
 from .utils import (
     get_namespace_kwargs,
@@ -25,6 +31,22 @@ from .utils import (
     resolve_namespace_table,
     validate_uri_or_namespace,
 )
+
+logger = logging.getLogger(__name__)
+
+
+class _LogicalSource(Protocol):
+    @property
+    def name(self) -> str: ...
+
+
+class _LogicalPlanWithSources(Protocol):
+    def sources(self) -> list[_LogicalSource]: ...
+
+
+class _DatasetWithLogicalPlan(Protocol):
+    _logical_plan: _LogicalPlanWithSources
+
 
 if TYPE_CHECKING:
     from lance.types import ReaderLike
@@ -122,7 +144,8 @@ def read_lance(
         with_metadata: If True, include ``_rowaddr`` and ``_fragid`` columns in the
             output. ``_rowaddr`` is a ``UInt64`` encoding ``(fragment_id << 32) |
             row_offset``. ``_fragid`` is the fragment ID derived from ``_rowaddr``.
-            These columns are needed for :func:`add_columns_from`. Default is False.
+            These columns are needed for :func:`add_columns_from` and
+            :func:`update_columns_from`. Default is False.
 
     Returns:
         A :class:`~ray.data.Dataset` producing records read from the Lance dataset.
@@ -144,7 +167,8 @@ def read_lance(
         with_metadata=with_metadata,
     )
 
-    return cast(
+    datasource.pin_source_version()
+    dataset = cast(
         Dataset,
         read_datasource(
             datasource=datasource,
@@ -153,6 +177,39 @@ def read_lance(
             override_num_blocks=override_num_blocks,
         ),
     )
+    return dataset
+
+
+def _source_provenance_from_dataset_lineage(
+    ds: Dataset,
+) -> tuple[int, str] | None:
+    """Return unique Lance version and identity when every logical source is Lance."""
+    logical_plan = cast(_DatasetWithLogicalPlan, ds)._logical_plan
+    sources = logical_plan.sources()
+    if not sources:
+        return None
+
+    source_versions: set[int] = set()
+    source_identities: set[str] = set()
+    for source in sources:
+        provenance = parse_source_provenance(source.name)
+        if provenance is None:
+            return None
+        version, identity = provenance
+        source_versions.add(version)
+        source_identities.add(identity)
+
+    if len(source_identities) > 1:
+        raise ValueError(
+            "Input Dataset combines multiple Lance source datasets. "
+            "Use rows from one source dataset."
+        )
+    if len(source_versions) > 1:
+        raise ValueError(
+            "Input Dataset combines multiple Lance source versions: "
+            f"{sorted(source_versions)}. Use rows from one source version."
+        )
+    return next(iter(source_versions)), next(iter(source_identities))
 
 
 def write_lance(
@@ -1175,6 +1232,418 @@ def merge_columns_from(
         storage_options=storage_options,
         namespace_kwargs=namespace_kwargs,
         original_fragments=fragments_in_lance,
+    )
+
+
+def update_columns_from(
+    uri: Optional[str] = None,
+    ds: Optional[Dataset] = None,
+    *,
+    columns: list[str],
+    read_version: Optional[int | str] = None,
+    ray_remote_args: Optional[dict[str, Any]] = None,
+    storage_options: Optional[dict[str, Any]] = None,
+    namespace_impl: Optional[str] = None,
+    namespace_properties: Optional[dict[str, str]] = None,
+    table_id: Optional[list[str]] = None,
+    batch_size: int = 1024,
+) -> None:
+    """Update existing columns in a Lance dataset using row metadata.
+
+    Unlike :func:`merge_columns_from`, which adds new columns, this function
+    updates existing columns by matching ``_rowaddr`` inside each fragment.
+    The source Ray Dataset must contain ``_rowaddr`` and every column listed
+    in ``columns``. If ``_fragid`` is absent, it is derived from ``_rowaddr``.
+    If supplied, ``_fragid`` must match the fragment encoded in ``_rowaddr``.
+    Row addresses must be non-null, unique integer values and are normalized
+    to ``uint64``. Update column names must be unique and their Arrow types
+    must match the target columns.
+    Unmatched source rows are ignored. Before grouping, the source is projected
+    to ``_rowaddr``, ``_fragid``, and the requested update columns. The final
+    operation is committed once; commit conflicts are returned to the caller
+    without retrying stale work. When source lineage is present, the source
+    dataset identity must match the update target.
+
+    Examples:
+        >>> import lance_ray as lr
+        >>> source = lr.read_lance("/tmp/data/", with_metadata=True)
+        >>> source = source.map_batches(modify_status)  # preserve metadata
+        >>> lr.update_columns_from(
+        ...     "/tmp/data/",
+        ...     source,
+        ...     columns=["status"],
+        ... )
+
+    Args:
+        uri: Path to the Lance dataset. If omitted, provide ``namespace_impl``
+            and ``table_id`` to resolve the location from the namespace.
+        ds: Ray Dataset containing ``_rowaddr`` and the columns to update.
+            ``_fragid`` is derived from ``_rowaddr`` when absent and validated
+            against it when supplied.
+        columns: Existing columns to update. Metadata columns cannot be used.
+        read_version: Dataset version to update. Defaults to the unique Lance
+            source version retained in the Ray Dataset's logical lineage. It is
+            required when that lineage is unavailable, such as after
+            materializing the source. When lineage is present, the source
+            dataset identity must match the update target.
+        ray_remote_args: Options passed to Ray Data ``map_groups``.
+        storage_options: Storage options used to open the dataset.
+        namespace_impl: Namespace implementation type, such as ``"dir"`` or
+            ``"rest"``.
+        namespace_properties: Namespace connection properties.
+        table_id: Table identifier used with namespace parameters.
+        batch_size: Batch size for the update reader. Must be positive.
+    """
+    if ds is None:
+        raise ValueError("'ds' must be provided")
+    if not columns:
+        raise ValueError("'columns' must be non-empty")
+    if batch_size <= 0:
+        raise ValueError("'batch_size' must be positive")
+
+    seen_columns: set[str] = set()
+    duplicate_columns: set[str] = set()
+    for column in columns:
+        if column in seen_columns:
+            duplicate_columns.add(column)
+        else:
+            seen_columns.add(column)
+    if duplicate_columns:
+        raise ValueError(
+            f"Duplicate columns are not allowed: {sorted(duplicate_columns)}"
+        )
+
+    metadata_columns = {"_rowaddr", "_fragid", "_rowid"}
+    invalid_columns = [column for column in columns if column in metadata_columns]
+    if invalid_columns:
+        raise ValueError(
+            f"Metadata columns cannot be updated: {sorted(invalid_columns)}"
+        )
+
+    validate_uri_or_namespace(uri, namespace_impl, table_id)
+
+    uri, storage_options = resolve_namespace_table(
+        uri,
+        storage_options,
+        namespace_impl,
+        namespace_properties,
+        table_id,
+    )
+    namespace_kwargs = get_namespace_kwargs(
+        namespace_impl, namespace_properties, table_id
+    )
+
+    if not ds.take(1):
+        logger.warning(
+            "No rows to update; update_columns_from completed without changes."
+        )
+        return
+
+    ray_schema = ds.schema()
+    if ray_schema is None:
+        logger.warning(
+            "No rows to update; update_columns_from completed without changes."
+        )
+        return
+    if "_rowaddr" not in ray_schema.names:
+        raise ValueError(
+            "Input Dataset must contain '_rowaddr'. "
+            "Use read_lance(uri, with_metadata=True) to include row metadata."
+        )
+
+    source_types = dict(zip(ray_schema.names, ray_schema.types, strict=True))
+    rowaddr_type = source_types["_rowaddr"]
+    if not (
+        isinstance(rowaddr_type, pa.DataType) and pa.types.is_integer(rowaddr_type)
+    ):
+        raise ValueError(
+            "Input Dataset '_rowaddr' must have an integer type, "
+            f"but found {rowaddr_type}."
+        )
+
+    has_fragid = "_fragid" in ray_schema.names
+    if has_fragid:
+        fragid_type = source_types["_fragid"]
+        if not (
+            isinstance(fragid_type, pa.DataType) and pa.types.is_integer(fragid_type)
+        ):
+            raise ValueError(
+                "Input Dataset '_fragid' must have an integer type, "
+                f"but found {fragid_type}."
+            )
+
+    source_names = set(ray_schema.names)
+    missing_columns = [column for column in columns if column not in source_names]
+    if missing_columns:
+        raise ValueError(
+            f"Input Dataset is missing requested update columns: {missing_columns}"
+        )
+
+    projected_columns = ["_rowaddr"]
+    if has_fragid:
+        projected_columns.append("_fragid")
+    projected_columns.extend(columns)
+    ds = ds.select_columns(projected_columns)
+
+    def _validate_and_derive_fragid(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        rowaddrs = table.column("_rowaddr")
+        if rowaddrs.null_count:
+            raise ValueError(
+                "Null _rowaddr values are not allowed before fragment routing."
+            )
+
+        if rowaddrs.type != pa.uint64():
+            rowaddrs = pc.cast(rowaddrs, pa.uint64())
+            table = table.set_column(
+                table.schema.get_field_index("_rowaddr"),
+                "_rowaddr",
+                rowaddrs,
+            )
+
+        derived_fragids = pc.cast(pc.shift_right(rowaddrs, 32), pa.uint64())
+        if has_fragid:
+            fragids = table.column("_fragid")
+            if fragids.null_count:
+                raise ValueError("Null _fragid values are not allowed.")
+
+            if fragids.type != pa.uint64():
+                fragids = pc.cast(fragids, pa.uint64())
+                table = table.set_column(
+                    table.schema.get_field_index("_fragid"),
+                    "_fragid",
+                    fragids,
+                )
+
+            mismatch_mask = pc.not_equal(fragids, derived_fragids)
+            if pc.any(mismatch_mask).as_py():
+                mismatch_index = int(pc.indices_nonzero(mismatch_mask)[0].as_py())
+                rowaddr = rowaddrs[mismatch_index].as_py()
+                fragid = fragids[mismatch_index].as_py()
+                expected_fragid = derived_fragids[mismatch_index].as_py()
+                raise ValueError(
+                    f"_fragid {fragid} does not match _rowaddr {rowaddr}; "
+                    f"expected fragment id {expected_fragid}."
+                )
+
+            return table.set_column(
+                table.schema.get_field_index("_fragid"),
+                "_fragid",
+                derived_fragids,
+            )
+
+        return table.append_column("_fragid", derived_fragids)
+
+    ds = ds.map_batches(
+        _validate_and_derive_fragid,
+        batch_format="pyarrow",
+    )
+    ray_schema = ds.schema()
+    if ray_schema is None:
+        logger.warning(
+            "No rows to update; update_columns_from completed without changes."
+        )
+        return
+
+    source_provenance = _source_provenance_from_dataset_lineage(ds)
+    source_version = None if source_provenance is None else source_provenance[0]
+    source_identity = None if source_provenance is None else source_provenance[1]
+    if read_version is None:
+        if source_version is None:
+            raise ValueError(
+                "'read_version' is required because the source Lance version "
+                "is unavailable from the Ray Dataset's logical lineage."
+            )
+        read_version = source_version
+
+    lance_ds = LanceDataset(
+        uri=uri,
+        storage_options=storage_options,
+        version=read_version,
+        **namespace_kwargs,
+    )
+    if source_identity is not None:
+        target_identity = dataset_identity(lance_ds, uri=uri)
+        if source_identity != target_identity:
+            raise ValueError(
+                "Input Dataset was read from a different Lance dataset "
+                "than the update target."
+            )
+    resolved_read_version = lance_ds.version
+    if source_version is not None and resolved_read_version != source_version:
+        raise ValueError(
+            "Source Dataset was read from Lance version "
+            f"{source_version}, but update requested version "
+            f"{resolved_read_version}."
+        )
+
+    unavailable_columns = [
+        column for column in columns if column not in lance_ds.schema.names
+    ]
+    if unavailable_columns:
+        raise ValueError(
+            f"Columns do not exist in target Lance dataset: {unavailable_columns}"
+        )
+
+    source_types = dict(zip(ray_schema.names, ray_schema.types, strict=True))
+    target_types = {column: lance_ds.schema.field(column).type for column in columns}
+    type_mismatches: list[str] = []
+    for column in columns:
+        source_type = source_types[column]
+        target_type = target_types[column]
+        if isinstance(source_type, pa.DataType) and source_type != target_type:
+            type_mismatches.append(
+                f"{column}: source {source_type}, target {target_type}"
+            )
+    if type_mismatches:
+        raise ValueError("Update column type mismatch: " + "; ".join(type_mismatches))
+
+    fragments_in_lance = {f.metadata.id for f in lance_ds.get_fragments()}
+
+    _uri = uri
+    _storage_options = storage_options
+    _namespace_impl = namespace_impl
+    _namespace_properties = namespace_properties
+    _table_id = table_id
+    _read_version = resolved_read_version
+    _columns = list(columns)
+    _target_types = target_types
+    _batch_size = batch_size
+
+    def _update_one_fragment(batch: DataBatch) -> pa.Table:
+        group = cast(pa.Table, batch)
+        if group.num_rows == 0:
+            return pa.table(
+                {
+                    "frag_id": pa.array([], type=pa.int64()),
+                    "fragment_meta": pa.array([], type=pa.binary()),
+                    "fields_modified": pa.array([], type=pa.binary()),
+                }
+            )
+
+        worker_type_mismatches: list[str] = []
+        for column in _columns:
+            source_type = group.schema.field(column).type
+            target_type = _target_types[column]
+            if source_type != target_type:
+                worker_type_mismatches.append(
+                    f"{column}: source {source_type}, target {target_type}"
+                )
+        if worker_type_mismatches:
+            raise ValueError(
+                "Update column type mismatch: " + "; ".join(worker_type_mismatches)
+            )
+
+        frag_id = int(group.column("_fragid")[0].as_py())
+        rowaddrs = group.column("_rowaddr")
+        if rowaddrs.null_count:
+            raise ValueError(
+                f"Null _rowaddr values are not allowed in fragment {frag_id}."
+            )
+
+        order = pc.sort_indices(group, sort_keys=[("_rowaddr", "ascending")])
+        sorted_group = group.take(order)
+        sorted_rowaddrs = sorted_group.column("_rowaddr").combine_chunks()
+        if len(sorted_rowaddrs) > 1:
+            duplicate_mask = pc.equal(
+                sorted_rowaddrs.slice(1),
+                sorted_rowaddrs.slice(0, len(sorted_rowaddrs) - 1),
+            )
+            duplicate_rowaddrs = pc.unique(
+                pc.filter(sorted_rowaddrs.slice(1), duplicate_mask)
+            ).to_pylist()
+            if duplicate_rowaddrs:
+                raise ValueError(
+                    f"Duplicate _rowaddr values in fragment {frag_id}: "
+                    f"{duplicate_rowaddrs}"
+                )
+
+        update_table = sorted_group.select(["_rowaddr", *_columns]).combine_chunks()
+
+        local_ns_kwargs = get_namespace_kwargs(
+            _namespace_impl, _namespace_properties, _table_id
+        )
+        local_ds = LanceDataset(
+            uri=_uri,
+            storage_options=_storage_options,
+            version=_read_version,
+            **local_ns_kwargs,
+        )
+        fragment = local_ds.get_fragment(frag_id)
+        if fragment is None:
+            raise ValueError(f"Fragment {frag_id} not found in Lance dataset at {_uri}")
+
+        reader = pa.RecordBatchReader.from_batches(
+            update_table.schema,
+            update_table.to_batches(max_chunksize=_batch_size),
+        )
+        fragment_meta, fields_modified = fragment.update_columns(
+            reader,
+            left_on="_rowaddr",
+            right_on="_rowaddr",
+        )
+
+        return pa.table(
+            {
+                "frag_id": pa.array([frag_id], type=pa.int64()),
+                "fragment_meta": pa.array(
+                    [pickle.dumps(fragment_meta)], type=pa.binary()
+                ),
+                "fields_modified": pa.array(
+                    [pickle.dumps(fields_modified)], type=pa.binary()
+                ),
+            }
+        )
+
+    map_groups_kwargs: dict[str, Any] = {}
+    if ray_remote_args:
+        map_groups_kwargs.update(ray_remote_args)
+
+    result_ds = ds.groupby("_fragid").map_groups(
+        _update_one_fragment,
+        batch_format="pyarrow",
+        **map_groups_kwargs,
+    )
+
+    rows = result_ds.take_all()
+    if not rows:
+        logger.warning(
+            "No rows to update; update_columns_from completed without changes."
+        )
+        return
+
+    updated_fragments = []
+    all_fields_modified: set[int] = set()
+    seen_frag_ids: set[int] = set()
+
+    for row in rows:
+        frag_id = int(row["frag_id"])
+        if frag_id not in fragments_in_lance:
+            raise ValueError(
+                f"_fragid {frag_id} from input Dataset is not present in the "
+                f"Lance dataset at {uri}"
+            )
+        if frag_id in seen_frag_ids:
+            raise ValueError(
+                f"Duplicate _fragid {frag_id} encountered in map_groups output"
+            )
+        seen_frag_ids.add(frag_id)
+
+        fragment_meta = pickle.loads(row["fragment_meta"])
+        fields_modified = pickle.loads(row["fields_modified"])
+        updated_fragments.append(fragment_meta)
+        all_fields_modified.update(fields_modified)
+
+    op = LanceOperation.Update(
+        updated_fragments=updated_fragments,
+        fields_modified=list(all_fields_modified),
+    )
+    LanceDataset.commit(
+        uri,
+        op,
+        read_version=resolved_read_version,
+        storage_options=storage_options,
+        **namespace_kwargs,
     )
 
 

--- a/lance_ray/io.py
+++ b/lance_ray/io.py
@@ -1274,15 +1274,18 @@ def _partition_block_by_fragid(
         block,
         sort_keys=[("_fragid", "ascending"), ("_rowaddr", "ascending")],
     )
-    sorted_block = block.take(order)
-    fragids = sorted_block.column("_fragid").to_numpy(zero_copy_only=False)
+    # Materialize only the routing column globally. Taking the full, potentially
+    # wide table here would temporarily duplicate an entire Ray block.
+    fragids = block.column("_fragid").take(order).to_numpy(zero_copy_only=False)
     unique_fragids = np.unique(fragids)
     starts = np.searchsorted(fragids, unique_fragids, side="left")
     ends = np.searchsorted(fragids, unique_fragids, side="right")
 
     partitions: dict[int, ray.ObjectRef[pa.Table]] = {}
     for frag_id, start, end in zip(unique_fragids, starts, ends, strict=True):
-        partition = sorted_block.slice(int(start), int(end) - int(start))
+        start_index = int(start)
+        partition_length = int(end) - start_index
+        partition = block.take(order.slice(start_index, partition_length))
         partitions[int(frag_id)] = cast(
             ray.ObjectRef[pa.Table],
             ray.put(partition),
@@ -1293,7 +1296,7 @@ def _partition_block_by_fragid(
 @ray.remote
 def _update_fragment_with_refs(
     args: _UpdateFragmentArgs,
-) -> tuple[int, bytes, bytes]:
+) -> tuple[bytes, bytes]:
     """Stream one fragment's update rows and return commit metadata."""
     frag_id = args.frag_id
     refs = args.refs
@@ -1375,9 +1378,9 @@ def _update_fragment_with_refs(
                         "INSERT INTO rowaddrs (value) VALUES (?)",
                         [(value,) for value in values],
                     )
-                    connection.commit()
 
             connection.execute("CREATE INDEX rowaddrs_value_idx ON rowaddrs (value)")
+            connection.commit()
             duplicates = connection.execute(
                 "SELECT value FROM rowaddrs GROUP BY value HAVING COUNT(*) > 1"
             ).fetchall()
@@ -1398,6 +1401,9 @@ def _update_fragment_with_refs(
     )
 
     def _update_batches() -> Iterator[pa.RecordBatch]:
+        # This second pass is intentional: validation must finish before Lance
+        # starts writing update files. Retaining every resolved table would trade
+        # the object-store lookup for unbounded per-fragment worker heap usage.
         for ref in refs:
             table = ray.get(ref)
             for batch in table.to_batches(max_chunksize=batch_size):
@@ -1409,11 +1415,7 @@ def _update_fragment_with_refs(
         left_on="_rowaddr",
         right_on="_rowaddr",
     )
-    return (
-        frag_id,
-        pickle.dumps(fragment_meta),
-        pickle.dumps(fields_modified),
-    )
+    return pickle.dumps(fragment_meta), pickle.dumps(fields_modified)
 
 
 def update_columns_from(
@@ -1570,6 +1572,16 @@ def update_columns_from(
     read_version_was_explicit = read_version is not None
     if read_version is None and source_version is not None:
         read_version = source_version
+    if (
+        source_version is not None
+        and source_identity is None
+        and not read_version_was_explicit
+    ):
+        raise ValueError(
+            "A reliable dataset identity is unavailable from the Ray Dataset's "
+            "logical lineage. Pass 'read_version' explicitly to update the "
+            "target dataset."
+        )
 
     def _validate_and_derive_fragid(batch: DataBatch) -> pa.Table:
         table = cast(pa.Table, batch)
@@ -1687,6 +1699,8 @@ def update_columns_from(
     partition_fn = _partition_block_by_fragid.options(**remote_options)
     update_fn = _update_fragment_with_refs.options(**remote_options)
 
+    # This documented DeveloperAPI is available in the minimum supported Ray
+    # version (2.41) and is the zero-copy API for distributed Arrow block refs.
     block_refs = normalized_ds.to_arrow_refs()
     partition_tasks = [partition_fn.remote(block_ref) for block_ref in block_refs]
     partition_results = ray.get(partition_tasks)
@@ -1710,17 +1724,6 @@ def update_columns_from(
             "No rows to update; update_columns_from completed without changes."
         )
         return
-    if (
-        source_version is not None
-        and source_identity is None
-        and not read_version_was_explicit
-    ):
-        raise ValueError(
-            "A reliable dataset identity is unavailable from the Ray Dataset's "
-            "logical lineage. Pass 'read_version' explicitly to update the "
-            "target dataset."
-        )
-
     update_tasks = [
         update_fn.remote(
             _UpdateFragmentArgs(
@@ -1743,20 +1746,8 @@ def update_columns_from(
 
     updated_fragments = []
     all_fields_modified: set[int] = set()
-    seen_frag_ids: set[int] = set()
 
-    for frag_id, fragment_meta_bytes, fields_modified_bytes in results:
-        if frag_id not in fragments_in_lance:
-            raise ValueError(
-                f"_fragid {frag_id} from input Dataset is not present in the "
-                f"Lance dataset at {uri}"
-            )
-        if frag_id in seen_frag_ids:
-            raise ValueError(
-                f"Duplicate _fragid {frag_id} encountered in update output"
-            )
-        seen_frag_ids.add(frag_id)
-
+    for fragment_meta_bytes, fields_modified_bytes in results:
         fragment_meta = pickle.loads(fragment_meta_bytes)
         fields_modified = pickle.loads(fields_modified_bytes)
         updated_fragments.append(fragment_meta)

--- a/lance_ray/io.py
+++ b/lance_ray/io.py
@@ -1567,11 +1567,6 @@ def update_columns_from(
     source_provenance = _source_provenance_from_dataset_lineage(ds)
     source_version = None if source_provenance is None else source_provenance[0]
     source_identity = None if source_provenance is None else source_provenance[1]
-    if read_version is None and source_provenance is None:
-        raise ValueError(
-            "'read_version' is required because the source Lance version "
-            "is unavailable from the Ray Dataset's logical lineage."
-        )
     read_version_was_explicit = read_version is not None
     if read_version is None and source_version is not None:
         read_version = source_version
@@ -1679,6 +1674,12 @@ def update_columns_from(
             )
     if type_mismatches:
         raise ValueError("Update column type mismatch: " + "; ".join(type_mismatches))
+
+    if read_version is None and source_provenance is None:
+        raise ValueError(
+            "'read_version' is required because the source Lance version "
+            "is unavailable from the Ray Dataset's logical lineage."
+        )
 
     fragments_in_lance = {f.metadata.id for f in lance_ds.get_fragments()}
 

--- a/lance_ray/io.py
+++ b/lance_ray/io.py
@@ -1438,12 +1438,6 @@ def update_columns_from(
         batch_format="pyarrow",
     )
 
-    if read_version is None:
-        raise ValueError(
-            "'read_version' is required because the source Lance version "
-            "is unavailable from the Ray Dataset's logical lineage."
-        )
-
     lance_ds = LanceDataset(
         uri=uri,
         storage_options=storage_options,
@@ -1493,6 +1487,11 @@ def update_columns_from(
             "No rows to update; update_columns_from completed without changes."
         )
         return
+    if read_version is None:
+        raise ValueError(
+            "'read_version' is required because the source Lance version "
+            "is unavailable from the Ray Dataset's logical lineage."
+        )
     ds = normalized_ds
 
     _uri = uri

--- a/lance_ray/io.py
+++ b/lance_ray/io.py
@@ -3,10 +3,23 @@ I/O operations for Lance-Ray integration.
 """
 
 import logging
+import os
 import pickle
-from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Literal, Optional, Protocol, cast
+import sqlite3
+import tempfile
+from collections import defaultdict
+from collections.abc import Callable, Iterator
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    NamedTuple,
+    Optional,
+    Protocol,
+    cast,
+)
 
+import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pc
 import ray
@@ -1235,6 +1248,172 @@ def merge_columns_from(
     )
 
 
+class _UpdateFragmentArgs(NamedTuple):
+    frag_id: int
+    refs: list[ray.ObjectRef[pa.Table]]
+    uri: str
+    storage_options: dict[str, Any] | None
+    namespace_impl: str | None
+    namespace_properties: dict[str, str] | None
+    table_id: list[str] | None
+    read_version: int
+    columns: list[str]
+    target_types: dict[str, pa.DataType]
+    batch_size: int
+
+
+@ray.remote
+def _partition_block_by_fragid(
+    block: pa.Table,
+) -> dict[int, ray.ObjectRef[pa.Table]]:
+    """Partition one Ray Data block into per-fragment object-store tables."""
+    if block.num_rows == 0:
+        return {}
+
+    order = pc.sort_indices(
+        block,
+        sort_keys=[("_fragid", "ascending"), ("_rowaddr", "ascending")],
+    )
+    sorted_block = block.take(order)
+    fragids = sorted_block.column("_fragid").to_numpy(zero_copy_only=False)
+    unique_fragids = np.unique(fragids)
+    starts = np.searchsorted(fragids, unique_fragids, side="left")
+    ends = np.searchsorted(fragids, unique_fragids, side="right")
+
+    partitions: dict[int, ray.ObjectRef[pa.Table]] = {}
+    for frag_id, start, end in zip(unique_fragids, starts, ends, strict=True):
+        partition = sorted_block.slice(int(start), int(end) - int(start))
+        partitions[int(frag_id)] = cast(
+            ray.ObjectRef[pa.Table],
+            ray.put(partition),
+        )
+    return partitions
+
+
+@ray.remote
+def _update_fragment_with_refs(
+    args: _UpdateFragmentArgs,
+) -> tuple[int, bytes, bytes]:
+    """Stream one fragment's update rows and return commit metadata."""
+    frag_id = args.frag_id
+    refs = args.refs
+    uri = args.uri
+    storage_options = args.storage_options
+    namespace_impl = args.namespace_impl
+    namespace_properties = args.namespace_properties
+    table_id = args.table_id
+    read_version = args.read_version
+    columns = args.columns
+    target_types = args.target_types
+    batch_size = args.batch_size
+
+    local_ns_kwargs = get_namespace_kwargs(
+        namespace_impl,
+        namespace_properties,
+        table_id,
+    )
+    local_ds = LanceDataset(
+        uri=uri,
+        storage_options=storage_options,
+        version=read_version,
+        **local_ns_kwargs,
+    )
+    fragment = local_ds.get_fragment(frag_id)
+    if fragment is None:
+        raise ValueError(f"Fragment {frag_id} not found in Lance dataset at {uri}")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = os.path.join(temp_dir, "rowaddrs.sqlite")
+        connection = sqlite3.connect(db_path)
+        try:
+            # Keep SQLite's page cache and temporary index on disk so duplicate
+            # detection does not reintroduce a fragment-sized memory bound.
+            connection.execute("PRAGMA journal_mode=OFF")
+            connection.execute("PRAGMA synchronous=OFF")
+            connection.execute("PRAGMA temp_store=FILE")
+            connection.execute("PRAGMA cache_size=-65536")
+            connection.execute("PRAGMA mmap_size=0")
+            connection.execute("CREATE TABLE rowaddrs (value BLOB)")
+            for ref in refs:
+                table = ray.get(ref)
+                if table.num_rows == 0:
+                    continue
+
+                if table.schema.field("_rowaddr").type != pa.uint64():
+                    raise ValueError(
+                        f"Fragment {frag_id} contains a non-uint64 _rowaddr."
+                    )
+                for column in columns:
+                    if table.schema.field(column).type != target_types[column]:
+                        raise ValueError(
+                            f"Update column type mismatch in fragment {frag_id}: "
+                            f"{column}: source "
+                            f"{table.schema.field(column).type}, target "
+                            f"{target_types[column]}"
+                        )
+                fragid_scalar = pa.scalar(
+                    frag_id,
+                    type=table.schema.field("_fragid").type,
+                )
+                if not pc.all(pc.equal(table.column("_fragid"), fragid_scalar)).as_py():
+                    raise ValueError(
+                        f"Fragment {frag_id} received rows routed to another fragment."
+                    )
+
+                for batch in table.to_batches(max_chunksize=batch_size):
+                    rowaddrs = batch.column("_rowaddr")
+                    if rowaddrs.null_count:
+                        raise ValueError(
+                            f"Null _rowaddr values are not allowed in fragment "
+                            f"{frag_id}."
+                        )
+                    values = [
+                        cast(int, value).to_bytes(8, "big")
+                        for value in rowaddrs.to_pylist()
+                    ]
+                    connection.executemany(
+                        "INSERT INTO rowaddrs (value) VALUES (?)",
+                        [(value,) for value in values],
+                    )
+                    connection.commit()
+
+            connection.execute("CREATE INDEX rowaddrs_value_idx ON rowaddrs (value)")
+            duplicate = connection.execute(
+                "SELECT value FROM rowaddrs GROUP BY value HAVING COUNT(*) > 1 LIMIT 1"
+            ).fetchone()
+            if duplicate is not None:
+                duplicate_rowaddr = int.from_bytes(duplicate[0], "big")
+                raise ValueError(
+                    f"Duplicate _rowaddr values in fragment {frag_id}: "
+                    f"[{duplicate_rowaddr}]"
+                )
+        finally:
+            connection.close()
+
+    update_schema = pa.schema(
+        [pa.field("_rowaddr", pa.uint64())]
+        + [pa.field(column, target_types[column]) for column in columns]
+    )
+
+    def _update_batches() -> Iterator[pa.RecordBatch]:
+        for ref in refs:
+            table = ray.get(ref)
+            for batch in table.to_batches(max_chunksize=batch_size):
+                yield batch.select(["_rowaddr", *columns])
+
+    reader = pa.RecordBatchReader.from_batches(update_schema, _update_batches())
+    fragment_meta, fields_modified = fragment.update_columns(
+        reader,
+        left_on="_rowaddr",
+        right_on="_rowaddr",
+    )
+    return (
+        frag_id,
+        pickle.dumps(fragment_meta),
+        pickle.dumps(fields_modified),
+    )
+
+
 def update_columns_from(
     uri: Optional[str] = None,
     ds: Optional[Dataset] = None,
@@ -1258,8 +1437,10 @@ def update_columns_from(
     Row addresses must be non-null, unique integer values and are normalized
     to ``uint64``. Update column names must be unique and their Arrow types
     must match the target columns.
-    Unmatched source rows are ignored. Before grouping, the source is projected
+    Unmatched source rows are ignored. Before partitioning, the source is projected
     to ``_rowaddr``, ``_fragid``, and the requested update columns. The final
+    per-fragment update is streamed as bounded ``RecordBatch`` values, and a
+    fragment-local disk-backed index rejects duplicate row addresses. The final
     operation is committed once; commit conflicts are returned to the caller
     without retrying stale work. When source lineage is present, the source
     dataset identity must match the update target.
@@ -1286,7 +1467,7 @@ def update_columns_from(
             required when that lineage is unavailable, such as after
             materializing the source. When lineage is present, the source
             dataset identity must match the update target.
-        ray_remote_args: Options passed to Ray Data ``map_groups``.
+        ray_remote_args: Options passed to the Ray partition and fragment-update tasks.
         storage_options: Storage options used to open the dataset.
         namespace_impl: Namespace implementation type, such as ``"dir"`` or
             ``"rest"``.
@@ -1482,7 +1663,29 @@ def update_columns_from(
 
     fragments_in_lance = {f.metadata.id for f in lance_ds.get_fragments()}
 
-    if not ds.take(1):
+    remote_options = dict(ray_remote_args or {})
+    partition_fn = _partition_block_by_fragid.options(**remote_options)
+    update_fn = _update_fragment_with_refs.options(**remote_options)
+
+    block_refs = normalized_ds.to_arrow_refs()
+    partition_tasks = [partition_fn.remote(block_ref) for block_ref in block_refs]
+    partition_results = ray.get(partition_tasks)
+    del partition_tasks
+    del block_refs
+
+    fragment_refs: dict[int, list[ray.ObjectRef[pa.Table]]] = defaultdict(list)
+    for partitions in partition_results:
+        for frag_id, partition_ref in partitions.items():
+            fragment_refs[frag_id].append(partition_ref)
+    del partition_results
+
+    unknown_fragments = set(fragment_refs) - fragments_in_lance
+    if unknown_fragments:
+        raise ValueError(
+            f"_fragid values from input Dataset are not present in the Lance "
+            f"dataset at {uri}: {sorted(unknown_fragments)}"
+        )
+    if not fragment_refs:
         logger.warning(
             "No rows to update; update_columns_from completed without changes."
         )
@@ -1492,126 +1695,32 @@ def update_columns_from(
             "'read_version' is required because the source Lance version "
             "is unavailable from the Ray Dataset's logical lineage."
         )
-    ds = normalized_ds
 
-    _uri = uri
-    _storage_options = storage_options
-    _namespace_impl = namespace_impl
-    _namespace_properties = namespace_properties
-    _table_id = table_id
-    _read_version = resolved_read_version
-    _columns = list(columns)
-    _target_types = target_types
-    _batch_size = batch_size
-
-    def _update_one_fragment(batch: DataBatch) -> pa.Table:
-        group = cast(pa.Table, batch)
-        if group.num_rows == 0:
-            return pa.table(
-                {
-                    "frag_id": pa.array([], type=pa.int64()),
-                    "fragment_meta": pa.array([], type=pa.binary()),
-                    "fields_modified": pa.array([], type=pa.binary()),
-                }
-            )
-
-        worker_type_mismatches: list[str] = []
-        for column in _columns:
-            source_type = group.schema.field(column).type
-            target_type = _target_types[column]
-            if source_type != target_type:
-                worker_type_mismatches.append(
-                    f"{column}: source {source_type}, target {target_type}"
-                )
-        if worker_type_mismatches:
-            raise ValueError(
-                "Update column type mismatch: " + "; ".join(worker_type_mismatches)
-            )
-
-        frag_id = int(group.column("_fragid")[0].as_py())
-        rowaddrs = group.column("_rowaddr")
-        if rowaddrs.null_count:
-            raise ValueError(
-                f"Null _rowaddr values are not allowed in fragment {frag_id}."
-            )
-
-        order = pc.sort_indices(group, sort_keys=[("_rowaddr", "ascending")])
-        sorted_group = group.take(order)
-        sorted_rowaddrs = sorted_group.column("_rowaddr").combine_chunks()
-        if len(sorted_rowaddrs) > 1:
-            duplicate_mask = pc.equal(
-                sorted_rowaddrs.slice(1),
-                sorted_rowaddrs.slice(0, len(sorted_rowaddrs) - 1),
-            )
-            duplicate_rowaddrs = pc.unique(
-                pc.filter(sorted_rowaddrs.slice(1), duplicate_mask)
-            ).to_pylist()
-            if duplicate_rowaddrs:
-                raise ValueError(
-                    f"Duplicate _rowaddr values in fragment {frag_id}: "
-                    f"{duplicate_rowaddrs}"
-                )
-
-        update_table = sorted_group.select(["_rowaddr", *_columns]).combine_chunks()
-
-        local_ns_kwargs = get_namespace_kwargs(
-            _namespace_impl, _namespace_properties, _table_id
+    update_tasks = [
+        update_fn.remote(
+            _UpdateFragmentArgs(
+                frag_id=frag_id,
+                refs=refs,
+                uri=uri,
+                storage_options=storage_options,
+                namespace_impl=namespace_impl,
+                namespace_properties=namespace_properties,
+                table_id=table_id,
+                read_version=resolved_read_version,
+                columns=list(columns),
+                target_types=target_types,
+                batch_size=batch_size,
+            ),
         )
-        local_ds = LanceDataset(
-            uri=_uri,
-            storage_options=_storage_options,
-            version=_read_version,
-            **local_ns_kwargs,
-        )
-        fragment = local_ds.get_fragment(frag_id)
-        if fragment is None:
-            raise ValueError(f"Fragment {frag_id} not found in Lance dataset at {_uri}")
-
-        reader = pa.RecordBatchReader.from_batches(
-            update_table.schema,
-            update_table.to_batches(max_chunksize=_batch_size),
-        )
-        fragment_meta, fields_modified = fragment.update_columns(
-            reader,
-            left_on="_rowaddr",
-            right_on="_rowaddr",
-        )
-
-        return pa.table(
-            {
-                "frag_id": pa.array([frag_id], type=pa.int64()),
-                "fragment_meta": pa.array(
-                    [pickle.dumps(fragment_meta)], type=pa.binary()
-                ),
-                "fields_modified": pa.array(
-                    [pickle.dumps(fields_modified)], type=pa.binary()
-                ),
-            }
-        )
-
-    map_groups_kwargs: dict[str, Any] = {}
-    if ray_remote_args:
-        map_groups_kwargs.update(ray_remote_args)
-
-    result_ds = ds.groupby("_fragid").map_groups(
-        _update_one_fragment,
-        batch_format="pyarrow",
-        **map_groups_kwargs,
-    )
-
-    rows = result_ds.take_all()
-    if not rows:
-        logger.warning(
-            "No rows to update; update_columns_from completed without changes."
-        )
-        return
+        for frag_id, refs in fragment_refs.items()
+    ]
+    results = ray.get(update_tasks)
 
     updated_fragments = []
     all_fields_modified: set[int] = set()
     seen_frag_ids: set[int] = set()
 
-    for row in rows:
-        frag_id = int(row["frag_id"])
+    for frag_id, fragment_meta_bytes, fields_modified_bytes in results:
         if frag_id not in fragments_in_lance:
             raise ValueError(
                 f"_fragid {frag_id} from input Dataset is not present in the "
@@ -1619,12 +1728,12 @@ def update_columns_from(
             )
         if frag_id in seen_frag_ids:
             raise ValueError(
-                f"Duplicate _fragid {frag_id} encountered in map_groups output"
+                f"Duplicate _fragid {frag_id} encountered in update output"
             )
         seen_frag_ids.add(frag_id)
 
-        fragment_meta = pickle.loads(row["fragment_meta"])
-        fields_modified = pickle.loads(row["fields_modified"])
+        fragment_meta = pickle.loads(fragment_meta_bytes)
+        fields_modified = pickle.loads(fields_modified_bytes)
         updated_fragments.append(fragment_meta)
         all_fields_modified.update(fields_modified)
 

--- a/lance_ray/io.py
+++ b/lance_ray/io.py
@@ -1333,12 +1333,6 @@ def update_columns_from(
         namespace_impl, namespace_properties, table_id
     )
 
-    if not ds.take(1):
-        logger.warning(
-            "No rows to update; update_columns_from completed without changes."
-        )
-        return
-
     ray_schema = ds.schema()
     if ray_schema is None:
         logger.warning(
@@ -1383,7 +1377,12 @@ def update_columns_from(
     if has_fragid:
         projected_columns.append("_fragid")
     projected_columns.extend(columns)
-    ds = ds.select_columns(projected_columns)
+
+    source_provenance = _source_provenance_from_dataset_lineage(ds)
+    source_version = None if source_provenance is None else source_provenance[0]
+    source_identity = None if source_provenance is None else source_provenance[1]
+    if read_version is None and source_version is not None:
+        read_version = source_version
 
     def _validate_and_derive_fragid(batch: DataBatch) -> pa.Table:
         table = cast(pa.Table, batch)
@@ -1434,27 +1433,10 @@ def update_columns_from(
 
         return table.append_column("_fragid", derived_fragids)
 
-    ds = ds.map_batches(
+    normalized_ds = ds.map_batches(
         _validate_and_derive_fragid,
         batch_format="pyarrow",
     )
-    ray_schema = ds.schema()
-    if ray_schema is None:
-        logger.warning(
-            "No rows to update; update_columns_from completed without changes."
-        )
-        return
-
-    source_provenance = _source_provenance_from_dataset_lineage(ds)
-    source_version = None if source_provenance is None else source_provenance[0]
-    source_identity = None if source_provenance is None else source_provenance[1]
-    if read_version is None:
-        if source_version is None:
-            raise ValueError(
-                "'read_version' is required because the source Lance version "
-                "is unavailable from the Ray Dataset's logical lineage."
-            )
-        read_version = source_version
 
     lance_ds = LanceDataset(
         uri=uri,
@@ -1499,6 +1481,19 @@ def update_columns_from(
         raise ValueError("Update column type mismatch: " + "; ".join(type_mismatches))
 
     fragments_in_lance = {f.metadata.id for f in lance_ds.get_fragments()}
+
+    if not ds.take(1):
+        logger.warning(
+            "No rows to update; update_columns_from completed without changes."
+        )
+        return
+    if read_version is None:
+        raise ValueError(
+            "'read_version' is required because the source Lance version "
+            "is unavailable from the Ray Dataset's logical lineage."
+        )
+
+    ds = normalized_ds.select_columns(projected_columns)
 
     _uri = uri
     _storage_options = storage_options

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "ray[data]>=2.41.0",
     "pylance>=10.0.0b7",
     "lance-namespace",
+    "numpy>=1.26",
     "packaging",
     "pyarrow>=17.0.0",
     "more_itertools>=2.6.0; python_version<'3.12'",

--- a/tests/_ray_test_support.py
+++ b/tests/_ray_test_support.py
@@ -6,6 +6,7 @@ inside Ray worker processes via ``runtime_env.worker_process_setup_hook``.
 
 from __future__ import annotations
 
+import importlib
 import threading
 from typing import Any, Optional
 
@@ -23,7 +24,12 @@ def patch_memory_profiler() -> None:
     except ImportError:
         return
 
-    original_init = ray_data_util.MemoryProfiler.__init__
+    memory_profiler = getattr(ray_data_util, "MemoryProfiler", None)
+    if memory_profiler is None:
+        # Ray 2.41-2.44 do not create this profiler, so no patch is needed.
+        return
+
+    original_init = memory_profiler.__init__
 
     def safe_init(self: Any, poll_interval_s: Optional[float]) -> None:
         self._poll_interval_s = poll_interval_s
@@ -38,13 +44,13 @@ def patch_memory_profiler() -> None:
 
     # Monkey-patching methods is the point of this module, so the
     # ``method-assign`` guard does not apply here.
-    ray_data_util.MemoryProfiler.__init__ = safe_init  # type: ignore[method-assign]
-    if hasattr(ray_data_util.MemoryProfiler, "_can_estimate_uss"):
+    memory_profiler.__init__ = safe_init
+    if hasattr(memory_profiler, "_can_estimate_uss"):
 
         def _cannot_estimate_uss(self: Any) -> bool:
             return False
 
-        ray_data_util.MemoryProfiler._can_estimate_uss = _cannot_estimate_uss  # type: ignore[method-assign,assignment]
+        memory_profiler._can_estimate_uss = _cannot_estimate_uss
 
 
 def patch_psutil_for_containers() -> None:
@@ -62,11 +68,16 @@ def patch_psutil_for_containers() -> None:
       — same call-chain as above.
     """
     try:
-        from ray._private.runtime_env import uv_runtime_env_hook
+        uv_runtime_env_hook = importlib.import_module(
+            "ray._private.runtime_env.uv_runtime_env_hook"
+        )
     except ImportError:
         return
 
-    original_fn = uv_runtime_env_hook._get_uv_run_cmdline
+    original_fn = getattr(uv_runtime_env_hook, "_get_uv_run_cmdline", None)
+    if original_fn is None:
+        # Older Ray releases have the module but not the uv hook being patched.
+        return
 
     def _safe_get_uv_run_cmdline() -> Any:
         try:
@@ -74,7 +85,7 @@ def patch_psutil_for_containers() -> None:
         except Exception:
             return None
 
-    uv_runtime_env_hook._get_uv_run_cmdline = _safe_get_uv_run_cmdline
+    uv_runtime_env_hook._get_uv_run_cmdline = _safe_get_uv_run_cmdline  # type: ignore[attr-defined]
 
     _patch_worker_log_offset()
 

--- a/tests/test_update_columns_from.py
+++ b/tests/test_update_columns_from.py
@@ -864,6 +864,7 @@ def test_update_columns_from_rejects_null_rowaddr_without_fragid(
             }
         )
     )
+    # Without lineage, an explicit version is required before worker validation.
     read_version = lance.dataset(str(multi_fragment_path)).version
 
     with pytest.raises(RayTaskError, match="Null _rowaddr"):

--- a/tests/test_update_columns_from.py
+++ b/tests/test_update_columns_from.py
@@ -476,6 +476,29 @@ def test_update_columns_from_does_not_materialize_fragment_groups(
     assert result.column("value").to_pylist() == [10, 20, 30, 40]
 
 
+def test_update_columns_from_does_not_consume_source_with_take(
+    multi_fragment_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_take(self: Dataset, limit: int = 20) -> list[dict[str, Any]]:
+        raise AssertionError(
+            "update_columns_from must not consume the source with take"
+        )
+
+    monkeypatch.setattr(Dataset, "take", fail_take)
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True)
+
+    lr.update_columns_from(
+        str(multi_fragment_path),
+        source,
+        columns=["value"],
+    )
+
+    result = lance.dataset(str(multi_fragment_path)).to_table().sort_by("id")
+    assert result.column("value").to_pylist() == [10, 20, 30, 40]
+
+
 def test_update_columns_from_rejects_different_source_dataset(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_update_columns_from.py
+++ b/tests/test_update_columns_from.py
@@ -11,7 +11,7 @@ import pyarrow.compute as pc
 import pytest
 import ray
 from lance.dataset import LanceDataset
-from lance_ray.datasource import dataset_identity_digest
+from lance_ray.datasource import dataset_identity_digest, normalize_dataset_uri
 from ray.data import Dataset, Schema
 from ray.data.block import DataBatch
 from ray.exceptions import RayTaskError
@@ -381,6 +381,15 @@ def test_dataset_identity_digest_requires_reliable_backend(
         )
         is not None
     )
+
+
+def test_normalize_dataset_uri_treats_file_scheme_as_local_path(
+    multi_fragment_path: Path,
+) -> None:
+    local_uri = str(multi_fragment_path)
+    file_uri = f"file://{multi_fragment_path}"
+
+    assert normalize_dataset_uri(file_uri) == normalize_dataset_uri(local_uri)
 
 
 def test_update_columns_from_rejects_source_version_mismatch(

--- a/tests/test_update_columns_from.py
+++ b/tests/test_update_columns_from.py
@@ -11,6 +11,7 @@ import pyarrow.compute as pc
 import pytest
 import ray
 from lance.dataset import LanceDataset
+from lance_ray.datasource import dataset_identity_digest
 from ray.data import Dataset, Schema
 from ray.data.block import DataBatch
 from ray.exceptions import RayTaskError
@@ -363,6 +364,23 @@ def test_update_columns_from_source_lineage_does_not_expose_uri(
 
     result = lance.dataset(str(multi_fragment_path)).to_table().sort_by("id")
     assert result.column("value").to_pylist() == [10, 20, 30, 40]
+
+
+def test_dataset_identity_digest_requires_reliable_backend(
+    multi_fragment_path: Path,
+) -> None:
+    class FakeLanceDataset:
+        uri = "s3://bucket/table"
+        _ds = object()
+
+    assert dataset_identity_digest(FakeLanceDataset()) is None
+    assert (
+        dataset_identity_digest(
+            FakeLanceDataset(),
+            storage_options={"endpoint": "http://minio:9000"},
+        )
+        is not None
+    )
 
 
 def test_update_columns_from_rejects_source_version_mismatch(

--- a/tests/test_update_columns_from.py
+++ b/tests/test_update_columns_from.py
@@ -459,6 +459,7 @@ def test_update_columns_from_does_not_materialize_fragment_groups(
     multi_fragment_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Avoid a fixed groupby signature because Ray Data's public API varies by version.
     def fail_groupby(*args: object, **kwargs: object) -> object:
         raise AssertionError("update_columns_from must not materialize fragment groups")
 

--- a/tests/test_update_columns_from.py
+++ b/tests/test_update_columns_from.py
@@ -6,12 +6,19 @@ from typing import Any, cast
 
 import lance
 import lance_ray as lr
+import lance_ray.datasource as datasource_module
+import lance_ray.io as lance_io
 import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
 import ray
 from lance.dataset import LanceDataset
-from lance_ray.datasource import dataset_identity_digest, normalize_dataset_uri
+from lance_ray.datasource import (
+    LanceDatasource,
+    dataset_identity,
+    dataset_identity_digest,
+    normalize_dataset_uri,
+)
 from ray.data import Dataset, Schema
 from ray.data.block import DataBatch
 from ray.exceptions import RayTaskError
@@ -366,11 +373,9 @@ def test_update_columns_from_source_lineage_does_not_expose_uri(
     assert result.column("value").to_pylist() == [10, 20, 30, 40]
 
 
-def test_dataset_identity_digest_requires_reliable_backend(
-    multi_fragment_path: Path,
-) -> None:
+def test_dataset_identity_digest_requires_reliable_backend() -> None:
     class FakeLanceDataset:
-        uri = "s3://bucket/table"
+        uri = "az://container/table"
         _ds = object()
 
     assert dataset_identity_digest(FakeLanceDataset()) is None
@@ -383,6 +388,77 @@ def test_dataset_identity_digest_requires_reliable_backend(
     )
 
 
+@pytest.mark.parametrize("scheme", ["s3", "gs"])
+def test_dataset_identity_digest_distinguishes_global_cloud_buckets(
+    scheme: str,
+) -> None:
+    class FakeLanceDataset:
+        _ds = object()
+
+        def __init__(self, dataset_uri: str) -> None:
+            self.uri = dataset_uri
+
+    first = dataset_identity_digest(FakeLanceDataset(f"{scheme}://first/table"))
+    second = dataset_identity_digest(FakeLanceDataset(f"{scheme}://second/table"))
+
+    assert first is not None
+    assert second is not None
+    assert first != second
+
+
+def test_dataset_identity_excludes_endpoint_credentials() -> None:
+    class FakeLanceDataset:
+        uri = "s3://bucket/table"
+        _ds = object()
+
+    first = dataset_identity(
+        FakeLanceDataset(),
+        storage_options={
+            "endpoint_url": "https://first:secret@minio.example:9000/api?token=one"
+        },
+    )
+    second = dataset_identity(
+        FakeLanceDataset(),
+        storage_options={
+            "endpoint_url": "https://second:rotated@minio.example:9000/api?token=two"
+        },
+    )
+
+    assert first == second
+    assert "first" not in first
+    assert "secret" not in first
+    assert "token" not in first
+
+
+def test_datasource_caches_unavailable_source_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeLanceDataset:
+        version = 7
+
+    calls = 0
+
+    def unavailable_identity(*args: object, **kwargs: object) -> None:
+        nonlocal calls
+        calls += 1
+        return None
+
+    monkeypatch.setattr(
+        datasource_module,
+        "dataset_identity_digest",
+        unavailable_identity,
+    )
+    datasource = object.__new__(LanceDatasource)
+    datasource._source_provenance = None
+    datasource._lance_ds = cast(Any, FakeLanceDataset())
+    datasource._storage_options = None
+
+    assert datasource.source_identity is None
+    assert datasource.source_identity is None
+    assert datasource.source_version == 7
+    assert calls == 1
+
+
 def test_normalize_dataset_uri_treats_file_scheme_as_local_path(
     multi_fragment_path: Path,
 ) -> None:
@@ -390,6 +466,38 @@ def test_normalize_dataset_uri_treats_file_scheme_as_local_path(
     file_uri = f"file://{multi_fragment_path}"
 
     assert normalize_dataset_uri(file_uri) == normalize_dataset_uri(local_uri)
+
+
+def test_normalize_dataset_uri_handles_windows_drive_paths() -> None:
+    normalized = normalize_dataset_uri("C:\\Data\\Table.lance\\")
+
+    assert normalized == normalize_dataset_uri("c:/data/table.lance")
+    assert normalized == normalize_dataset_uri("file:///C:/Data/Table.lance/")
+
+
+def test_update_columns_from_fails_before_partitioning_without_reliable_identity(
+    multi_fragment_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    version = lance.dataset(str(multi_fragment_path)).version
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True)
+    monkeypatch.setattr(
+        lance_io,
+        "_source_provenance_from_dataset_lineage",
+        lambda _: (version, None),
+    )
+
+    def fail_to_arrow_refs(self: Dataset) -> list[Any]:
+        raise AssertionError("partitioning must not start before provenance validation")
+
+    monkeypatch.setattr(Dataset, "to_arrow_refs", fail_to_arrow_refs)
+
+    with pytest.raises(ValueError, match="reliable dataset identity"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["value"],
+        )
 
 
 def test_update_columns_from_rejects_source_version_mismatch(
@@ -465,7 +573,15 @@ def test_update_columns_from_does_not_use_groupby(
 
     monkeypatch.setattr(Dataset, "groupby", fail_groupby)
 
-    source = lr.read_lance(str(multi_fragment_path), with_metadata=True)
+    def update_values(batch: DataBatch) -> pd.DataFrame:
+        frame = cast(pd.DataFrame, batch).copy()
+        frame["value"] += 100
+        return frame
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        update_values,
+        batch_format="pandas",
+    )
 
     lr.update_columns_from(
         str(multi_fragment_path),
@@ -474,7 +590,7 @@ def test_update_columns_from_does_not_use_groupby(
     )
 
     result = lance.dataset(str(multi_fragment_path)).to_table().sort_by("id")
-    assert result.column("value").to_pylist() == [10, 20, 30, 40]
+    assert result.column("value").to_pylist() == [110, 120, 130, 140]
 
 
 def test_update_columns_from_does_not_consume_source_with_take(
@@ -488,7 +604,15 @@ def test_update_columns_from_does_not_consume_source_with_take(
 
     monkeypatch.setattr(Dataset, "take", fail_take)
 
-    source = lr.read_lance(str(multi_fragment_path), with_metadata=True)
+    def update_values(batch: DataBatch) -> pd.DataFrame:
+        frame = cast(pd.DataFrame, batch).copy()
+        frame["value"] += 100
+        return frame
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        update_values,
+        batch_format="pandas",
+    )
 
     lr.update_columns_from(
         str(multi_fragment_path),
@@ -497,7 +621,7 @@ def test_update_columns_from_does_not_consume_source_with_take(
     )
 
     result = lance.dataset(str(multi_fragment_path)).to_table().sort_by("id")
-    assert result.column("value").to_pylist() == [10, 20, 30, 40]
+    assert result.column("value").to_pylist() == [110, 120, 130, 140]
 
 
 def test_update_columns_from_streams_multiple_refs_for_one_fragment(
@@ -515,11 +639,17 @@ def test_update_columns_from_streams_multiple_refs_for_one_fragment(
         str(path),
         max_rows_per_file=6,
     )
+
+    def update_values(batch: DataBatch) -> pd.DataFrame:
+        frame = cast(pd.DataFrame, batch).copy()
+        frame["value"] += 100
+        return frame
+
     source = lr.read_lance(
         str(path),
         with_metadata=True,
         override_num_blocks=3,
-    )
+    ).map_batches(update_values, batch_format="pandas")
 
     captured_block_refs: list[Any] = []
     original_to_arrow_refs = Dataset.to_arrow_refs
@@ -539,7 +669,7 @@ def test_update_columns_from_streams_multiple_refs_for_one_fragment(
 
     assert len(captured_block_refs) >= 2
     result = lance.dataset(str(path)).to_table().sort_by("id")
-    assert result.column("value").to_pylist() == [10, 20, 30, 40, 50, 60]
+    assert result.column("value").to_pylist() == [110, 120, 130, 140, 150, 160]
 
 
 def test_update_columns_from_rejects_different_source_dataset(
@@ -1391,7 +1521,7 @@ def test_update_columns_from_rejects_null_fragid(
         )
 
 
-def test_update_columns_from_rejects_cross_group_duplicate_rowaddr(
+def test_update_columns_from_rejects_inconsistent_fragid_on_duplicated_rows(
     multi_fragment_path: Path,
 ) -> None:
     def duplicate_with_other_fragid(batch: DataBatch) -> pa.Table:
@@ -1465,20 +1595,28 @@ def test_update_columns_from_worker_failure_does_not_commit_partial_updates(
     first_frag_id = fragments[0].metadata.id
     second_frag_id = fragments[1].metadata.id
     source = ray.data.from_arrow(
-        pa.table(
-            {
-                "_rowaddr": pa.array(
-                    [
-                        first_frag_id << 32,
-                        second_frag_id << 32,
-                        second_frag_id << 32,
-                    ],
-                    type=pa.uint64(),
-                ),
-                "value": pa.array([999, 888, 777], type=pa.int64()),
-            }
-        )
+        [
+            pa.table(
+                {
+                    "_rowaddr": pa.array(
+                        [first_frag_id << 32],
+                        type=pa.uint64(),
+                    ),
+                    "value": pa.array([999], type=pa.int64()),
+                }
+            ),
+            pa.table(
+                {
+                    "_rowaddr": pa.array(
+                        [second_frag_id << 32, second_frag_id << 32],
+                        type=pa.uint64(),
+                    ),
+                    "value": pa.array([888, 777], type=pa.int64()),
+                }
+            ),
+        ]
     )
+    assert source.num_blocks() == 2
 
     with pytest.raises(RayTaskError, match="Duplicate _rowaddr"):
         lr.update_columns_from(
@@ -1491,6 +1629,20 @@ def test_update_columns_from_worker_failure_does_not_commit_partial_updates(
     result = lance.dataset(str(multi_fragment_path))
     assert result.version == read_version
     assert result.to_table().sort_by("id") == original
+
+
+def test_read_lance_projected_schema_includes_requested_metadata(
+    multi_fragment_path: Path,
+) -> None:
+    source = lr.read_lance(
+        str(multi_fragment_path),
+        columns=["value"],
+        with_metadata=True,
+    )
+
+    schema = source.schema()
+    assert schema is not None
+    assert schema.names == ["value", "_rowaddr", "_fragid"]
 
 
 def test_update_columns_from_warns_for_empty_source(

--- a/tests/test_update_columns_from.py
+++ b/tests/test_update_columns_from.py
@@ -362,23 +362,21 @@ def test_update_columns_from_rejects_source_version_mismatch(
         )
 
 
-def test_update_columns_from_projects_columns_before_groupby(
+def test_update_columns_from_projects_columns_before_partitioning(
     multi_fragment_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    grouped_column_names: list[list[str]] = []
-    original_groupby = Dataset.groupby
+    partitioned_column_names: list[list[str]] = []
+    original_to_arrow_refs = Dataset.to_arrow_refs
 
-    def capturing_groupby(
+    def capturing_to_arrow_refs(
         self: Dataset,
-        key: str | list[str] | None,
-        num_partitions: int | None = None,
-    ) -> object:
+    ) -> list[Any]:
         schema = self.schema()
-        grouped_column_names.append([] if schema is None else list(schema.names))
-        return original_groupby(self, key, num_partitions)
+        partitioned_column_names.append([] if schema is None else list(schema.names))
+        return cast(list[Any], original_to_arrow_refs(self))
 
-    monkeypatch.setattr(Dataset, "groupby", capturing_groupby)
+    monkeypatch.setattr(Dataset, "to_arrow_refs", capturing_to_arrow_refs)
 
     def add_unused_and_update(batch: DataBatch) -> pa.Table:
         table = cast(pa.Table, batch)
@@ -403,11 +401,32 @@ def test_update_columns_from_projects_columns_before_groupby(
         columns=["value"],
     )
 
-    assert grouped_column_names
-    assert set(grouped_column_names[-1]) == {"_fragid", "_rowaddr", "value"}
+    assert partitioned_column_names
+    assert set(partitioned_column_names[-1]) == {"_fragid", "_rowaddr", "value"}
 
     result = lance.dataset(str(multi_fragment_path)).to_table().sort_by("id")
     assert result.column("value").to_pylist() == [999, 999, 999, 999]
+
+
+def test_update_columns_from_does_not_materialize_fragment_groups(
+    multi_fragment_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_groupby(*args: object, **kwargs: object) -> object:
+        raise AssertionError("update_columns_from must not materialize fragment groups")
+
+    monkeypatch.setattr(Dataset, "groupby", fail_groupby)
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True)
+
+    lr.update_columns_from(
+        str(multi_fragment_path),
+        source,
+        columns=["value"],
+    )
+
+    result = lance.dataset(str(multi_fragment_path)).to_table().sort_by("id")
+    assert result.column("value").to_pylist() == [10, 20, 30, 40]
 
 
 def test_update_columns_from_rejects_different_source_dataset(
@@ -1287,7 +1306,7 @@ def test_update_columns_from_rejects_cross_group_duplicate_rowaddr(
         )
 
 
-def test_update_columns_from_worker_failure_does_not_commit_partial_updates(
+def test_update_columns_from_rejects_unknown_fragment_before_update(
     multi_fragment_path: Path,
 ) -> None:
     dataset = lance.dataset(str(multi_fragment_path))
@@ -1309,7 +1328,45 @@ def test_update_columns_from_worker_failure_does_not_commit_partial_updates(
         )
     )
 
-    with pytest.raises(RayTaskError, match=f"Fragment {missing_frag_id} not found"):
+    with pytest.raises(ValueError, match="_fragid values from input Dataset"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["value"],
+            read_version=read_version,
+        )
+
+    result = lance.dataset(str(multi_fragment_path))
+    assert result.version == read_version
+    assert result.to_table().sort_by("id") == original
+
+
+def test_update_columns_from_worker_failure_does_not_commit_partial_updates(
+    multi_fragment_path: Path,
+) -> None:
+    dataset = lance.dataset(str(multi_fragment_path))
+    read_version = dataset.version
+    original = dataset.to_table().sort_by("id")
+    fragments = dataset.get_fragments()
+    first_frag_id = fragments[0].metadata.id
+    second_frag_id = fragments[1].metadata.id
+    source = ray.data.from_arrow(
+        pa.table(
+            {
+                "_rowaddr": pa.array(
+                    [
+                        first_frag_id << 32,
+                        second_frag_id << 32,
+                        second_frag_id << 32,
+                    ],
+                    type=pa.uint64(),
+                ),
+                "value": pa.array([999, 888, 777], type=pa.int64()),
+            }
+        )
+    )
+
+    with pytest.raises(RayTaskError, match="Duplicate _rowaddr"):
         lr.update_columns_from(
             str(multi_fragment_path),
             source,

--- a/tests/test_update_columns_from.py
+++ b/tests/test_update_columns_from.py
@@ -1,5 +1,6 @@
 """Tests for update_columns_from."""
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import cast
 
@@ -1605,8 +1606,8 @@ def test_update_columns_from_forwards_storage_options(
     storage_options = {"timeout": "60s"}
     opened_storage_options: list[dict[str, str] | None] = []
     committed_storage_options: list[dict[str, str] | None] = []
-    original_init = LanceDataset.__init__
-    original_commit = LanceDataset.commit
+    original_init = cast(Callable[..., None], LanceDataset.__init__)
+    original_commit = cast(Callable[..., LanceDataset], LanceDataset.commit)
 
     def capturing_init(
         self: LanceDataset,

--- a/tests/test_update_columns_from.py
+++ b/tests/test_update_columns_from.py
@@ -455,13 +455,13 @@ def test_update_columns_from_projects_columns_before_partitioning(
     assert result.column("value").to_pylist() == [999, 999, 999, 999]
 
 
-def test_update_columns_from_does_not_materialize_fragment_groups(
+def test_update_columns_from_does_not_use_groupby(
     multi_fragment_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # Avoid a fixed groupby signature because Ray Data's public API varies by version.
     def fail_groupby(*args: object, **kwargs: object) -> object:
-        raise AssertionError("update_columns_from must not materialize fragment groups")
+        raise AssertionError("update_columns_from must not use groupby")
 
     monkeypatch.setattr(Dataset, "groupby", fail_groupby)
 
@@ -498,6 +498,48 @@ def test_update_columns_from_does_not_consume_source_with_take(
 
     result = lance.dataset(str(multi_fragment_path)).to_table().sort_by("id")
     assert result.column("value").to_pylist() == [10, 20, 30, 40]
+
+
+def test_update_columns_from_streams_multiple_refs_for_one_fragment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "one_fragment.lance"
+    lance.write_dataset(
+        pa.table(
+            {
+                "id": pa.array([1, 2, 3, 4, 5, 6], type=pa.int64()),
+                "value": pa.array([10, 20, 30, 40, 50, 60], type=pa.int64()),
+            }
+        ),
+        str(path),
+        max_rows_per_file=6,
+    )
+    source = lr.read_lance(
+        str(path),
+        with_metadata=True,
+        override_num_blocks=3,
+    )
+
+    captured_block_refs: list[Any] = []
+    original_to_arrow_refs = Dataset.to_arrow_refs
+
+    def capturing_to_arrow_refs(self: Dataset) -> list[Any]:
+        refs = original_to_arrow_refs(self)
+        captured_block_refs.extend(refs)
+        return cast(list[Any], refs)
+
+    monkeypatch.setattr(Dataset, "to_arrow_refs", capturing_to_arrow_refs)
+
+    lr.update_columns_from(
+        str(path),
+        source,
+        columns=["value"],
+    )
+
+    assert len(captured_block_refs) >= 2
+    result = lance.dataset(str(path)).to_table().sort_by("id")
+    assert result.column("value").to_pylist() == [10, 20, 30, 40, 50, 60]
 
 
 def test_update_columns_from_rejects_different_source_dataset(
@@ -1619,6 +1661,7 @@ def test_update_columns_from_empty_source_without_fragid(
         str(multi_fragment_path),
         source,
         columns=["value"],
+        read_version=version_before,
     )
 
     assert "No rows to update" in caplog.text

--- a/tests/test_update_columns_from.py
+++ b/tests/test_update_columns_from.py
@@ -1,0 +1,1649 @@
+"""Tests for update_columns_from."""
+
+from pathlib import Path
+from typing import cast
+
+import lance
+import lance_ray as lr
+import pyarrow as pa
+import pyarrow.compute as pc
+import pytest
+import ray
+from lance.dataset import LanceDataset
+from ray.data import Dataset, Schema
+from ray.data.block import DataBatch
+from ray.exceptions import RayTaskError
+
+import pandas as pd
+
+
+@pytest.fixture
+def multi_fragment_path(tmp_path: Path) -> Path:
+    path = tmp_path / "update_columns.lance"
+    data = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "name": ["Alice", "Bob", "Charlie", "Dave"],
+            "value": [10, 20, 30, 40],
+        }
+    )
+    lance.write_dataset(pa.Table.from_pandas(data), str(path), max_rows_per_file=2)
+    return path
+
+
+def test_update_columns_from_updates_partial_rows(
+    multi_fragment_path: Path,
+) -> None:
+    def update_selected_rows(batch: DataBatch) -> pd.DataFrame:
+        frame = cast(pd.DataFrame, batch).copy()
+        frame.loc[frame["id"] == 1, "value"] = 101
+        frame.loc[frame["id"] == 3, "value"] = 303
+        return frame
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        update_selected_rows, batch_format="pandas"
+    )
+
+    lr.update_columns_from(
+        str(multi_fragment_path),
+        source,
+        columns=["value"],
+    )
+
+    result = (
+        lr.read_lance(str(multi_fragment_path))
+        .to_pandas()
+        .sort_values("id")
+        .reset_index(drop=True)
+    )
+
+    assert result["value"].tolist() == [101, 20, 303, 40]
+    assert result["name"].tolist() == ["Alice", "Bob", "Charlie", "Dave"]
+
+
+def test_update_columns_from_updates_filtered_source_rows(
+    multi_fragment_path: Path,
+) -> None:
+    def update_id_one(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        selected = table.filter(
+            pc.equal(
+                table.column("id"),
+                pa.scalar(1, type=table.schema.field("id").type),
+            )
+        )
+        return selected.set_column(
+            selected.schema.get_field_index("value"),
+            "value",
+            pa.array(
+                [101] * selected.num_rows, type=selected.schema.field("value").type
+            ),
+        )
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        update_id_one, batch_format="pyarrow"
+    )
+
+    lr.update_columns_from(
+        str(multi_fragment_path),
+        source,
+        columns=["value"],
+    )
+
+    result = (
+        lr.read_lance(str(multi_fragment_path))
+        .to_pandas()
+        .sort_values("id")
+        .reset_index(drop=True)
+    )
+
+    assert result["value"].tolist() == [101, 20, 30, 40]
+    assert result["name"].tolist() == ["Alice", "Bob", "Charlie", "Dave"]
+
+
+def test_update_columns_from_preserves_row_metadata(
+    multi_fragment_path: Path,
+) -> None:
+    metadata_before = (
+        lr.read_lance(str(multi_fragment_path), with_metadata=True)
+        .to_pandas()
+        .sort_values("id")
+        .reset_index(drop=True)[["id", "_rowaddr", "_fragid"]]
+    )
+
+    def update_id_one(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        selected = table.filter(
+            pc.equal(
+                table.column("id"),
+                pa.scalar(1, type=table.schema.field("id").type),
+            )
+        )
+        return selected.set_column(
+            selected.schema.get_field_index("value"),
+            "value",
+            pa.array(
+                [101] * selected.num_rows, type=selected.schema.field("value").type
+            ),
+        )
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        update_id_one, batch_format="pyarrow"
+    )
+
+    lr.update_columns_from(
+        str(multi_fragment_path),
+        source,
+        columns=["value"],
+    )
+
+    metadata_after = (
+        lr.read_lance(str(multi_fragment_path), with_metadata=True)
+        .to_pandas()
+        .sort_values("id")
+        .reset_index(drop=True)[["id", "_rowaddr", "_fragid"]]
+    )
+
+    assert metadata_after.equals(metadata_before)
+
+
+def test_update_columns_from_surfaces_stale_version_conflict(
+    multi_fragment_path: Path,
+) -> None:
+    old_version = lance.dataset(str(multi_fragment_path)).version
+
+    def update_id_one(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        selected = table.filter(
+            pc.equal(
+                table.column("id"),
+                pa.scalar(1, type=table.schema.field("id").type),
+            )
+        )
+        return selected.set_column(
+            selected.schema.get_field_index("value"),
+            "value",
+            pa.array(
+                [999] * selected.num_rows, type=selected.schema.field("value").type
+            ),
+        )
+
+    stale_source = lr.read_lance(
+        str(multi_fragment_path),
+        dataset_options={"version": old_version},
+        with_metadata=True,
+    ).map_batches(update_id_one, batch_format="pyarrow")
+
+    lance.dataset(str(multi_fragment_path)).update({"value": "101"})
+    newer_dataset = lance.dataset(str(multi_fragment_path))
+
+    with pytest.raises(Exception, match="(?i)(conflict|preempted)"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            stale_source,
+            columns=["value"],
+            read_version=old_version,
+        )
+
+    latest_dataset = lance.dataset(str(multi_fragment_path))
+    assert latest_dataset.version == newer_dataset.version
+    assert latest_dataset.to_table().sort_by("id").column("value").to_pylist() == [
+        101,
+        101,
+        101,
+        101,
+    ]
+
+
+def test_update_columns_from_defaults_to_source_version_after_rename(
+    multi_fragment_path: Path,
+) -> None:
+    def update_id_one(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        selected = table.filter(
+            pc.equal(
+                table.column("id"),
+                pa.scalar(1, type=table.schema.field("id").type),
+            )
+        )
+        return selected.set_column(
+            selected.schema.get_field_index("value"),
+            "value",
+            pa.array(
+                [999] * selected.num_rows, type=selected.schema.field("value").type
+            ),
+        )
+
+    stale_source = lr.read_lance(
+        str(multi_fragment_path),
+        with_metadata=True,
+    ).map_batches(update_id_one, batch_format="pyarrow")
+    stale_source._set_name("caller-owned-name")
+
+    lance.dataset(str(multi_fragment_path)).update({"value": "101"})
+    newer_dataset = lance.dataset(str(multi_fragment_path))
+
+    with pytest.raises(Exception, match="(?i)(conflict|preempted)"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            stale_source,
+            columns=["value"],
+        )
+
+    latest_dataset = lance.dataset(str(multi_fragment_path))
+    assert latest_dataset.version == newer_dataset.version
+    assert latest_dataset.to_table().sort_by("id").column("value").to_pylist() == [
+        101,
+        101,
+        101,
+        101,
+    ]
+
+
+def test_update_columns_from_defaults_to_union_source_version(
+    multi_fragment_path: Path,
+) -> None:
+    def update_values(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        return table.set_column(
+            table.schema.get_field_index("value"),
+            "value",
+            pa.array([999] * table.num_rows, type=table.schema.field("value").type),
+        )
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True)
+    stale_source = (
+        source.filter(lambda row: row["id"] <= 2)
+        .union(source.filter(lambda row: row["id"] > 2))
+        .map_batches(update_values, batch_format="pyarrow")
+    )
+
+    lance.dataset(str(multi_fragment_path)).update({"value": "101"})
+    newer_dataset = lance.dataset(str(multi_fragment_path))
+
+    with pytest.raises(Exception, match="(?i)(conflict|preempted)"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            stale_source,
+            columns=["value"],
+        )
+
+    latest_dataset = lance.dataset(str(multi_fragment_path))
+    assert latest_dataset.version == newer_dataset.version
+    assert latest_dataset.to_table().sort_by("id").column("value").to_pylist() == [
+        101,
+        101,
+        101,
+        101,
+    ]
+
+
+def test_update_columns_from_rejects_union_of_different_source_versions(
+    multi_fragment_path: Path,
+) -> None:
+    old_source = lr.read_lance(str(multi_fragment_path), with_metadata=True).filter(
+        lambda row: row["id"] <= 2
+    )
+
+    lance.dataset(str(multi_fragment_path)).update({"value": "101"})
+    latest_dataset = lance.dataset(str(multi_fragment_path))
+    new_source = lr.read_lance(str(multi_fragment_path), with_metadata=True).filter(
+        lambda row: row["id"] > 2
+    )
+    mixed_source = old_source.union(new_source)
+
+    with pytest.raises(ValueError, match="multiple Lance source versions"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            mixed_source,
+            columns=["value"],
+        )
+
+    result = lance.dataset(str(multi_fragment_path))
+    assert result.version == latest_dataset.version
+    assert result.to_table().sort_by("id").column("value").to_pylist() == [
+        101,
+        101,
+        101,
+        101,
+    ]
+
+
+def test_update_columns_from_requires_version_without_source_lineage(
+    multi_fragment_path: Path,
+) -> None:
+    def update_values(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        return table.set_column(
+            table.schema.get_field_index("value"),
+            "value",
+            pa.array([999] * table.num_rows, type=table.schema.field("value").type),
+        )
+
+    read_version = lance.dataset(str(multi_fragment_path)).version
+    materialized_source = lr.read_lance(
+        str(multi_fragment_path), with_metadata=True
+    ).materialize()
+    source = materialized_source.map_batches(update_values, batch_format="pyarrow")
+
+    with pytest.raises(ValueError, match="'read_version' is required"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["value"],
+        )
+
+    lr.update_columns_from(
+        str(multi_fragment_path),
+        source,
+        columns=["value"],
+        read_version=read_version,
+    )
+
+    result = lance.dataset(str(multi_fragment_path)).to_table().sort_by("id")
+    assert result.column("value").to_pylist() == [999, 999, 999, 999]
+
+
+def test_update_columns_from_rejects_source_version_mismatch(
+    multi_fragment_path: Path,
+) -> None:
+    old_version = lance.dataset(str(multi_fragment_path)).version
+    lance.dataset(str(multi_fragment_path)).update({"value": "101"})
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True)
+
+    with pytest.raises(ValueError, match="Source Dataset was read from Lance version"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["value"],
+            read_version=old_version,
+        )
+
+
+def test_update_columns_from_projects_columns_before_groupby(
+    multi_fragment_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    grouped_column_names: list[list[str]] = []
+    original_groupby = Dataset.groupby
+
+    def capturing_groupby(
+        self: Dataset,
+        key: str | list[str] | None,
+        num_partitions: int | None = None,
+    ) -> object:
+        schema = self.schema()
+        grouped_column_names.append([] if schema is None else list(schema.names))
+        return original_groupby(self, key, num_partitions)
+
+    monkeypatch.setattr(Dataset, "groupby", capturing_groupby)
+
+    def add_unused_and_update(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        updated = table.set_column(
+            table.schema.get_field_index("value"),
+            "value",
+            pa.array([999] * table.num_rows, type=table.schema.field("value").type),
+        )
+        return updated.append_column(
+            "embedding",
+            pa.array([[0.0] * 8] * table.num_rows, type=pa.list_(pa.float32(), 8)),
+        )
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        add_unused_and_update,
+        batch_format="pyarrow",
+    )
+
+    lr.update_columns_from(
+        str(multi_fragment_path),
+        source,
+        columns=["value"],
+    )
+
+    assert grouped_column_names
+    assert set(grouped_column_names[-1]) == {"_fragid", "_rowaddr", "value"}
+
+    result = lance.dataset(str(multi_fragment_path)).to_table().sort_by("id")
+    assert result.column("value").to_pylist() == [999, 999, 999, 999]
+
+
+def test_update_columns_from_rejects_different_source_dataset(
+    tmp_path: Path,
+) -> None:
+    def write_dataset(name: str) -> Path:
+        path = tmp_path / name
+        data = pd.DataFrame(
+            {
+                "id": [1, 2, 3, 4],
+                "name": ["Alice", "Bob", "Charlie", "Dave"],
+                "value": [10, 20, 30, 40],
+            }
+        )
+        lance.write_dataset(pa.Table.from_pandas(data), str(path), max_rows_per_file=2)
+        return path
+
+    source_path = write_dataset("source.lance")
+    target_path = write_dataset("target.lance")
+    source_dataset = lance.dataset(str(source_path))
+    target_dataset = lance.dataset(str(target_path))
+    assert source_dataset.version == target_dataset.version == 1
+
+    def update_values(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        return table.set_column(
+            table.schema.get_field_index("value"),
+            "value",
+            pa.array([999] * table.num_rows, type=table.schema.field("value").type),
+        )
+
+    source = lr.read_lance(str(source_path), with_metadata=True).map_batches(
+        update_values,
+        batch_format="pyarrow",
+    )
+    target_before = target_dataset.to_table().sort_by("id")
+
+    with pytest.raises(ValueError, match="different Lance dataset"):
+        lr.update_columns_from(
+            str(target_path),
+            source,
+            columns=["value"],
+        )
+
+    result = lance.dataset(str(target_path))
+    assert result.version == target_dataset.version
+    assert result.to_table().sort_by("id") == target_before
+
+
+def test_update_columns_from_accepts_normalized_target_uri(
+    multi_fragment_path: Path,
+) -> None:
+    def update_values(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        return table.set_column(
+            table.schema.get_field_index("value"),
+            "value",
+            pa.array([999] * table.num_rows, type=table.schema.field("value").type),
+        )
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        update_values,
+        batch_format="pyarrow",
+    )
+
+    lr.update_columns_from(
+        f"{multi_fragment_path}/",
+        source,
+        columns=["value"],
+    )
+
+    result = lance.dataset(str(multi_fragment_path)).to_table().sort_by("id")
+    assert result.column("value").to_pylist() == [999, 999, 999, 999]
+
+
+def test_update_columns_from_rejects_union_of_different_source_datasets(
+    tmp_path: Path,
+) -> None:
+    def write_dataset(name: str) -> Path:
+        path = tmp_path / name
+        data = pd.DataFrame(
+            {
+                "id": [1, 2],
+                "value": [10, 20],
+            }
+        )
+        lance.write_dataset(pa.Table.from_pandas(data), str(path), max_rows_per_file=1)
+        return path
+
+    first_path = write_dataset("first.lance")
+    second_path = write_dataset("second.lance")
+    first_dataset = lance.dataset(str(first_path))
+    second_dataset = lance.dataset(str(second_path))
+    assert first_dataset.version == second_dataset.version == 1
+
+    mixed_source = lr.read_lance(str(first_path), with_metadata=True).union(
+        lr.read_lance(str(second_path), with_metadata=True)
+    )
+
+    with pytest.raises(ValueError, match="multiple Lance source datasets"):
+        lr.update_columns_from(
+            str(first_path),
+            mixed_source,
+            columns=["value"],
+        )
+
+    result = lance.dataset(str(first_path))
+    assert result.version == first_dataset.version
+    assert result.to_table().sort_by("id") == first_dataset.to_table().sort_by("id")
+
+
+def test_update_columns_from_updates_multiple_columns(
+    multi_fragment_path: Path,
+) -> None:
+    def update_batch(batch: DataBatch) -> pd.DataFrame:
+        frame = cast(pd.DataFrame, batch).copy()
+        frame.loc[frame["id"] == 2, "name"] = "Bobby"
+        frame.loc[frame["id"] == 4, "name"] = "David"
+        frame.loc[frame["id"] == 2, "value"] = 202
+        frame.loc[frame["id"] == 4, "value"] = 404
+        return frame
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        update_batch, batch_format="pandas"
+    )
+
+    lr.update_columns_from(
+        str(multi_fragment_path),
+        source,
+        columns=["name", "value"],
+    )
+
+    result = (
+        lr.read_lance(str(multi_fragment_path))
+        .to_pandas()
+        .sort_values("id")
+        .reset_index(drop=True)
+    )
+
+    assert result["name"].tolist() == ["Alice", "Bobby", "Charlie", "David"]
+    assert result["value"].tolist() == [10, 202, 30, 404]
+
+
+def test_update_columns_from_ignores_unmatched_rowaddr(
+    multi_fragment_path: Path,
+) -> None:
+    def replace_rowaddr(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        rowaddrs = table.column("_rowaddr").to_pylist()
+        values = table.column("value").to_pylist()
+        ids = table.column("id").to_pylist()
+        for index, row_id in enumerate(ids):
+            if row_id == 1:
+                frag_id = table.column("_fragid")[index].as_py()
+                rowaddrs[index] = (frag_id << 32) | 0xFFFFFFFF
+                values[index] = 999
+        return table.set_column(
+            table.schema.get_field_index("_rowaddr"),
+            "_rowaddr",
+            pa.array(rowaddrs, type=pa.uint64()),
+        ).set_column(
+            table.schema.get_field_index("value"),
+            "value",
+            pa.array(values, type=table.schema.field("value").type),
+        )
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        replace_rowaddr, batch_format="pyarrow"
+    )
+
+    lr.update_columns_from(
+        str(multi_fragment_path),
+        source,
+        columns=["value"],
+    )
+
+    result = (
+        lr.read_lance(str(multi_fragment_path))
+        .to_pandas()
+        .sort_values("id")
+        .reset_index(drop=True)
+    )
+    assert result["value"].tolist() == [10, 20, 30, 40]
+
+
+def test_update_columns_from_uses_requested_read_version(
+    multi_fragment_path: Path,
+) -> None:
+    def update_selected_rows(batch: DataBatch) -> pd.DataFrame:
+        frame = cast(pd.DataFrame, batch).copy()
+        frame.loc[frame["id"] == 1, "value"] = 101
+        frame.loc[frame["id"] == 3, "value"] = 303
+        return frame
+
+    read_version = lance.dataset(str(multi_fragment_path)).version
+    source = lr.read_lance(
+        str(multi_fragment_path),
+        dataset_options={"version": read_version},
+        with_metadata=True,
+    ).map_batches(update_selected_rows, batch_format="pandas")
+
+    lr.update_columns_from(
+        str(multi_fragment_path),
+        source,
+        columns=["value"],
+        read_version=read_version,
+    )
+
+    result = lance.dataset(str(multi_fragment_path))
+    assert result.version == read_version + 1
+    assert result.to_table().sort_by("id").column("value").to_pylist() == [
+        101,
+        20,
+        303,
+        40,
+    ]
+
+
+def test_update_columns_from_uses_tag_as_read_version(
+    multi_fragment_path: Path,
+) -> None:
+    def update_selected_rows(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        values = table.column("value").to_pylist()
+        ids = table.column("id").to_pylist()
+        updated_values = [
+            202 if row_id == 2 else value
+            for row_id, value in zip(ids, values, strict=True)
+        ]
+        return table.set_column(
+            table.schema.get_field_index("value"),
+            "value",
+            pa.array(updated_values, type=table.schema.field("value").type),
+        )
+
+    tag = "update-base"
+    tagged_version = lance.dataset(str(multi_fragment_path)).version
+    lance.dataset(str(multi_fragment_path)).tags.create(tag, tagged_version)
+    source = lr.read_lance(
+        str(multi_fragment_path),
+        dataset_options={"version": tag},
+        with_metadata=True,
+    ).map_batches(update_selected_rows, batch_format="pyarrow")
+
+    lr.update_columns_from(
+        str(multi_fragment_path),
+        source,
+        columns=["value"],
+        read_version=tag,
+    )
+
+    result = lance.dataset(str(multi_fragment_path))
+    assert result.version == tagged_version + 1
+    assert result.to_table().sort_by("id").column("value").to_pylist() == [
+        10,
+        202,
+        30,
+        40,
+    ]
+
+
+def test_update_columns_from_does_not_retry_commit_conflict(
+    multi_fragment_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True)
+    commit_calls = 0
+
+    def fail_commit(*args: object, **kwargs: object) -> None:
+        nonlocal commit_calls
+        commit_calls += 1
+        raise RuntimeError("concurrent update conflict")
+
+    monkeypatch.setattr(LanceDataset, "commit", fail_commit)
+
+    with pytest.raises(RuntimeError, match="concurrent update conflict"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["value"],
+        )
+
+    assert commit_calls == 1
+
+
+def test_update_columns_from_requires_dataset(multi_fragment_path: Path) -> None:
+    with pytest.raises(ValueError, match="'ds' must be provided"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            columns=["value"],
+        )
+
+
+def test_update_columns_from_requires_rowaddr(multi_fragment_path: Path) -> None:
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=False)
+
+    with pytest.raises(ValueError, match="_rowaddr"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["value"],
+        )
+
+
+def test_update_columns_from_requires_columns(multi_fragment_path: Path) -> None:
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True)
+
+    with pytest.raises(ValueError, match="'columns' must be non-empty"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=[],
+        )
+
+
+def test_update_columns_from_rejects_duplicate_columns(
+    multi_fragment_path: Path,
+) -> None:
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True)
+
+    with pytest.raises(ValueError, match="Duplicate columns"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["value", "value"],
+        )
+
+
+def test_update_columns_from_rejects_duplicate_rowaddr(
+    multi_fragment_path: Path,
+) -> None:
+    def duplicate_updates(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        conflicting = table.set_column(
+            table.schema.get_field_index("value"),
+            "value",
+            pc.add(table.column("value"), 1000),
+        )
+        return pa.concat_tables([table, conflicting])
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        duplicate_updates,
+        batch_format="pyarrow",
+    )
+
+    with pytest.raises(RayTaskError, match="Duplicate _rowaddr.*fragment"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["value"],
+        )
+
+
+def test_update_columns_from_rejects_null_rowaddr(
+    multi_fragment_path: Path,
+) -> None:
+    def null_first_rowaddr(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        rowaddrs = table.column("_rowaddr").to_pylist()
+        rowaddrs[0] = None
+        return table.set_column(
+            table.schema.get_field_index("_rowaddr"),
+            "_rowaddr",
+            pa.array(rowaddrs, type=pa.uint64()),
+        )
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        null_first_rowaddr,
+        batch_format="pyarrow",
+    )
+
+    with pytest.raises(RayTaskError, match="Null _rowaddr.*fragment"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["value"],
+        )
+
+
+def test_update_columns_from_rejects_null_rowaddr_without_fragid(
+    multi_fragment_path: Path,
+) -> None:
+    source = ray.data.from_arrow(
+        pa.table(
+            {
+                "_rowaddr": pa.array([None], type=pa.uint64()),
+                "value": pa.array([10], type=pa.int64()),
+            }
+        )
+    )
+
+    with pytest.raises(RayTaskError, match="Null _rowaddr"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["value"],
+        )
+
+
+def test_update_columns_from_rejects_non_integer_rowaddr(
+    multi_fragment_path: Path,
+) -> None:
+    def cast_rowaddr_to_string(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        return table.set_column(
+            table.schema.get_field_index("_rowaddr"),
+            "_rowaddr",
+            pc.cast(table.column("_rowaddr"), pa.string()),
+        )
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        cast_rowaddr_to_string,
+        batch_format="pyarrow",
+    )
+
+    with pytest.raises(ValueError, match="_rowaddr.*integer"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["value"],
+        )
+
+
+def test_update_columns_from_rejects_update_column_type_mismatch(
+    multi_fragment_path: Path,
+) -> None:
+    def cast_value_to_float64(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        return table.set_column(
+            table.schema.get_field_index("value"),
+            "value",
+            pc.cast(table.column("value"), pa.float64()),
+        )
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        cast_value_to_float64,
+        batch_format="pyarrow",
+    )
+
+    with pytest.raises(ValueError, match="type mismatch.*value"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["value"],
+        )
+
+
+def test_update_columns_from_rejects_pandas_object_type_mismatch(
+    multi_fragment_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def cast_value_to_object(batch: DataBatch) -> pd.DataFrame:
+        frame = cast(pd.DataFrame, batch).copy()
+        frame["value"] = frame["value"].astype(str)
+        return frame
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        cast_value_to_object,
+        batch_format="pandas",
+    )
+    source_schema = cast(Schema | None, source.schema())
+    assert source_schema is not None
+    source_types = dict(zip(source_schema.names, source_schema.types, strict=True))
+    assert source_types["value"] is object
+
+    original_schema = Dataset.schema
+    masked_arrow_schema = False
+
+    def retain_ambiguous_pandas_schema(
+        self: Dataset,
+        fetch_if_missing: bool = True,
+    ) -> Schema | None:
+        nonlocal masked_arrow_schema
+        schema = cast(Schema | None, original_schema(self, fetch_if_missing))
+        if schema is None or masked_arrow_schema or not fetch_if_missing:
+            return schema
+        schema_types = dict(zip(schema.names, schema.types, strict=True))
+        if schema_types.get("value") == pa.string():
+            # Model a lazy Pandas plan whose driver schema remains ambiguous
+            # even though the worker receives a concrete Arrow string column.
+            masked_arrow_schema = True
+            return source_schema
+        return schema
+
+    monkeypatch.setattr(Dataset, "schema", retain_ambiguous_pandas_schema)
+
+    version_before = lance.dataset(str(multi_fragment_path)).version
+    with pytest.raises(RayTaskError, match="type mismatch.*value"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["value"],
+        )
+
+    assert masked_arrow_schema
+    assert lance.dataset(str(multi_fragment_path)).version == version_before
+
+
+def test_update_columns_from_with_batch_size_one(multi_fragment_path: Path) -> None:
+    def update_values(batch: DataBatch) -> pd.DataFrame:
+        frame = cast(pd.DataFrame, batch).copy()
+        frame["value"] += 100
+        return frame
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        update_values,
+        batch_format="pandas",
+    )
+
+    lr.update_columns_from(
+        str(multi_fragment_path),
+        source,
+        columns=["value"],
+        batch_size=1,
+    )
+
+    result = (
+        lr.read_lance(str(multi_fragment_path))
+        .to_pandas()
+        .sort_values("id")
+        .reset_index(drop=True)
+    )
+    assert result["value"].tolist() == [110, 120, 130, 140]
+
+
+def test_update_columns_from_forwards_ray_remote_args(
+    multi_fragment_path: Path,
+) -> None:
+    def update_values(batch: DataBatch) -> pd.DataFrame:
+        frame = cast(pd.DataFrame, batch).copy()
+        frame["value"] += 100
+        return frame
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        update_values,
+        batch_format="pandas",
+    )
+
+    lr.update_columns_from(
+        str(multi_fragment_path),
+        source,
+        columns=["value"],
+        ray_remote_args={"num_cpus": 1},
+    )
+
+    result = (
+        lr.read_lance(str(multi_fragment_path))
+        .to_pandas()
+        .sort_values("id")
+        .reset_index(drop=True)
+    )
+    assert result["value"].tolist() == [110, 120, 130, 140]
+
+
+@pytest.mark.parametrize("batch_size", [0, -1])
+def test_update_columns_from_rejects_invalid_batch_size(
+    multi_fragment_path: Path,
+    batch_size: int,
+) -> None:
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True)
+
+    with pytest.raises(ValueError, match="'batch_size' must be positive"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["value"],
+            batch_size=batch_size,
+        )
+
+
+def test_update_columns_from_supports_row_filter(
+    multi_fragment_path: Path,
+) -> None:
+    def update_value(batch: DataBatch) -> pd.DataFrame:
+        frame = cast(pd.DataFrame, batch).copy()
+        frame["value"] = 101
+        return frame
+
+    source = (
+        lr.read_lance(str(multi_fragment_path), with_metadata=True)
+        .filter(lambda row: row["id"] == 1)
+        .map_batches(update_value, batch_format="pandas")
+    )
+
+    lr.update_columns_from(
+        str(multi_fragment_path),
+        source,
+        columns=["value"],
+    )
+
+    result = (
+        lr.read_lance(str(multi_fragment_path))
+        .to_pandas()
+        .sort_values("id")
+        .reset_index(drop=True)
+    )
+    assert result["value"].tolist() == [101, 20, 30, 40]
+
+
+def test_update_columns_from_normalizes_signed_integer_metadata(
+    multi_fragment_path: Path,
+) -> None:
+    def cast_metadata_and_update(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        table = table.set_column(
+            table.schema.get_field_index("_rowaddr"),
+            "_rowaddr",
+            pc.cast(table.column("_rowaddr"), pa.int64()),
+        ).set_column(
+            table.schema.get_field_index("_fragid"),
+            "_fragid",
+            pc.cast(table.column("_fragid"), pa.int64()),
+        )
+        return table.set_column(
+            table.schema.get_field_index("value"),
+            "value",
+            pc.add(
+                table.column("value"),
+                pa.scalar(100, type=table.schema.field("value").type),
+            ),
+        )
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        cast_metadata_and_update,
+        batch_format="pyarrow",
+    )
+    source_schema = source.schema()
+    assert source_schema is not None
+    source_types = dict(zip(source_schema.names, source_schema.types, strict=True))
+    assert source_types["_rowaddr"] == pa.int64()
+    assert source_types["_fragid"] == pa.int64()
+
+    lr.update_columns_from(
+        str(multi_fragment_path),
+        source,
+        columns=["value"],
+    )
+
+    result = lance.dataset(str(multi_fragment_path)).to_table().sort_by("id")
+    assert result.column("value").to_pylist() == [110, 120, 130, 140]
+
+
+@pytest.mark.parametrize("metadata_column", ["_rowaddr", "_fragid"])
+def test_update_columns_from_rejects_negative_signed_metadata(
+    multi_fragment_path: Path,
+    metadata_column: str,
+) -> None:
+    def make_first_value_negative(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        values = table.column(metadata_column).to_pylist()
+        values[0] = -1
+        return table.set_column(
+            table.schema.get_field_index(metadata_column),
+            metadata_column,
+            pa.array(values, type=pa.int64()),
+        )
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        make_first_value_negative,
+        batch_format="pyarrow",
+    )
+    version_before = lance.dataset(str(multi_fragment_path)).version
+
+    with pytest.raises(RayTaskError, match="-1"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["value"],
+        )
+
+    assert lance.dataset(str(multi_fragment_path)).version == version_before
+
+
+def test_update_columns_from_derives_missing_fragid(
+    multi_fragment_path: Path,
+) -> None:
+    def drop_fragid_and_update(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        values = table.column("value").to_pylist()
+        updated_values = [101 if value == 10 else value for value in values]
+        return table.drop_columns(["_fragid"]).set_column(
+            table.schema.get_field_index("value"),
+            "value",
+            pa.array(updated_values, type=table.schema.field("value").type),
+        )
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        drop_fragid_and_update, batch_format="pyarrow"
+    )
+
+    lr.update_columns_from(
+        str(multi_fragment_path),
+        source,
+        columns=["value"],
+    )
+
+    result = (
+        lr.read_lance(str(multi_fragment_path))
+        .to_pandas()
+        .sort_values("id")
+        .reset_index(drop=True)
+    )
+    assert result["value"].tolist() == [101, 20, 30, 40]
+
+
+@pytest.mark.parametrize("metadata_column", ["_rowaddr", "_fragid", "_rowid"])
+def test_update_columns_from_rejects_metadata_column(
+    multi_fragment_path: Path,
+    metadata_column: str,
+) -> None:
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True)
+
+    with pytest.raises(ValueError, match="Metadata columns"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=[metadata_column],
+        )
+
+
+def test_update_columns_from_rejects_rowid_present_in_source(
+    multi_fragment_path: Path,
+) -> None:
+    def add_rowid(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        return table.append_column(
+            "_rowid",
+            pa.array(range(table.num_rows), type=pa.uint64()),
+        )
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        add_rowid,
+        batch_format="pyarrow",
+    )
+
+    with pytest.raises(ValueError, match="Metadata columns"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["_rowid"],
+        )
+
+
+def test_update_columns_from_rejects_missing_column(
+    multi_fragment_path: Path,
+) -> None:
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True)
+
+    with pytest.raises(ValueError, match="missing requested update columns"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["missing"],
+        )
+
+
+def test_update_columns_from_rejects_column_missing_from_target(
+    multi_fragment_path: Path,
+) -> None:
+    def add_missing_column(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        return table.append_column(
+            "missing",
+            pa.array([1] * table.num_rows, type=pa.int64()),
+        )
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        add_missing_column, batch_format="pyarrow"
+    )
+
+    with pytest.raises(ValueError, match="do not exist in target"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["missing"],
+        )
+
+
+def test_update_columns_from_rejects_inconsistent_fragid(
+    multi_fragment_path: Path,
+) -> None:
+    def replace_fragid(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        return table.set_column(
+            table.schema.get_field_index("_fragid"),
+            "_fragid",
+            pa.array([999] * table.num_rows, type=pa.uint64()),
+        )
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        replace_fragid, batch_format="pyarrow"
+    )
+
+    with pytest.raises(RayTaskError, match="_fragid.*does not match _rowaddr"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["value"],
+        )
+
+
+def test_update_columns_from_rejects_non_integer_fragid(
+    multi_fragment_path: Path,
+) -> None:
+    def cast_fragid_to_string(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        return table.set_column(
+            table.schema.get_field_index("_fragid"),
+            "_fragid",
+            pc.cast(table.column("_fragid"), pa.string()),
+        )
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        cast_fragid_to_string,
+        batch_format="pyarrow",
+    )
+
+    with pytest.raises(ValueError, match="_fragid.*integer"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["value"],
+        )
+
+
+def test_update_columns_from_rejects_null_fragid(
+    multi_fragment_path: Path,
+) -> None:
+    def null_first_fragid(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        fragids = table.column("_fragid").to_pylist()
+        fragids[0] = None
+        return table.set_column(
+            table.schema.get_field_index("_fragid"),
+            "_fragid",
+            pa.array(fragids, type=pa.uint64()),
+        )
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        null_first_fragid,
+        batch_format="pyarrow",
+    )
+
+    with pytest.raises(RayTaskError, match="Null _fragid"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["value"],
+        )
+
+
+def test_update_columns_from_rejects_cross_group_duplicate_rowaddr(
+    multi_fragment_path: Path,
+) -> None:
+    def duplicate_with_other_fragid(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        other_fragids = pc.bit_wise_xor(
+            pc.cast(pc.shift_right(table.column("_rowaddr"), 32), pa.uint64()),
+            pa.scalar(1, type=pa.uint64()),
+        )
+        conflicting = table.set_column(
+            table.schema.get_field_index("_fragid"),
+            "_fragid",
+            other_fragids,
+        )
+        return pa.concat_tables([table, conflicting])
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        duplicate_with_other_fragid,
+        batch_format="pyarrow",
+    )
+
+    with pytest.raises(RayTaskError, match="_fragid.*does not match _rowaddr"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["value"],
+        )
+
+
+def test_update_columns_from_worker_failure_does_not_commit_partial_updates(
+    multi_fragment_path: Path,
+) -> None:
+    dataset = lance.dataset(str(multi_fragment_path))
+    read_version = dataset.version
+    original = dataset.to_table().sort_by("id")
+    valid_frag_id = dataset.get_fragments()[0].metadata.id
+    missing_frag_id = (
+        max(fragment.metadata.id for fragment in dataset.get_fragments()) + 1
+    )
+    source = ray.data.from_arrow(
+        pa.table(
+            {
+                "_rowaddr": pa.array(
+                    [valid_frag_id << 32, missing_frag_id << 32],
+                    type=pa.uint64(),
+                ),
+                "value": pa.array([999, 888], type=pa.int64()),
+            }
+        )
+    )
+
+    with pytest.raises(RayTaskError, match=f"Fragment {missing_frag_id} not found"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["value"],
+            read_version=read_version,
+        )
+
+    result = lance.dataset(str(multi_fragment_path))
+    assert result.version == read_version
+    assert result.to_table().sort_by("id") == original
+
+
+def test_update_columns_from_warns_for_empty_source(
+    multi_fragment_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).filter(
+        lambda row: False
+    )
+    version_before = lance.dataset(str(multi_fragment_path)).version
+
+    lr.update_columns_from(
+        str(multi_fragment_path),
+        source,
+        columns=["value"],
+    )
+
+    assert "No rows to update" in caplog.text
+    assert lance.dataset(str(multi_fragment_path)).version == version_before
+
+
+def test_update_columns_from_supports_null_column_updates(
+    multi_fragment_path: Path,
+) -> None:
+    def update_with_null(batch: DataBatch) -> pa.Table:
+        table = cast(pa.Table, batch)
+        ids = table.column("id").to_pylist()
+        values = table.column("value").to_pylist()
+        updated_values = [
+            None if row_id == 1 else value
+            for row_id, value in zip(ids, values, strict=True)
+        ]
+        return table.set_column(
+            table.schema.get_field_index("value"),
+            "value",
+            pa.array(updated_values, type=table.schema.field("value").type),
+        )
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True).map_batches(
+        update_with_null, batch_format="pyarrow"
+    )
+
+    lr.update_columns_from(
+        str(multi_fragment_path),
+        source,
+        columns=["value"],
+    )
+
+    result = lance.dataset(str(multi_fragment_path)).to_table().sort_by("id")
+    assert result.column("value").to_pylist() == [None, 20, 30, 40]
+
+
+def test_update_columns_from_supports_nested_column_updates(tmp_path: Path) -> None:
+    path = tmp_path / "nested_columns.lance"
+    list_type = pa.list_(pa.int64())
+    struct_type = pa.struct([pa.field("score", pa.int64())])
+    table = pa.table(
+        {
+            "id": pa.array([1, 2], type=pa.int64()),
+            "items": pa.array([[1], [2, 3]], type=list_type),
+            "profile": pa.array([{"score": 1}, {"score": 2}], type=struct_type),
+        }
+    )
+    lance.write_dataset(table, str(path), max_rows_per_file=1)
+
+    def update_nested_columns(batch: DataBatch) -> pa.Table:
+        source = cast(pa.Table, batch)
+        ids = source.column("id").to_pylist()
+        items = source.column("items").to_pylist()
+        profiles = source.column("profile").to_pylist()
+        item_updates = [
+            [10, 11] if row_id == 1 else value
+            for row_id, value in zip(ids, items, strict=True)
+        ]
+        profile_updates = [
+            {"score": 101} if row_id == 1 else value
+            for row_id, value in zip(ids, profiles, strict=True)
+        ]
+        return source.set_column(
+            source.schema.get_field_index("items"),
+            "items",
+            pa.array(item_updates, type=list_type),
+        ).set_column(
+            source.schema.get_field_index("profile"),
+            "profile",
+            pa.array(profile_updates, type=struct_type),
+        )
+
+    source = lr.read_lance(str(path), with_metadata=True).map_batches(
+        update_nested_columns,
+        batch_format="pyarrow",
+    )
+
+    lr.update_columns_from(
+        str(path),
+        source,
+        columns=["items", "profile"],
+    )
+
+    result = lance.dataset(str(path)).to_table().sort_by("id")
+    assert result.column("items").to_pylist() == [[10, 11], [2, 3]]
+    assert result.column("profile").to_pylist() == [
+        {"score": 101},
+        {"score": 2},
+    ]
+
+
+def test_update_columns_from_empty_source_without_fragid(
+    multi_fragment_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    source = ray.data.from_arrow(
+        pa.table(
+            {
+                "_rowaddr": pa.array([], type=pa.uint64()),
+                "value": pa.array([], type=pa.int64()),
+            }
+        )
+    )
+    version_before = lance.dataset(str(multi_fragment_path)).version
+
+    lr.update_columns_from(
+        str(multi_fragment_path),
+        source,
+        columns=["value"],
+    )
+
+    assert "No rows to update" in caplog.text
+    assert lance.dataset(str(multi_fragment_path)).version == version_before
+
+
+@pytest.mark.parametrize(
+    ("namespace_impl", "table_id"),
+    [
+        (None, None),
+        ("dir", None),
+        (None, ["table"]),
+    ],
+)
+def test_update_columns_from_requires_uri_or_complete_namespace(
+    multi_fragment_path: Path,
+    namespace_impl: str | None,
+    table_id: list[str] | None,
+) -> None:
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True)
+
+    with pytest.raises(ValueError, match="Must provide either 'uri'"):
+        lr.update_columns_from(
+            ds=source,
+            columns=["value"],
+            namespace_impl=namespace_impl,
+            table_id=table_id,
+        )
+
+
+def test_update_columns_from_rejects_uri_and_namespace(
+    multi_fragment_path: Path,
+) -> None:
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True)
+
+    with pytest.raises(ValueError, match="Cannot provide both 'uri'"):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=["value"],
+            namespace_impl="dir",
+            namespace_properties={"root": str(multi_fragment_path.parent)},
+            table_id=["table"],
+        )
+
+
+def test_update_columns_from_namespace_mode(tmp_path: Path) -> None:
+    table_id = ["update_columns_namespace"]
+    data = pd.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "value": [10, 20, 30],
+        }
+    )
+    lr.write_lance(
+        ray.data.from_pandas(data),
+        namespace_impl="dir",
+        namespace_properties={"root": str(tmp_path)},
+        table_id=table_id,
+        min_rows_per_file=1,
+        max_rows_per_file=2,
+    )
+
+    def update_batch(batch: DataBatch) -> pd.DataFrame:
+        frame = cast(pd.DataFrame, batch).copy()
+        frame.loc[frame["id"] == 2, "value"] = 200
+        return frame
+
+    source = lr.read_lance(
+        namespace_impl="dir",
+        namespace_properties={"root": str(tmp_path)},
+        table_id=table_id,
+        with_metadata=True,
+    ).map_batches(update_batch, batch_format="pandas")
+
+    lr.update_columns_from(
+        ds=source,
+        columns=["value"],
+        namespace_impl="dir",
+        namespace_properties={"root": str(tmp_path)},
+        table_id=table_id,
+    )
+
+    result = (
+        lr.read_lance(
+            namespace_impl="dir",
+            namespace_properties={"root": str(tmp_path)},
+            table_id=table_id,
+        )
+        .to_pandas()
+        .sort_values("id")
+        .reset_index(drop=True)
+    )
+    assert result["value"].tolist() == [10, 200, 30]
+
+
+def test_update_columns_from_reads_uri_and_updates_via_namespace(
+    tmp_path: Path,
+) -> None:
+    import lance_namespace as ln
+    from lance_namespace import DescribeTableRequest
+
+    table_id = ["update_columns_uri_source"]
+    data = pd.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "value": [10, 20, 30],
+        }
+    )
+    lr.write_lance(
+        ray.data.from_pandas(data),
+        namespace_impl="dir",
+        namespace_properties={"root": str(tmp_path)},
+        table_id=table_id,
+        min_rows_per_file=1,
+        max_rows_per_file=2,
+    )
+
+    namespace = ln.connect("dir", {"root": str(tmp_path)})
+    location = namespace.describe_table(DescribeTableRequest(id=table_id)).location
+    assert location is not None
+
+    def update_batch(batch: DataBatch) -> pd.DataFrame:
+        frame = cast(pd.DataFrame, batch).copy()
+        frame.loc[frame["id"] == 2, "value"] = 200
+        return frame
+
+    source = lr.read_lance(location, with_metadata=True).map_batches(
+        update_batch,
+        batch_format="pandas",
+    )
+
+    lr.update_columns_from(
+        ds=source,
+        columns=["value"],
+        namespace_impl="dir",
+        namespace_properties={"root": str(tmp_path)},
+        table_id=table_id,
+    )
+
+    result = (
+        lr.read_lance(
+            namespace_impl="dir",
+            namespace_properties={"root": str(tmp_path)},
+            table_id=table_id,
+        )
+        .to_pandas()
+        .sort_values("id")
+        .reset_index(drop=True)
+    )
+    assert result["value"].tolist() == [10, 200, 30]
+
+
+def test_update_columns_from_forwards_storage_options(
+    multi_fragment_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage_options = {"timeout": "60s"}
+    opened_storage_options: list[dict[str, str] | None] = []
+    committed_storage_options: list[dict[str, str] | None] = []
+    original_init = LanceDataset.__init__
+    original_commit = LanceDataset.commit
+
+    def capturing_init(
+        self: LanceDataset,
+        uri: str | Path,
+        *args: object,
+        storage_options: dict[str, str] | None = None,
+        **kwargs: object,
+    ) -> None:
+        opened_storage_options.append(storage_options)
+        original_init(self, uri, *args, storage_options=storage_options, **kwargs)
+
+    def capturing_commit(
+        base_uri: str | Path | LanceDataset,
+        operation: object,
+        *args: object,
+        storage_options: dict[str, str] | None = None,
+        **kwargs: object,
+    ) -> LanceDataset:
+        committed_storage_options.append(storage_options)
+        return original_commit(
+            base_uri,
+            operation,
+            *args,
+            storage_options=storage_options,
+            **kwargs,
+        )
+
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True)
+    monkeypatch.setattr(LanceDataset, "__init__", capturing_init)
+    monkeypatch.setattr(LanceDataset, "commit", capturing_commit)
+
+    lr.update_columns_from(
+        str(multi_fragment_path),
+        source,
+        columns=["value"],
+        storage_options=storage_options,
+    )
+
+    assert storage_options in opened_storage_options
+    assert committed_storage_options == [storage_options]

--- a/tests/test_update_columns_from.py
+++ b/tests/test_update_columns_from.py
@@ -798,12 +798,14 @@ def test_update_columns_from_rejects_null_rowaddr_without_fragid(
             }
         )
     )
+    read_version = lance.dataset(str(multi_fragment_path)).version
 
     with pytest.raises(RayTaskError, match="Null _rowaddr"):
         lr.update_columns_from(
             str(multi_fragment_path),
             source,
             columns=["value"],
+            read_version=read_version,
         )
 
 
@@ -882,15 +884,12 @@ def test_update_columns_from_rejects_pandas_object_type_mismatch(
     ) -> Schema | None:
         nonlocal masked_arrow_schema
         schema = cast(Schema | None, original_schema(self, fetch_if_missing))
-        if schema is None or masked_arrow_schema or not fetch_if_missing:
+        if schema is None or "value" not in schema.names:
             return schema
-        schema_types = dict(zip(schema.names, schema.types, strict=True))
-        if schema_types.get("value") == pa.string():
-            # Model a lazy Pandas plan whose driver schema remains ambiguous
-            # even though the worker receives a concrete Arrow string column.
-            masked_arrow_schema = True
-            return source_schema
-        return schema
+        # Model a lazy Pandas plan whose driver schema remains ambiguous
+        # even though the worker receives a concrete Arrow string column.
+        masked_arrow_schema = True
+        return source_schema
 
     monkeypatch.setattr(Dataset, "schema", retain_ambiguous_pandas_schema)
 

--- a/tests/test_update_columns_from.py
+++ b/tests/test_update_columns_from.py
@@ -345,6 +345,26 @@ def test_update_columns_from_requires_version_without_source_lineage(
     assert result.column("value").to_pylist() == [999, 999, 999, 999]
 
 
+def test_update_columns_from_source_lineage_does_not_expose_uri(
+    multi_fragment_path: Path,
+) -> None:
+    source = lr.read_lance(str(multi_fragment_path), with_metadata=True)
+    logical_plan = cast(Any, source)._logical_plan
+    source_name = logical_plan.sources()[0].name
+
+    assert str(multi_fragment_path) not in source_name
+    assert "lance_ray_source_id=" in source_name
+
+    lr.update_columns_from(
+        str(multi_fragment_path),
+        source,
+        columns=["value"],
+    )
+
+    result = lance.dataset(str(multi_fragment_path)).to_table().sort_by("id")
+    assert result.column("value").to_pylist() == [10, 20, 30, 40]
+
+
 def test_update_columns_from_rejects_source_version_mismatch(
     multi_fragment_path: Path,
 ) -> None:

--- a/tests/test_update_columns_from.py
+++ b/tests/test_update_columns_from.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import lance
 import lance_ray as lr
@@ -1339,6 +1339,51 @@ def test_update_columns_from_warns_for_empty_source(
     )
 
     assert "No rows to update" in caplog.text
+    assert lance.dataset(str(multi_fragment_path)).version == version_before
+
+
+@pytest.mark.parametrize(
+    ("source_columns", "requested_columns", "error_match"),
+    [
+        pytest.param(
+            {"value": pa.array([], type=pa.int64())},
+            ["value"],
+            "must contain '_rowaddr'",
+            id="missing-rowaddr",
+        ),
+        pytest.param(
+            {"_rowaddr": pa.array([], type=pa.uint64())},
+            ["missing"],
+            "missing requested update columns",
+            id="missing-source-column",
+        ),
+        pytest.param(
+            {
+                "_rowaddr": pa.array([], type=pa.uint64()),
+                "missing": pa.array([], type=pa.int64()),
+            },
+            ["missing"],
+            "do not exist in target",
+            id="missing-target-column",
+        ),
+    ],
+)
+def test_update_columns_from_validates_empty_source(
+    multi_fragment_path: Path,
+    source_columns: dict[str, Any],
+    requested_columns: list[str],
+    error_match: str,
+) -> None:
+    source = ray.data.from_arrow(pa.table(source_columns))
+    version_before = lance.dataset(str(multi_fragment_path)).version
+
+    with pytest.raises(ValueError, match=error_match):
+        lr.update_columns_from(
+            str(multi_fragment_path),
+            source,
+            columns=requested_columns,
+        )
+
     assert lance.dataset(str(multi_fragment_path)).version == version_before
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -514,6 +514,8 @@ source = { editable = "." }
 dependencies = [
     { name = "lance-namespace" },
     { name = "more-itertools", marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packaging" },
     { name = "pyarrow" },
     { name = "pylance" },
@@ -548,6 +550,7 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.0.0" },
     { name = "more-itertools", marker = "python_full_version < '3.12'", specifier = ">=2.6.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=2.3.0" },
+    { name = "numpy", specifier = ">=1.26" },
     { name = "packaging" },
     { name = "pandas-stubs", marker = "extra == 'dev'" },
     { name = "pyarrow", specifier = ">=17.0.0" },


### PR DESCRIPTION
## Summary

- Add `lance_ray.update_columns_from()` for fragment-local updates of existing columns using Lance row addresses.
- Validate source metadata and schemas before grouping updates by fragment with Ray Data.
- Commit updates once against the source snapshot so conflicts cannot retry stale fragment metadata.

## Background

Lance Spark exposes `UPDATE COLUMNS FROM`, which updates existing columns by matching row metadata. Unlike `MERGE INTO`, it uses Lance's fragment update path and avoids a global hash join and full-row rewrites.

Lance-Ray currently has additive data-evolution APIs (`add_columns`, `add_columns_from`, and `merge_columns_from`), but no equivalent fragment-level API for updating existing columns. This PR adds that primitive.

## API

```python
import lance_ray as lr

source = lr.read_lance("my_dataset.lance", with_metadata=True)
source = source.map_batches(modify_status, batch_format="pandas")

lr.update_columns_from(
    "my_dataset.lance",
    source,
    columns=["status"],
)
```

The source Ray Dataset must contain `_rowaddr` and every requested update column. `_fragid` is optional: it is derived from `_rowaddr` when absent and validated against the encoded fragment ID when supplied.

Unmatched source rows are ignored. This API only updates existing columns; it does not insert, delete, or upsert rows.

## Changes

- `lance_ray/io.py`
  - add `update_columns_from()`
  - validate URI/namespace input, batch size, column names and types, row-address uniqueness, and fragment routing metadata
  - normalize integer `_rowaddr` / `_fragid` values to `uint64`
  - group source rows by `_fragid` and call `fragment.update_columns(..., left_on="_rowaddr", right_on="_rowaddr")`
  - preserve the Lance source version through normal Ray Data transforms when available
  - commit `LanceOperation.Update` once against the resolved source version and surface conflicts without retrying stale work
  - forward Ray remote arguments to `map_groups()`
- `lance_ray/__init__.py`: export `update_columns_from`.
- `docs/src/data-evolution.md`: document the API contract and conflict behavior.
- `tests/test_update_columns_from.py`: cover partial and filtered updates, metadata preservation, schema and row-address validation, source-version conflicts, remote arguments, batch sizing, and namespace mode.

## Validation

- `python -m ruff check lance_ray/io.py lance_ray/__init__.py tests/test_update_columns_from.py`
- `python -m ruff format --check lance_ray/io.py lance_ray/__init__.py tests/test_update_columns_from.py`
- `uv run mypy`
- `pytest tests/test_update_columns_from.py -q`