### PR TITLE
feat: support distributed merge_into

### DIFF
--- a/docs/src/.pages
+++ b/docs/src/.pages
@@ -5,5 +5,6 @@ nav:
   - Write: write.md
   - Index: distributed-indexing.md
   - Compaction: compaction.md
+  - Merge Into: merge_into.md
   - Data Evolution: data-evolution.md
   - Examples: examples.md

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,8 +1,8 @@
 # Lance-Ray Integration
 
-Welcome to the Lance-Ray documentation! 
-Lance-Ray combines the distributed computing capabilities of [Ray](https://ray.io/) 
-with the efficient Lance storage format, 
+Welcome to the Lance-Ray documentation!
+Lance-Ray combines the distributed computing capabilities of [Ray](https://ray.io/)
+with the efficient Lance storage format,
 enabling scalable data processing workflows with optimal performance.
 
 ## Features
@@ -13,6 +13,7 @@ enabling scalable data processing workflows with optimal performance.
 - **Schema Validation**: Automatic schema compatibility checking between Ray and Lance
 - **Flexible Filtering**: Support for complex filtering pushdown on distributed Lance data
 - **Data Evolution**: Support for data evolution to add new columns and distributedly backfill data using a Ray UDF
+- **Merge Into**: Distributed, fragment-parallel merge of a source dataset into a Lance table (update matched, insert unmatched), committed as a single atomic version
 - **Index Maintenance**: Incremental index updates and distributed dataset compaction
 - **Catalog Integration**: Support for working with Lance datasets stored in various catalog services (e.g. Hive MetaStore, Iceberg REST Catalog, Unity, Gravitino, AWS Glue, etc.)
 

--- a/docs/src/merge_into.md
+++ b/docs/src/merge_into.md
@@ -1,0 +1,77 @@
+# Distributed Merge Into
+
+`merge_into` merges a source dataset into a target Lance table by join key: rows whose key already exists in the target are **updated** (all columns replaced), and rows with a new key are **inserted**. It is the distributed counterpart of pylance's `LanceDataset.merge_insert`, designed for sources and targets that are too large to process on a single machine.
+
+The whole operation commits as a **single atomic version** — readers see either the old table or the fully merged table, never an intermediate state.
+
+## How it works
+
+1. **Plan (distributed):** the source is split into chunks; each Ray task maps its keys to their target fragments using batched index lookups on the join key column, then routes rows to per-worker buckets keyed by target fragment (a map-side shuffle). The driver only handles object references and small metadata — source rows never pass through it.
+2. **Apply (distributed):** each Ray task owns a disjoint set of target fragments. Updates are merge-on-read: the task masks the matched rows of every owned fragment with a deletion vector (fragment data files are never rewritten), and appends the replacement values together with unmatched rows as new fragments. Scans filter through the deletion vectors until the next compaction folds them away.
+3. **Commit (driver):** all per-task results are unioned into one `lance.LanceOperation.Update` and committed once, with bounded retries on conflicting concurrent commits.
+
+## `merge_into`
+
+```python
+merge_into(
+    ds,
+    uri=None,
+    *,
+    on,
+    table_id=None,
+    namespace_impl=None,
+    namespace_properties=None,
+    storage_options=None,
+    num_workers=4,
+    num_partitions=None,
+    ray_remote_args=None,
+)
+```
+
+Returns the updated `lance.LanceDataset` at the committed version. When the source produced no updates and no inserts, returns the dataset pinned at the read version (no empty commit).
+
+**Parameters:**
+
+- `ds`: The source rows, as a `ray.data.Dataset` or a `pyarrow.Table`. The source must contain every column of the target schema (columns are reordered/cast as needed) and must not contain null join keys. Duplicate join keys are deduplicated, keeping one arbitrary occurrence per key (which copy survives is unspecified).
+- `uri`: Target dataset URI (either `uri` OR `namespace_impl` + `table_id` required)
+- `on`: Join key column name (required, keyword-only). A scalar index on this column is strongly recommended for large targets (the plan phase falls back to filtered scans without one).
+- `table_id`: Table identifier as a list of strings (requires `namespace_impl`)
+- `namespace_impl`: Namespace implementation type (e.g., `"rest"`, `"dir"`)
+- `namespace_properties`: Properties for connecting to the namespace
+- `storage_options`: Optional storage configuration dictionary
+- `num_workers`: Maximum number of Ray tasks running concurrently in each phase (default: 4). Lower it to reduce peak memory and IO pressure.
+- `num_partitions`: How the work is partitioned — the number of source chunks (plan phase) and fragment buckets (apply phase); default: `num_workers`. Raise it above `num_workers` to get smaller, more granular tasks on a memory-constrained cluster.
+- `ray_remote_args`: Optional kwargs for Ray remote tasks (e.g., `num_cpus`)
+
+## Examples
+
+### Merge a Ray dataset into a table
+
+```python
+import lance_ray as lr
+import ray
+
+source = ray.data.read_parquet("s3://bucket/daily_updates/")
+
+dataset = lr.merge_into(source, "/path/to/table.lance", on="id", num_workers=8)
+print(dataset.version)
+```
+
+### Merge via namespace
+
+```python
+dataset = lr.merge_into(
+    source,
+    on="id",
+    namespace_impl="dir",
+    namespace_properties={"root": "/path/to/tables"},
+    table_id=["my_table"],
+)
+```
+
+## Notes and limitations
+
+- Each source row must match at most one target row. Duplicate source keys are always resolved automatically by a sort-based dedupe pass (a Ray Data sort of the source by key plus a vectorized adjacent-duplicate drop), keeping one arbitrary occurrence per key — which copy survives is unspecified.
+- Concurrent writes: appends that land during the merge_into are tolerated (the commit is retried on the newer version). If a concurrent commit rewrites or removes one of the fragments this merge_into touches (e.g. compaction or another update), the operation fails rather than silently dropping the concurrent change.
+- Concurrent inserts of the same key: Lance's conflict detection is fragment-level, so two concurrent `merge_into` calls inserting the same *new* join key are physically disjoint — both commits succeed and the key is duplicated. Serialize `merge_into` against the same table externally (e.g. one scheduled writer). Key-level conflict detection is discussed as future work in the [design doc](merge-insert-design.md#112-key-level-conflict-detection-isolation-parity-with-native-merge_insert).
+- Create a scalar index (e.g. BTREE) on the join key column before calling `merge_into` on large tables — key-to-fragment planning is served by the index instead of scanning the table.

--- a/lance_ray/__init__.py
+++ b/lance_ray/__init__.py
@@ -23,6 +23,7 @@ from .io import (
     read_lance,
     write_lance,
 )
+from .merge_into import merge_into
 from .pool import clear_global_pool, get_global_pool, init_global_pool, set_global_pool
 from .search import vector_search
 
@@ -37,6 +38,7 @@ __all__ = [
     "add_columns",
     "add_columns_from",
     "merge_columns_from",
+    "merge_into",
     "create_scalar_index",
     "create_index",
     "optimize_indices",

--- a/lance_ray/merge_into.py
+++ b/lance_ray/merge_into.py
@@ -1,0 +1,828 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+"""Distributed merge for Lance datasets on Ray.
+
+This module provides a fragment-parallel, atomic merge: every source row that
+matches a target row on the join key replaces that row (all columns), and
+every source row with no match is inserted. The plan executes across Ray
+workers so that neither the source rows nor the rewritten fragments ever have
+to fit on the driver:
+
+0. DEDUPE (distributed): the source is range-partitioned with a
+   Ray Data sort on the join key -- all copies of a key land adjacent in
+   exactly one block -- and one arbitrary row per key is kept by dropping
+   adjacent duplicates per block. The sort also gives the plan phase
+   contiguous key slices, so each chunk's index lookups stay within few
+   BTREE leaf pages.
+1. PLAN (distributed): each plan task takes one source chunk and maps every
+   join key to its target fragment id using batched ``key IN (...)`` lookups
+   against the target dataset (``_rowaddr >> 32`` = fragment id; served by the
+   scalar index on the key column when one exists). Each plan task then
+   hash-partitions its rows into per-apply-task buckets with a static
+   ownership function -- ``owner(fragment_id) = crc32(fragment_id) % n_apply``
+   -- and returns the buckets as separate Ray objects (a map-side shuffle). The
+   driver only receives small metadata; bucket bytes move from plan node to
+   apply node directly through the Ray object store.
+2. APPLY (distributed): each apply task owns a disjoint set of target
+   fragments (guaranteed by the ownership function). Updates are
+   merge-on-read: for every owned fragment the task writes a *deletion file*
+   marking the matched rows dead (addressed by the ``_rowid`` values from
+   the plan phase, so no fragment data is rescanned), and the replacement
+   values, together with the rows that had
+   no match, are appended as brand-new fragments.
+3. COMMIT (driver): the per-task results are unioned into a single
+   ``lance.LanceOperation.Update`` and committed once, so the whole merge is
+   one atomic version change (all-or-nothing). Conflict detection is
+   fragment-level: concurrent appends are rebased over with bounded retries,
+   while a concurrent commit that touched any fragment this merge modifies
+   fails with an explicit error.
+
+Example:
+    >>> import lance_ray as lr
+    >>> dataset = lr.merge_into(source, "/path/to/table.lance", on="id", num_workers=4)
+    >>> dataset.version
+    5
+"""
+
+import collections
+import logging
+import pickle
+import time
+import zlib
+from typing import Any, Optional
+
+import lance
+import pyarrow as pa
+import pyarrow.compute as pc
+import ray
+import ray.data
+
+from .utils import (
+    get_namespace_kwargs,
+    get_write_fragments_kwargs,
+    resolve_namespace_table,
+    validate_uri_or_namespace,
+)
+
+__all__ = [
+    "merge_into",
+]
+
+logger = logging.getLogger(__name__)
+
+_COMMIT_MAX_RETRIES = 3
+_COMMIT_RETRY_DELAY_S = 1.0
+# Number of join keys per ``IN (...)`` index lookup in the plan phase.
+_LOOKUP_BATCH_SIZE = 10_000
+
+# Helper column shipped inside the plan buckets: the ``_rowid`` of the
+# matched target row, so the apply phase can delete rows directly without
+# rescanning the fragment for the keys. ``_rowid`` (not ``_rowaddr``) is the
+# id ``LanceFragment.delete`` resolves on BOTH dataset flavors: it equals the
+# physical row address on regular datasets and the stable id on
+# stable-row-id datasets (where ``_rowaddr`` predicates do not match).
+_ROWID_COLUMN = "__merge_into_rowid"
+
+
+# ---------------------------------------------------------------------------
+# helpers shared by driver and workers
+# ---------------------------------------------------------------------------
+
+
+def _sql_literal(value: Any) -> str:
+    """Render a join-key value as a SQL literal for an ``IN (...)`` filter."""
+    if isinstance(value, str):
+        return "'" + value.replace("'", "''") + "'"
+    if isinstance(value, bool):
+        return "TRUE" if value else "FALSE"
+    if isinstance(value, int | float):
+        return repr(value)
+    raise TypeError(
+        f"Unsupported join key type {type(value).__name__!r}; "
+        "merge_into currently supports string, integer, and float keys."
+    )
+
+
+def _chunked(seq: list, n: int):
+    for i in range(0, len(seq), n):
+        yield seq[i : i + n]
+
+
+def _align_chunk(chunk: pa.Table, target_schema: pa.Schema, on: str) -> pa.Table:
+    """Project/cast a source chunk to the target schema and validate the key."""
+    missing = [name for name in target_schema.names if name not in chunk.column_names]
+    if missing:
+        raise ValueError(f"Source is missing target-table columns: {missing}")
+    chunk = chunk.select(target_schema.names)
+    if chunk.schema != target_schema:
+        chunk = chunk.cast(target_schema)
+    key_column = chunk.column(on)
+    if key_column.null_count:
+        raise ValueError(f"Source contains null values in join key column {on!r}")
+    return chunk
+
+
+def _raise_on_duplicate_keys(keys: list, on: str, context: str) -> None:
+    if len(keys) != len(set(keys)):
+        raise ValueError(
+            f"Duplicate join keys detected ({context}). Each source row must "
+            f"match at most one target row; the dedupe pass keeps one row "
+            f"per {on!r} key, so this indicates an internal routing error."
+        )
+
+
+def _key_bucket(key: Any, n: int) -> int:
+    """Deterministic key -> bucket assignment for the plan shuffle
+    (apply-task ownership, bucket by fragment id). One property matters:
+
+    - **Process-stable.** Python's built-in ``hash()`` is salted per process,
+      so two tasks running in different Ray workers would disagree on the
+      bucket of the same key; crc32 over ``repr`` is stable everywhere.
+    """
+    return zlib.crc32(repr(key).encode("utf-8")) % n
+
+
+def _drop_adjacent_duplicate_keys(batch: pa.Table, on: str) -> pa.Table:
+    """Keep one row per key within a sorted block (keep-any).
+
+    After ``Dataset.sort(on)`` all copies of a key are adjacent *and* live in
+    the same range partition (Ray's sort assigns each key to exactly one
+    half-open boundary range), so dropping adjacent duplicates per block is a
+    complete, global dedupe.
+    """
+    keys = batch.column(on)
+    if keys.null_count:
+        raise ValueError(f"Source contains null values in join key column {on!r}")
+    n = batch.num_rows
+    if n <= 1:
+        return batch
+    changed = pc.not_equal(keys.slice(1), keys.slice(0, n - 1))
+    chunks = changed.chunks if isinstance(changed, pa.ChunkedArray) else [changed]
+    mask = pa.chunked_array([pa.array([True]), *chunks])
+    return batch.filter(mask)
+
+
+# ---------------------------------------------------------------------------
+# Ray tasks (module-level so they are picklable)
+# ---------------------------------------------------------------------------
+
+
+@ray.remote
+def _plan_task(
+    task_id: int,
+    uri: str,
+    read_version: int,
+    on: str,
+    storage_options: Optional[dict[str, Any]],
+    namespace_impl: Optional[str],
+    namespace_properties: Optional[dict[str, str]],
+    table_id: Optional[list[str]],
+    source_chunk: pa.Table,
+    target_schema: pa.Schema,
+    n_apply: int,
+):
+    """PLAN + map-side shuffle: map keys to target fragments, bucket by owner.
+
+    Declared with ``num_returns=n_apply + 1`` at the call site: the first
+    ``n_apply`` returns are the bucket payloads
+    ``{"frags": {fragment_id: rows}, "inserts": rows | None}`` and the last is
+    a small metadata dict. The driver only fetches the metadata; bucket bytes
+    stay in the object store on this node until the owning apply task pulls
+    them. Ownership is a pure function of the fragment id
+    (``crc32(fragment_id) % n_apply``), so every plan task routes a given
+    fragment to the same apply task without coordination -- that is what makes
+    the apply phase write-disjoint by construction. Hashing (rather than a raw
+    modulo) keeps the buckets balanced.
+    """
+    t0 = time.perf_counter()
+    # The dedupe sort can leave some range partitions empty (fewer rows than
+    # partitions); such blocks materialize as zero-column tables, so bail
+    # out before schema alignment.
+    if source_chunk.num_rows == 0:
+        meta = {
+            "label": f"plan-{task_id}",
+            "rows": 0,
+            "matched": 0,
+            "touched_fragments": [],
+            "bucket_rows": [0] * n_apply,
+            "elapsed_s": time.perf_counter() - t0,
+        }
+        return (*({"frags": {}, "inserts": None} for _ in range(n_apply)), meta)
+
+    namespace_kwargs = get_namespace_kwargs(
+        namespace_impl, namespace_properties, table_id
+    )
+    source_chunk = _align_chunk(source_chunk, target_schema, on)
+    keys = source_chunk.column(on).to_pylist()
+    _raise_on_duplicate_keys(keys, on, f"plan task {task_id}")
+
+    dataset = lance.LanceDataset(
+        uri,
+        version=read_version,
+        storage_options=storage_options or None,
+        **namespace_kwargs,
+    )
+    # Batched index lookups: only the key column plus _rowaddr and _rowid
+    # are materialized. _rowaddr >> 32 is the physical fragment id (the
+    # shuffle key); _rowid is what the apply phase deletes by, so matched
+    # rows never have to be re-found by rescanning the fragment.
+    rowinfo_of: dict[Any, tuple[int, int]] = {}  # key -> (fragment id, rowid)
+    for batch in _chunked(keys, _LOOKUP_BATCH_SIZE):
+        in_list = ", ".join(_sql_literal(key) for key in batch)
+        # Backticks are Lance's identifier quoting (double quotes would be
+        # parsed as a string literal by the filter planner).
+        hits = dataset.to_table(
+            columns=[on],
+            filter=f"`{on}` IN ({in_list})",
+            with_row_address=True,
+            with_row_id=True,
+        )
+        for key, rowaddr, rowid in zip(
+            hits.column(on).to_pylist(),
+            hits.column("_rowaddr").to_pylist(),
+            hits.column("_rowid").to_pylist(),
+            strict=False,
+        ):
+            rowinfo_of[key] = (rowaddr >> 32, rowid)
+
+    fragment_ids = [rowinfo_of.get(key, (-1, -1))[0] for key in keys]
+    row_ids = [rowinfo_of.get(key, (-1, -1))[1] for key in keys]
+    num_matched = sum(1 for f in fragment_ids if f != -1)
+
+    # Ship each row's target rowid with it so every bucket slice below
+    # carries the ids of the target rows it replaces (-1 on insert rows).
+    source_chunk = source_chunk.append_column(
+        _ROWID_COLUMN, pa.array(row_ids, type=pa.int64())
+    )
+
+    # Map-side shuffle: route each row to its owner's bucket. Matched rows go
+    # to owner(fragment_id); inserts are spread round-robin.
+    updates_by_owner: list[dict[int, list[int]]] = [
+        collections.defaultdict(list) for _ in range(n_apply)
+    ]
+    inserts_by_owner: list[list[int]] = [[] for _ in range(n_apply)]
+    for i, fragment_id in enumerate(fragment_ids):
+        if fragment_id == -1:
+            inserts_by_owner[i % n_apply].append(i)
+        else:
+            updates_by_owner[_key_bucket(fragment_id, n_apply)][fragment_id].append(i)
+
+    buckets = []
+    bucket_rows: list[int] = []
+    for owner in range(n_apply):
+        frags = {
+            fragment_id: source_chunk.take(indices)
+            for fragment_id, indices in updates_by_owner[owner].items()
+        }
+        inserts = (
+            source_chunk.take(inserts_by_owner[owner])
+            if inserts_by_owner[owner]
+            else None
+        )
+        buckets.append({"frags": frags, "inserts": inserts})
+        bucket_rows.append(
+            sum(t.num_rows for t in frags.values())
+            + (inserts.num_rows if inserts is not None else 0)
+        )
+
+    meta = {
+        "label": f"plan-{task_id}",
+        "rows": len(keys),
+        "matched": num_matched,
+        "touched_fragments": sorted({f for f in fragment_ids if f != -1}),
+        "bucket_rows": bucket_rows,
+        "elapsed_s": time.perf_counter() - t0,
+    }
+    return (*buckets, meta)
+
+
+@ray.remote
+def _apply_task(
+    task_id: int,
+    uri: str,
+    read_version: int,
+    on: str,
+    storage_options: Optional[dict[str, Any]],
+    namespace_impl: Optional[str],
+    namespace_properties: Optional[dict[str, str]],
+    table_id: Optional[list[str]],
+    bucket_refs: list,
+) -> dict[str, Any]:
+    """APPLY: merge-on-read updates for a disjoint set of target fragments.
+
+    ``bucket_refs`` are this task's bucket ObjectRefs from every plan task.
+    They are nested inside a list on purpose so Ray does not resolve them on
+    the driver -- this task fetches them here, i.e. the bytes move from the
+    plan node to this node directly. A fragment's matched rows can arrive from
+    several plan chunks, so per-fragment sub-tables are concatenated first.
+
+    For each owned fragment the task writes
+    a new *deletion file* marking the matched rows dead
+    (``LanceFragment.delete`` by ``_rowid``, using the ids gathered by the
+    plan phase's index lookups, so no fragment data is rescanned and
+    the data files are untouched); the
+    replacement rows and the inserts are appended together as brand-new
+    fragments. A fragment left empty by the deletion is removed instead.
+
+    Returns the parts of the final ``LanceOperation.Update``: removed
+    fragment ids (fully-emptied fragments), pickled metadata of the fragments
+    that received a new deletion file, and pickled metadata of the new
+    fragments it wrote.
+    """
+    t0 = time.perf_counter()
+    payloads = ray.get(bucket_refs)
+    tables_by_fragment: dict[int, list[pa.Table]] = collections.defaultdict(list)
+    insert_parts: list[pa.Table] = []
+    for payload in payloads:
+        for fragment_id, table in payload["frags"].items():
+            tables_by_fragment[fragment_id].append(table)
+        if payload["inserts"] is not None and payload["inserts"].num_rows:
+            # Insert rows carry no useful rowid (-1); strip the helper
+            # column so the appended rows match the target schema.
+            insert_parts.append(payload["inserts"].drop_columns([_ROWID_COLUMN]))
+
+    namespace_kwargs = get_namespace_kwargs(
+        namespace_impl, namespace_properties, table_id
+    )
+    write_kwargs = get_write_fragments_kwargs(
+        namespace_impl, namespace_properties, table_id
+    )
+    dataset = lance.LanceDataset(
+        uri,
+        version=read_version,
+        storage_options=storage_options or None,
+        **namespace_kwargs,
+    )
+    fragment_by_id = {f.fragment_id: f for f in dataset.get_fragments()}
+
+    removed_fragment_ids: list[int] = []
+    updated_fragments: list[bytes] = []
+    replacement_parts: list[pa.Table] = []
+    updated_rows = 0
+    for fragment_id in tables_by_fragment:
+        source_rows = pa.concat_tables(tables_by_fragment[fragment_id])
+        keys = source_rows.column(on).to_pylist()
+        # Duplicates that landed on the same target fragment (possibly from
+        # different plan chunks) are caught here.
+        _raise_on_duplicate_keys(keys, on, f"target fragment {fragment_id}")
+        # Mark the matched rows dead with a deletion file, addressed by the
+        # rowids gathered in the plan phase. A key predicate would force the
+        # delete to rescan and decode the fragment's key column thus avoided.
+        row_ids = source_rows.column(_ROWID_COLUMN).to_pylist()
+        source_rows = source_rows.drop_columns([_ROWID_COLUMN])
+        in_list = ", ".join(str(rowid) for rowid in row_ids)
+        new_meta = fragment_by_id[fragment_id].delete(f"_rowid IN ({in_list})")
+        if new_meta is None:
+            removed_fragment_ids.append(fragment_id)
+        else:
+            updated_fragments.append(pickle.dumps(new_meta))
+        replacement_parts.append(source_rows)
+        updated_rows += source_rows.num_rows
+
+    # Replacement rows and inserts are all full rows in target-schema order
+    # (aligned in the plan phase), so they are appended together in one write.
+    inserted_rows = sum(t.num_rows for t in insert_parts)
+    new_fragments: list[bytes] = []
+    append_parts = replacement_parts + insert_parts
+    if append_parts:
+        append_table = pa.concat_tables(append_parts)
+        fragments = lance.fragment.write_fragments(
+            append_table,
+            uri,
+            mode="append",
+            storage_options=storage_options or None,
+            **write_kwargs,
+        )
+        new_fragments.extend(pickle.dumps(f) for f in fragments)
+
+    return {
+        "label": f"apply-{task_id}",
+        "removed_fragment_ids": removed_fragment_ids,
+        "updated_fragments": updated_fragments,
+        "new_fragments": new_fragments,
+        "updated_rows": updated_rows,
+        "inserted_rows": inserted_rows,
+        "rows": updated_rows + inserted_rows,
+        "elapsed_s": time.perf_counter() - t0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# driver-side scheduling helpers
+# ---------------------------------------------------------------------------
+
+
+def _bounded_map(remote_fn, arg_tuples: list[tuple], max_in_flight: int) -> list[dict]:
+    """Run one Ray task per arg tuple with at most ``max_in_flight`` in flight."""
+    total = len(arg_tuples)
+    results: list[dict] = []
+    pending: list = []
+    i = 0
+    while i < total and len(pending) < max_in_flight:
+        pending.append(remote_fn.remote(*arg_tuples[i]))
+        i += 1
+    while pending:
+        done, pending = ray.wait(pending, num_returns=1)
+        result = ray.get(done[0])
+        results.append(result)
+        if i < total:
+            pending.append(remote_fn.remote(*arg_tuples[i]))
+            i += 1
+    return results
+
+
+def _bounded_map_shuffle(
+    remote_fn, arg_tuples: list[tuple], max_in_flight: int
+) -> list[dict]:
+    """``_bounded_map`` for tasks declared with ``num_returns > 1``.
+
+    Only the last return value (a small metadata dict) is fetched on the
+    driver; the data returns stay in the object store on the producing node
+    and are attached to the metadata as ``meta["bucket_refs"]``. Because the
+    returns are task outputs (not worker-side ``ray.put``), the driver owns
+    them and they survive Ray recycling idle worker processes between phases.
+    """
+    total = len(arg_tuples)
+    results: list[dict] = []
+    pending: dict = {}  # meta ObjectRef -> bucket ObjectRefs
+    i = 0
+
+    def _submit(j: int) -> None:
+        refs = remote_fn.remote(*arg_tuples[j])
+        pending[refs[-1]] = refs[:-1]  # meta is the last return value
+
+    while i < total and len(pending) < max_in_flight:
+        _submit(i)
+        i += 1
+    while pending:
+        ready_meta_refs, _ = ray.wait(list(pending), num_returns=1)
+        bucket_refs = pending.pop(ready_meta_refs[0])
+        meta = ray.get(ready_meta_refs[0])
+        meta["bucket_refs"] = bucket_refs
+        results.append(meta)
+        if i < total:
+            _submit(i)
+            i += 1
+    return results
+
+
+def _commit_update_with_retry(
+    uri: str,
+    operation: "lance.LanceOperation.Update",
+    read_version: int,
+    storage_options: dict[str, Any],
+    namespace_kwargs: dict[str, Any],
+    touched_fragment_ids: set[int],
+) -> "lance.LanceDataset":
+    """Commit an Update operation, retrying on concurrent-commit conflicts.
+
+    A retry is only safe while every fragment this operation touches --
+    removed (fully emptied) or updated with a new deletion file -- still
+    exists in the latest version. If any of them disappeared (e.g. a
+    concurrent compaction or another update rewrote them), rebasing would
+    silently drop the concurrent change, so we fail instead.
+    """
+    last_exc = None
+    for attempt in range(_COMMIT_MAX_RETRIES):
+        try:
+            return lance.LanceDataset.commit(
+                uri,
+                operation,
+                read_version=read_version,
+                storage_options=storage_options or None,
+                **namespace_kwargs,
+            )
+        except Exception as exc:
+            last_exc = exc
+            if attempt < _COMMIT_MAX_RETRIES - 1:
+                time.sleep(_COMMIT_RETRY_DELAY_S * (2**attempt))
+                try:
+                    current = lance.LanceDataset(
+                        uri,
+                        storage_options=storage_options or None,
+                        **namespace_kwargs,
+                    )
+                    current_ids = {f.fragment_id for f in current.get_fragments()}
+                    if not touched_fragment_ids.issubset(current_ids):
+                        raise ValueError(
+                            "Concurrent write detected: fragments "
+                            f"{sorted(touched_fragment_ids - current_ids)} were "
+                            "rewritten or removed by another commit. Cannot "
+                            "safely retry merge_into; re-run it against the "
+                            "latest version."
+                        ) from exc
+                    read_version = current.version
+                except ValueError:
+                    raise
+                except Exception:  # noqa: BLE001 - probe failure, retry blind
+                    pass
+    raise last_exc
+
+
+def _has_scalar_index_on(dataset: "lance.LanceDataset", column: str) -> bool:
+    try:
+        if hasattr(dataset, "describe_indices"):
+            for index in dataset.describe_indices():
+                names = getattr(index, "field_names", None) or []
+                # field_names may render identifiers quoted (e.g. '"id"').
+                if any(name.strip('"') == column for name in names):
+                    return True
+            return False
+        for index in dataset.list_indices():
+            fields = (
+                index.get("fields")
+                if isinstance(index, dict)
+                else getattr(index, "fields", None)
+            )
+            if fields and column in fields:
+                return True
+    except Exception:  # noqa: BLE001 - best effort, only used for a warning
+        return True
+    return False
+
+
+def _source_to_chunk_refs(
+    source: ray.data.Dataset | pa.Table, on: str, num_partitions: int
+) -> list["ray.ObjectRef"]:
+    """Sort-dedupe the source on the join key; return Arrow-table ObjectRefs.
+
+    The source is range-partitioned with a Ray Data sort on the key: all
+    copies of a key land adjacent in exactly one block, so dropping adjacent
+    duplicates per block is a complete global dedupe (one arbitrary row per
+    key survives). The sort also hands the plan phase contiguous key slices,
+    which keeps each chunk's index lookups within few BTREE leaf pages.
+    """
+    if isinstance(source, pa.Table):
+        if source.num_rows == 0:
+            return []
+        source = ray.data.from_arrow(source)
+    elif not isinstance(source, ray.data.Dataset):
+        raise TypeError(
+            "source must be a ray.data.Dataset or a pyarrow.Table, got "
+            f"{type(source).__name__}"
+        )
+    deduped = (
+        source.repartition(num_partitions)
+        .sort(on)
+        .map_batches(
+            _drop_adjacent_duplicate_keys,
+            fn_kwargs={"on": on},
+            batch_size=None,
+            batch_format="pyarrow",
+        )
+        .materialize()
+    )
+    return list(deduped.to_arrow_refs())  # pyright: ignore[reportReturnType]
+
+
+# ---------------------------------------------------------------------------
+# public API
+# ---------------------------------------------------------------------------
+
+
+def merge_into(
+    ds: ray.data.Dataset | pa.Table,
+    uri: Optional[str] = None,
+    *,
+    on: str,
+    table_id: Optional[list[str]] = None,
+    namespace_impl: Optional[str] = None,
+    namespace_properties: Optional[dict[str, str]] = None,
+    storage_options: Optional[dict[str, Any]] = None,
+    num_workers: int = 4,
+    num_partitions: Optional[int] = None,
+    ray_remote_args: Optional[dict[str, Any]] = None,
+) -> "lance.LanceDataset":
+    """Distributed merge of ``ds`` into a Lance dataset.
+
+    Every source row that matches a target row on the ``on`` key replaces
+    that row entirely (all columns), and every source row with no match is
+    inserted. All changes -- across every touched fragment -- are committed
+    as one atomic version; on any failure before the commit, the visible
+    table is untouched.
+
+    This is the distributed counterpart of pylance's
+    ``LanceDataset.merge_insert(on).when_matched_update_all()
+    .when_not_matched_insert_all()``: the source rows are matched to their
+    target fragments with distributed index lookups, and Ray workers apply
+    the updates (each fragment owned by exactly one
+    worker): matched rows are masked out with per-fragment deletion files,
+    and replacement plus insert rows are
+    appended as new fragments. All changes are committed as a single atomic
+    version. Scans filter through the deletion vectors until the next
+    compaction folds them away.
+
+    Concurrency: conflict detection is fragment-level. Concurrent appends
+    that land during the merge_into are tolerated (the commit rebases with
+    bounded retries); a concurrent commit that rewrote or removed any
+    fragment this merge_into touches fails with an explicit error -- re-run
+    against the latest version. Two concurrent merge_into calls inserting
+    the same *new* key are physically disjoint and would both succeed,
+    duplicating the key; serialize merge_into against the same table to
+    avoid this.
+
+    Args:
+        ds: The rows to merge into the target table, as a
+            ``ray.data.Dataset`` or an in-memory ``pyarrow.Table``. The
+            source must contain every column of the target schema (columns
+            are reordered/cast as needed) and must not contain null join
+            keys. Duplicate join keys are deduplicated, keeping one
+            arbitrary occurrence per key (which copy survives is
+            unspecified).
+        uri: The URI of the target Lance dataset. Either ``uri`` OR
+            (``namespace_impl`` + ``table_id``) must be provided.
+        on: The join key column name. A scalar index on this column is
+            strongly recommended for large targets (the plan phase falls
+            back to filtered scans without one).
+        table_id: The table identifier as a list of strings. Must be provided
+            together with ``namespace_impl``.
+        namespace_impl: The namespace implementation type (e.g. ``"rest"``,
+            ``"dir"``), used for resolving the dataset location and credential
+            vending in distributed workers.
+        namespace_properties: Properties for connecting to the namespace.
+        storage_options: Storage options for the dataset.
+        num_workers: Maximum number of Ray tasks running concurrently in each
+            phase (default: 4). Lower it to reduce peak memory and IO
+            pressure without changing how the data is partitioned.
+        num_partitions: How the work is partitioned: the number of source
+            chunks in the plan phase and of fragment buckets in the apply
+            phase (default: ``num_workers``). Unlike ``num_workers``, this is
+            baked into the shuffle layout, so raise it to get smaller,
+            more granular tasks (e.g. ``num_partitions=32`` with
+            ``num_workers=8``).
+        ray_remote_args: Options for the Ray tasks (e.g. ``num_cpus``,
+            ``resources``).
+
+    Returns:
+        The updated :class:`lance.LanceDataset` at the committed version.
+        When the source produced no updates and no inserts, returns the
+        dataset pinned at ``read_version`` (no empty commit).
+
+    Example:
+        >>> import lance_ray as lr
+        >>> dataset = lr.merge_into(
+        ...     daily_batch,                  # ray.data.Dataset or pyarrow.Table
+        ...     "s3://bucket/users.lance",
+        ...     on="user_id",
+        ...     num_workers=8,
+        ... )
+        >>> dataset.version
+        5
+    """
+    if not on:
+        raise ValueError("merge_into requires a join key column name ('on')")
+    if num_workers < 1:
+        raise ValueError("num_workers must be >= 1")
+    if num_partitions is not None and num_partitions < 1:
+        raise ValueError("num_partitions must be >= 1")
+    num_partitions = num_partitions or num_workers
+    ray_remote_args = ray_remote_args or {}
+
+    validate_uri_or_namespace(uri, namespace_impl, table_id)
+    uri, storage_options = resolve_namespace_table(
+        uri,
+        storage_options,
+        namespace_impl,
+        namespace_properties,
+        table_id,
+    )
+    namespace_kwargs = get_namespace_kwargs(
+        namespace_impl, namespace_properties, table_id
+    )
+
+    dataset = lance.LanceDataset(
+        uri,
+        storage_options=storage_options or None,
+        **namespace_kwargs,
+    )
+    read_version = dataset.version
+    target_schema = dataset.schema
+    field_ids = [field.id() for field in dataset.lance_schema.fields()]
+    if on not in target_schema.names:
+        raise ValueError(
+            f"Join key column {on!r} not found in target schema {target_schema.names}"
+        )
+    if not _has_scalar_index_on(dataset, on):
+        logger.warning(
+            "No scalar index found on join key column %r; the merge_into plan "
+            "phase will fall back to filtered scans of the target table. "
+            "Create a scalar index on the key column for large targets.",
+            on,
+        )
+
+    # Phase 0: sort-based dedupe. The deduplicated, range-partitioned blocks
+    # become the plan chunks; every downstream duplicate check then passes
+    # by construction.
+    chunk_refs = _source_to_chunk_refs(ds, on, num_partitions)
+
+    # Phase 1: PLAN + map-side shuffle. Chunk refs are passed as top-level
+    # args (resolved on the worker); each plan task returns num_partitions
+    # bucket objects plus a small metadata dict.
+    plan_remote = _plan_task.options(num_returns=num_partitions + 1, **ray_remote_args)
+    plan_args = [
+        (
+            i,
+            uri,
+            read_version,
+            on,
+            storage_options,
+            namespace_impl,
+            namespace_properties,
+            table_id,
+            chunk_ref,
+            target_schema,
+            num_partitions,
+        )
+        for i, chunk_ref in enumerate(chunk_refs)
+    ]
+    plan_results = (
+        _bounded_map_shuffle(plan_remote, plan_args, num_workers) if plan_args else []
+    )
+    touched_fragment_ids = {
+        f for meta in plan_results for f in meta["touched_fragments"]
+    }
+    logger.info(
+        "merge_into plan done: %d source rows, %d matched, %d fragment(s) touched",
+        sum(meta["rows"] for meta in plan_results),
+        sum(meta["matched"] for meta in plan_results),
+        len(touched_fragment_ids),
+    )
+
+    # Phase 2: route each bucket's ObjectRef to its owning apply task. The
+    # refs are nested in a list on purpose so Ray does not resolve them on
+    # the driver; the apply task fetches them node-to-node itself.
+    apply_args = []
+    for owner in range(num_partitions):
+        bucket_refs = [
+            meta["bucket_refs"][owner]
+            for meta in plan_results
+            if meta["bucket_rows"][owner]
+        ]
+        if bucket_refs:
+            apply_args.append(
+                (
+                    owner,
+                    uri,
+                    read_version,
+                    on,
+                    storage_options,
+                    namespace_impl,
+                    namespace_properties,
+                    table_id,
+                    bucket_refs,
+                )
+            )
+    apply_remote = _apply_task.options(**ray_remote_args)
+    apply_results = (
+        _bounded_map(apply_remote, apply_args, num_workers) if apply_args else []
+    )
+
+    # Phase 3: union the parts into ONE atomic LanceOperation.Update.
+    num_inserted_rows = sum(r["inserted_rows"] for r in apply_results)
+    num_updated_rows = sum(r["updated_rows"] for r in apply_results)
+    if not apply_results:
+        logger.info("merge_into: nothing to update or insert; no commit")
+        return lance.LanceDataset(
+            uri,
+            version=read_version,
+            storage_options=storage_options or None,
+            **namespace_kwargs,
+        )
+
+    removed = [f for r in apply_results for f in r["removed_fragment_ids"]]
+    updated = [pickle.loads(f) for r in apply_results for f in r["updated_fragments"]]
+    new_fragments = [pickle.loads(f) for r in apply_results for f in r["new_fragments"]]
+    touched_ids = removed + [f.id for f in updated]
+    if len(touched_ids) != len(set(touched_ids)):
+        raise RuntimeError(
+            "Internal error: fragment overlap across apply tasks -- the "
+            "assignment is not fragment-disjoint"
+        )
+    operation = lance.LanceOperation.Update(
+        removed_fragment_ids=removed,
+        updated_fragments=updated,
+        new_fragments=new_fragments,
+        fields_modified=[],
+        fields_for_preserving_frag_bitmap=field_ids,
+        update_mode="rewrite_rows",
+    )
+
+    committed = _commit_update_with_retry(
+        uri,
+        operation,
+        read_version,
+        storage_options,
+        namespace_kwargs,
+        set(touched_ids),
+    )
+    logger.info(
+        "merge_into committed version %d: %d row(s) updated, %d row(s) "
+        "inserted, %d fragment(s) deletion-vector-updated, %d removed",
+        committed.version,
+        num_updated_rows,
+        num_inserted_rows,
+        len(updated),
+        len(removed),
+    )
+    return committed

--- a/tests/test_merge_into.py
+++ b/tests/test_merge_into.py
@@ -1,0 +1,515 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+"""Test cases for lance_ray.merge_into (distributed merge_into)."""
+
+import tempfile
+from pathlib import Path
+
+import lance
+import lance_ray as lr
+import pyarrow as pa
+import pytest
+import ray
+
+import pandas as pd
+
+
+@pytest.fixture
+def temp_dir():
+    """Create a temporary directory for testing."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        yield temp_dir
+
+
+def create_dataset_with_fragments(path, fragment_data, **write_kwargs):
+    """Create a Lance dataset where each DataFrame becomes one fragment."""
+    first_df = fragment_data[0]
+    lr.write_lance(
+        ray.data.from_pandas(first_df),
+        str(path),
+        min_rows_per_file=len(first_df),
+        max_rows_per_file=len(first_df),
+        **write_kwargs,
+    )
+    for df in fragment_data[1:]:
+        lr.write_lance(
+            ray.data.from_pandas(df),
+            str(path),
+            mode="append",
+            min_rows_per_file=len(df),
+            max_rows_per_file=len(df),
+            **write_kwargs,
+        )
+    return lance.dataset(str(path))
+
+
+def make_fragments(num_fragments, rows_per_fragment):
+    """DataFrames with ids 0..N-1 and value 'orig_<id>'."""
+    return [
+        pd.DataFrame(
+            {
+                "id": range(i * rows_per_fragment, (i + 1) * rows_per_fragment),
+                "value": [
+                    f"orig_{j}"
+                    for j in range(i * rows_per_fragment, (i + 1) * rows_per_fragment)
+                ],
+            }
+        )
+        for i in range(num_fragments)
+    ]
+
+
+def id_to_value(dataset):
+    table = dataset.to_table()
+    return dict(
+        zip(
+            table.column("id").to_pylist(),
+            table.column("value").to_pylist(),
+            strict=False,
+        )
+    )
+
+
+class TestMergeInto:
+    def test_basic_merge_into(self, temp_dir):
+        """Update rows in several fragments and insert new rows atomically."""
+        path = Path(temp_dir) / "basic_merge_into"
+        dataset = create_dataset_with_fragments(path, make_fragments(3, 10))
+        assert len(dataset.get_fragments()) == 3
+        version_before = dataset.version
+
+        source = pa.table(
+            {
+                "id": [5, 15, 25, 100, 101],
+                "value": ["new_5", "new_15", "new_25", "new_100", "new_101"],
+            }
+        )
+        updated = lr.merge_into(source, str(path), on="id", num_workers=2)
+
+        assert updated.version == version_before + 1, (
+            "merge_into must commit exactly one new version"
+        )
+
+        dataset = updated
+        assert dataset.version == version_before + 1
+        assert dataset.count_rows() == 32
+        values = id_to_value(dataset)
+        assert values[5] == "new_5"
+        assert values[15] == "new_15"
+        assert values[25] == "new_25"
+        assert values[100] == "new_100"
+        assert values[101] == "new_101"
+        # Untouched rows are preserved.
+        assert values[0] == "orig_0"
+        assert values[14] == "orig_14"
+        assert values[29] == "orig_29"
+
+    def test_merge_into_with_ray_dataset_source(self, temp_dir):
+        """The source can be a ray.data.Dataset."""
+        path = Path(temp_dir) / "ray_ds_source"
+        create_dataset_with_fragments(path, make_fragments(2, 10))
+
+        source = ray.data.from_pandas(
+            pd.DataFrame({"id": [3, 13, 50], "value": ["new_3", "new_13", "new_50"]})
+        )
+        updated = lr.merge_into(source, str(path), on="id", num_workers=2)
+
+        dataset = updated
+        assert dataset.count_rows() == 21
+        values = id_to_value(dataset)
+        assert values[3] == "new_3"
+        assert values[13] == "new_13"
+        assert values[50] == "new_50"
+
+    def test_insert_only_source(self, temp_dir):
+        """A source with no matching keys only inserts."""
+        path = Path(temp_dir) / "insert_only"
+        dataset = create_dataset_with_fragments(path, make_fragments(2, 10))
+        version_before = dataset.version
+
+        source = pa.table({"id": [100, 101], "value": ["new_100", "new_101"]})
+        updated = lr.merge_into(source, str(path), on="id", num_workers=2)
+
+        dataset = updated
+        assert dataset.version == version_before + 1
+        assert dataset.count_rows() == 22
+        values = id_to_value(dataset)
+        assert values[100] == "new_100"
+        assert values[101] == "new_101"
+
+    def test_update_only_source(self, temp_dir):
+        """A source where every key matches only updates."""
+        path = Path(temp_dir) / "update_only"
+        create_dataset_with_fragments(path, make_fragments(2, 10))
+
+        source = pa.table({"id": [5, 15], "value": ["new_5", "new_15"]})
+        updated = lr.merge_into(source, str(path), on="id", num_workers=2)
+
+        dataset = updated
+        assert dataset.count_rows() == 20
+        values = id_to_value(dataset)
+        assert values[5] == "new_5"
+        assert values[15] == "new_15"
+
+    def test_empty_source_is_noop(self, temp_dir):
+        """An empty source commits nothing."""
+        path = Path(temp_dir) / "empty_source"
+        dataset = create_dataset_with_fragments(path, make_fragments(1, 10))
+        version_before = dataset.version
+
+        source = pa.table(
+            {"id": pa.array([], pa.int64()), "value": pa.array([], pa.string())}
+        )
+        updated = lr.merge_into(source, str(path), on="id")
+
+        assert updated.version == version_before
+        assert lance.dataset(str(path)).version == updated.version
+
+    def test_more_fragments_than_workers(self, temp_dir):
+        """Fragment routing works when touched fragments outnumber workers."""
+        path = Path(temp_dir) / "many_fragments"
+        dataset = create_dataset_with_fragments(path, make_fragments(8, 5))
+        assert len(dataset.get_fragments()) == 8
+        version_before = dataset.version
+
+        # One update in every fragment (ids 0, 5, 10, ... 35) + two inserts.
+        update_ids = list(range(0, 40, 5))
+        source = pa.table(
+            {
+                "id": update_ids + [1000, 1001],
+                "value": [f"new_{i}" for i in update_ids] + ["new_1000", "new_1001"],
+            }
+        )
+        updated = lr.merge_into(source, str(path), on="id", num_workers=3)
+
+        assert updated.version == version_before + 1, (
+            "All 8 fragment rewrites must land in one atomic commit"
+        )
+        dataset = updated
+        assert dataset.count_rows() == 42
+        values = id_to_value(dataset)
+        for i in update_ids:
+            assert values[i] == f"new_{i}"
+        for i in range(40):
+            if i not in update_ids:
+                assert values[i] == f"orig_{i}"
+
+    def test_more_partitions_than_workers(self, temp_dir):
+        """num_partitions controls layout independently of num_workers."""
+        path = Path(temp_dir) / "partitions_vs_workers"
+        create_dataset_with_fragments(path, make_fragments(4, 5))
+
+        update_ids = [0, 6, 12, 18]
+        source = pa.table(
+            {
+                "id": update_ids + [500, 501, 502],
+                "value": [f"new_{i}" for i in update_ids]
+                + ["new_500", "new_501", "new_502"],
+            }
+        )
+        updated = lr.merge_into(source, str(path), on="id", num_workers=2, num_partitions=6)
+
+        dataset = updated
+        assert dataset.count_rows() == 23
+        values = id_to_value(dataset)
+        for i in update_ids:
+            assert values[i] == f"new_{i}"
+        assert values[500] == "new_500"
+        assert values[502] == "new_502"
+
+    def test_merge_into_with_scalar_index(self, temp_dir):
+        """The plan phase works with a scalar index on the join key."""
+        path = Path(temp_dir) / "with_index"
+        dataset = create_dataset_with_fragments(path, make_fragments(3, 10))
+        dataset.create_scalar_index("id", index_type="BTREE")
+
+        source = pa.table({"id": [7, 17, 27, 200], "value": ["a", "b", "c", "d"]})
+        updated = lr.merge_into(source, str(path), on="id", num_workers=2)
+
+        values = id_to_value(updated)
+        assert values[7] == "a"
+        assert values[17] == "b"
+        assert values[27] == "c"
+        assert values[200] == "d"
+
+    def test_merge_into_with_stable_row_ids(self, temp_dir):
+        """_rowaddr-based planning is correct on stable-row-id datasets."""
+        path = Path(temp_dir) / "stable_row_ids"
+        create_dataset_with_fragments(
+            path, make_fragments(2, 10), enable_stable_row_ids=True
+        )
+
+        source = pa.table({"id": [4, 14, 300], "value": ["new_4", "new_14", "new_300"]})
+        updated = lr.merge_into(source, str(path), on="id", num_workers=2)
+
+        dataset = updated
+        assert dataset.count_rows() == 21
+        values = id_to_value(dataset)
+        assert values[4] == "new_4"
+        assert values[14] == "new_14"
+        assert values[300] == "new_300"
+
+    def test_string_join_keys(self, temp_dir):
+        """String keys (including quotes) are escaped correctly in lookups."""
+        path = Path(temp_dir) / "string_keys"
+        df = pd.DataFrame(
+            {"key": ["alpha", "be'ta", "gamma"], "value": ["1", "2", "3"]}
+        )
+        lr.write_lance(ray.data.from_pandas(df), str(path))
+
+        source = pa.table({"key": ["be'ta", "delta"], "value": ["updated", "inserted"]})
+        updated = lr.merge_into(source, str(path), on="key", num_workers=2)
+
+        table = updated.to_table()
+        values = dict(
+            zip(
+                table.column("key").to_pylist(),
+                table.column("value").to_pylist(),
+                strict=False,
+            )
+        )
+        assert values["be'ta"] == "updated"
+        assert values["delta"] == "inserted"
+
+    def test_merge_into_with_directory_namespace(self, temp_dir):
+        """Namespace-resolved tables work end to end."""
+        import lance_namespace as ln
+        from lance_namespace import DescribeTableRequest
+
+        table_id = ["merge_into_test_table"]
+        df = pd.DataFrame({"id": range(10), "value": [f"orig_{i}" for i in range(10)]})
+        lr.write_lance(
+            ray.data.from_pandas(df),
+            namespace_impl="dir",
+            namespace_properties={"root": temp_dir},
+            table_id=table_id,
+        )
+
+        source = pa.table({"id": [2, 100], "value": ["new_2", "new_100"]})
+        lr.merge_into(
+            source,
+            on="id",
+            namespace_impl="dir",
+            namespace_properties={"root": temp_dir},
+            table_id=table_id,
+            num_workers=2,
+        )
+
+        namespace = ln.connect("dir", {"root": temp_dir})
+        location = namespace.describe_table(DescribeTableRequest(id=table_id)).location
+        values = id_to_value(lance.dataset(location))
+        assert values[2] == "new_2"
+        assert values[100] == "new_100"
+
+
+class TestMergeIntoDedupe:
+    def test_dedupe_within_chunk(self, temp_dir):
+        """Adjacent duplicates collapse to a single row per key."""
+        path = Path(temp_dir) / "dedupe_within_chunk"
+        create_dataset_with_fragments(path, make_fragments(1, 10))
+
+        source = pa.table(
+            {
+                "id": [5, 5, 100, 100],
+                "value": ["first_5", "dup_5", "first_100", "dup_100"],
+            }
+        )
+        updated = lr.merge_into(source, str(path), on="id", num_workers=1, num_partitions=1)
+
+        values = id_to_value(updated)
+        assert values[5] in {"first_5", "dup_5"}
+        assert values[100] in {"first_100", "dup_100"}
+
+    def test_dedupe_across_chunks(self, temp_dir):
+        """Duplicates split across plan chunks collapse to one row per key.
+
+        With num_partitions=4 the source table is sliced into 4 chunks, so
+        the duplicate pairs (row 0 vs row 19, row 1 vs row 18) land in
+        different chunks -- exactly the blind spot dedupe closes. Which copy
+        survives is unspecified.
+        """
+        path = Path(temp_dir) / "dedupe_across_chunks"
+        dataset = create_dataset_with_fragments(path, make_fragments(2, 10))
+        version_before = dataset.version
+
+        ids = [5, 200] + list(range(300, 316)) + [200, 5]
+        values = (
+            ["first_5", "first_200"]
+            + [f"v_{i}" for i in range(300, 316)]
+            + ["dup_200", "dup_5"]
+        )
+        source = pa.table({"id": ids, "value": values})
+        updated = lr.merge_into(source, str(path), on="id", num_workers=2, num_partitions=4)
+
+        assert updated.version == version_before + 1
+        dataset = updated
+        table = dataset.to_table()
+        assert table.column("id").to_pylist().count(5) == 1
+        assert table.column("id").to_pylist().count(200) == 1
+        got = id_to_value(dataset)
+        assert got[5] in {"first_5", "dup_5"}
+        assert got[200] in {"first_200", "dup_200"}
+
+    def test_dedupe_with_ray_dataset_source(self, temp_dir):
+        """Dedupe works when the source is a ray.data.Dataset."""
+        path = Path(temp_dir) / "dedupe_ray_ds"
+        create_dataset_with_fragments(path, make_fragments(1, 10))
+
+        source = ray.data.from_pandas(
+            pd.DataFrame(
+                {"id": [3, 50, 3, 50], "value": ["first_3", "first_50", "b", "c"]}
+            )
+        )
+        updated = lr.merge_into(source, str(path), on="id", num_workers=2)
+
+        values = id_to_value(updated)
+        assert values[3] in {"first_3", "b"}
+        assert values[50] in {"first_50", "c"}
+
+    def test_dedupe_noop_on_unique_source(self, temp_dir):
+        """A source without duplicates is unchanged by the dedupe pass."""
+        path = Path(temp_dir) / "dedupe_unique"
+        create_dataset_with_fragments(path, make_fragments(2, 10))
+
+        source = pa.table({"id": [5, 15, 100], "value": ["new_5", "new_15", "new_100"]})
+        updated = lr.merge_into(source, str(path), on="id", num_workers=2)
+
+        values = id_to_value(updated)
+        assert values[5] == "new_5"
+        assert values[15] == "new_15"
+        assert values[100] == "new_100"
+
+    def test_dedupe_string_keys(self, temp_dir):
+        """Sort-based dedupe handles string keys across chunks."""
+        path = Path(temp_dir) / "dedupe_string_keys"
+        df = pd.DataFrame({"key": ["alpha", "beta"], "value": ["1", "2"]})
+        lr.write_lance(ray.data.from_pandas(df), str(path))
+
+        source = pa.table(
+            {
+                "key": ["alpha", "x1", "x2", "x3", "x4", "x5", "x6", "alpha"],
+                "value": ["first", "a", "b", "c", "d", "e", "f", "dup"],
+            }
+        )
+        updated = lr.merge_into(
+            source, str(path), on="key", num_workers=2, num_partitions=4
+        )
+
+        table = updated.to_table()
+        values = dict(
+            zip(
+                table.column("key").to_pylist(),
+                table.column("value").to_pylist(),
+                strict=False,
+            )
+        )
+        assert values["alpha"] in {"first", "dup"}
+
+
+class TestMergeIntoMergeOnRead:
+    def test_update_writes_deletion_vector_not_rewrite(self, temp_dir):
+        """A partial update must never rewrite the fragment's data files."""
+        path = Path(temp_dir) / "mor_partial_update"
+        dataset = create_dataset_with_fragments(path, make_fragments(2, 10))
+        files_before = {
+            f.fragment_id: [d.path for d in f.metadata.files]
+            for f in dataset.get_fragments()
+        }
+
+        source = pa.table({"id": [5, 100], "value": ["new_5", "new_100"]})
+        updated = lr.merge_into(source, str(path), on="id", num_workers=2)
+
+        dataset = updated
+        frags_after = {f.fragment_id: f.metadata for f in dataset.get_fragments()}
+        for fragment_id, files in files_before.items():
+            assert fragment_id in frags_after, (
+                "Partially-updated fragments must survive (merge-on-read)"
+            )
+            assert [d.path for d in frags_after[fragment_id].files] == files, (
+                "Data files must never be rewritten by an update"
+            )
+        touched = frags_after[5 // 10]  # id 5 lives in the first fragment
+        assert touched.deletion_file is not None, (
+            "The matched row must be masked by a deletion file"
+        )
+        values = id_to_value(dataset)
+        assert values[5] == "new_5"
+        assert values[100] == "new_100"
+        assert dataset.count_rows() == 21
+
+    def test_full_fragment_update_removes_fragment(self, temp_dir):
+        """Updating every row of a fragment removes it instead of keeping an
+        all-dead deletion vector."""
+        path = Path(temp_dir) / "mor_full_update"
+        dataset = create_dataset_with_fragments(path, make_fragments(2, 5))
+        ids_before = {f.fragment_id for f in dataset.get_fragments()}
+        first_fragment_id = min(ids_before)
+
+        source = pa.table(
+            {"id": list(range(5)), "value": [f"new_{i}" for i in range(5)]}
+        )
+        updated = lr.merge_into(source, str(path), on="id", num_workers=2)
+
+        dataset = updated
+        ids_after = {f.fragment_id for f in dataset.get_fragments()}
+        assert first_fragment_id not in ids_after, (
+            "A fully-updated fragment must be removed, not kept empty"
+        )
+        assert dataset.count_rows() == 10
+        values = id_to_value(dataset)
+        assert all(values[i] == f"new_{i}" for i in range(5))
+        assert all(values[i] == f"orig_{i}" for i in range(5, 10))
+
+
+class TestMergeIntoValidation:
+    def test_requires_uri_or_namespace(self):
+        with pytest.raises(ValueError, match="Must provide either"):
+            lr.merge_into(pa.table({"id": [1]}), on="id")
+
+    def test_rejects_uri_and_namespace(self):
+        with pytest.raises(ValueError, match="Cannot provide both"):
+            lr.merge_into(
+                pa.table({"id": [1]}),
+                "/tmp/x.lance",
+                on="id",
+                namespace_impl="dir",
+                table_id=["t"],
+            )
+
+    def test_rejects_empty_on(self):
+        with pytest.raises(ValueError, match="join key"):
+            lr.merge_into(pa.table({"id": [1]}), "/tmp/x.lance", on="")
+
+    def test_rejects_unknown_key_column(self, temp_dir):
+        path = Path(temp_dir) / "unknown_key"
+        create_dataset_with_fragments(path, make_fragments(1, 5))
+        source = pa.table({"id": [1], "value": ["x"]})
+        with pytest.raises(ValueError, match="not found in target schema"):
+            lr.merge_into(source, str(path), on="missing_column")
+
+    def test_rejects_missing_source_columns(self, temp_dir):
+        path = Path(temp_dir) / "missing_columns"
+        create_dataset_with_fragments(path, make_fragments(1, 5))
+        source = pa.table({"id": [1]})  # no "value" column
+        with pytest.raises(Exception, match="missing target-table columns"):
+            lr.merge_into(source, str(path), on="id")
+
+    def test_rejects_null_source_keys(self, temp_dir):
+        path = Path(temp_dir) / "null_keys"
+        create_dataset_with_fragments(path, make_fragments(1, 5))
+        source = pa.table({"id": [1, None], "value": ["a", "b"]})
+        with pytest.raises(Exception, match="null values in join key"):
+            lr.merge_into(source, str(path), on="id", num_workers=1)
+
+    def test_rejects_bad_source_type(self, temp_dir):
+        path = Path(temp_dir) / "bad_source"
+        create_dataset_with_fragments(path, make_fragments(1, 5))
+        with pytest.raises(TypeError, match="ray.data.Dataset or a pyarrow.Table"):
+            lr.merge_into([{"id": 1}], str(path), on="id")
+
+    def test_rejects_bad_worker_counts(self):
+        with pytest.raises(ValueError, match="num_workers"):
+            lr.merge_into(pa.table({"id": [1]}), "/tmp/x.lance", on="id", num_workers=0)
+        with pytest.raises(ValueError, match="num_partitions"):
+            lr.merge_into(pa.table({"id": [1]}), "/tmp/x.lance", on="id", num_partitions=0)


### PR DESCRIPTION
## Summary

Adds `lance_ray.merge_into` for large-scale, daily merge ingestions: match a source batch to a Lance table on a join key, update existing rows, and insert new ones, committed as a single atomic version.

It is the distributed counterpart of pylance’s `LanceDataset.merge_insert(on).when_matched_update_all().when_not_matched_insert_all()`, for Ray jobs where the source and target are too large to process on a single machine. Unlike lance-spark’s `MERGE INTO`, which shuffle-joins the source against the target, this path probes a scalar index (BTREE is preferred) to map each source key to its target fragment, then applies updates.

## How it works

1. **Dedupe** — sort the source on the join key across Ray and keep one row per key.
2. **Plan** — each worker maps its keys to target fragment ids with batched index lookups (`key IN (...)`, served by a BTREE/scalar index when present), then shuffles rows to the worker that owns that fragment.
3. **Apply** — matched rows are masked with per-fragment deletion files (data files are not rewritten); replacements and inserts are appended as new fragments.
4. **Commit** — one `LanceOperation.Update` on the driver. Concurrent appends rebase; a concurrent rewrite of a touched fragment fails rather than silently dropping the other write.

```python
import lance_ray as lr

dataset = lr.merge_into(daily_batch, "s3://bucket/users.lance", on="user_id", num_workers=128)
```

A scalar index on the join key is strongly recommended for large targets.

## Performance

Measured merging **1M source rows into a 2.5B-row table** with a **BTREE** index on the join key, using **64 Ray workers (2 cpu each)**:

| Phase | Time |
|---|---|
| Dedupe (repartition + sort + drop dups) | 11.0 s |
| Plan (index probe) | 36.1 s |
| Apply + commit | 2.7 s |
| **Total** | **49.8 s** |

Peak memory **~5.5 GB**.

<img width="1403" height="342" alt="Screenshot 2026-08-18 at 6 27 10 PM" src="https://github.com/user-attachments/assets/50c87d48-74fe-4b8d-84d8-9e3911ebb202" />

## Test plan

- [x] `uv run pytest tests/test_merge_into.py`
- [x] `uv run ruff check lance_ray tests`
- [x] `uv run ruff format --check lance_ray tests`