### PR TITLE
test: support ray >= 2.56 Arrow-backed pandas conversion

### DIFF
--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -1,6 +1,10 @@
 """Shared helpers for tests."""
 
 import inspect
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def missing_fragment_write_options(*options: str) -> tuple[str, ...]:
@@ -17,3 +21,28 @@ def fragment_write_options_skip_reason(*options: str) -> str:
         "option(s) on lance.fragment.write_fragments: "
         f"{', '.join(missing)}"
     )
+
+
+def to_numpy_backed(df: "pd.DataFrame") -> "pd.DataFrame":
+    """Convert Arrow-backed columns of ``df`` back to numpy dtypes.
+
+    Ray 2.56 made ``Dataset.to_pandas()`` map Arrow types onto
+    ``pd.ArrowDtype`` (``DataContext.enable_arrow_backed_pandas_conversion``,
+    on by default). That changes the dtypes a frame reports and surfaces nulls
+    as ``pd.NA`` rather than ``None``, so assertions written against plain
+    pandas frames and Python values normalise through this helper first.
+
+    On Ray < 2.56 there is nothing to convert and ``df`` is returned unchanged,
+    which keeps the assertions meaningful on both sides of that release.
+    """
+    import pyarrow as pa
+
+    import pandas as pd
+
+    if not any(isinstance(dtype, pd.ArrowDtype) for dtype in df.dtypes):
+        return df
+
+    table = pa.Table.from_pandas(df, preserve_index=False)
+    # ``from_pandas`` records the Arrow-backed origin in the schema metadata and
+    # ``to_pandas`` would faithfully restore it, so drop the metadata first.
+    return table.replace_schema_metadata(None).to_pandas()

--- a/tests/test_basic_read_write.py
+++ b/tests/test_basic_read_write.py
@@ -18,6 +18,7 @@ import pandas as pd
 from _utils import (
     fragment_write_options_skip_reason,
     missing_fragment_write_options,
+    to_numpy_backed,
 )
 
 sys.path.insert(
@@ -265,7 +266,7 @@ class TestReadWrite:
 
         # Read it back
         read_dataset = lr.read_lance(str(path))
-        read_df = read_dataset.to_pandas()
+        read_df = read_dataset.to_pandas().pipe(to_numpy_backed)
 
         # Compare data (sort by id to ensure consistent order)
         original_sorted = sample_data.sort_values("id").reset_index(drop=True)
@@ -397,7 +398,7 @@ class TestNamespaceReadWrite:
             namespace_properties={"root": temp_dir},
             table_id=table_id,
         )
-        read_df = read_dataset.to_pandas()
+        read_df = read_dataset.to_pandas().pipe(to_numpy_backed)
 
         original_sorted = sample_data.sort_values("id").reset_index(drop=True)
         read_sorted = read_df.sort_values("id").reset_index(drop=True)

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -29,6 +29,7 @@ import pytest
 import ray
 
 import pandas as pd
+from _utils import to_numpy_backed
 
 # Skip cleanly if Lance isn't available in the environment
 pytest.importorskip("lance")
@@ -97,7 +98,7 @@ def test_single_blob_roundtrip(temp_dir: str) -> None:
 
     # Read back via lance-ray
     ds_read = lr.read_lance(str(path))
-    df = ds_read.to_pandas()
+    df = ds_read.to_pandas().pipe(to_numpy_backed)
 
     # Sort by id to ensure consistent order
     df_sorted = df.sort_values("id").reset_index(drop=True)
@@ -138,7 +139,7 @@ def test_multi_blob_roundtrip(temp_dir: str) -> None:
 
     # Read back via lance-ray
     ds_read = lr.read_lance(str(path))
-    df = ds_read.to_pandas()
+    df = ds_read.to_pandas().pipe(to_numpy_backed)
 
     # Sort by id to ensure consistent order
     df_sorted = df.sort_values("id").reset_index(drop=True)
@@ -177,7 +178,7 @@ def test_jpg_blob_integration(
 
     # Read back via lance-ray
     ds_read = lr.read_lance(str(path))
-    df = ds_read.to_pandas()
+    df = ds_read.to_pandas().pipe(to_numpy_backed)
     df_sorted = df.sort_values("id").reset_index(drop=True)
 
     # Validate blob bytes and other columns
@@ -227,7 +228,7 @@ def test_blob_projection_and_filter(temp_dir: str) -> None:
 
     # Read only blob column with a filter
     ds_read = lr.read_lance(str(path), columns=["blob"], filter="id >= 12")
-    df = ds_read.to_pandas()
+    df = ds_read.to_pandas().pipe(to_numpy_backed)
     assert df.columns.tolist() == ["blob"]
 
     # Expected values for id >= 12 -> ["c", "d"]
@@ -263,7 +264,7 @@ def test_multi_blob_projection_and_filter(temp_dir: str) -> None:
 
     # Read only blob columns with a filter on id
     ds_read = lr.read_lance(str(path), columns=["blob1", "blob2"], filter="id >= 2")
-    df = ds_read.to_pandas()
+    df = ds_read.to_pandas().pipe(to_numpy_backed)
     assert df.columns.tolist() == ["blob1", "blob2"]
 
     # Expected values for id >= 2 -> index 2,3,4
@@ -321,11 +322,16 @@ def test_stream_copy_basic_local(temp_dir: str) -> None:
     assert src.schema == dst.schema
 
     src_df = (
-        ray.data.from_arrow(table).to_pandas().sort_values("id").reset_index(drop=True)
+        ray.data.from_arrow(table)
+        .to_pandas()
+        .pipe(to_numpy_backed)
+        .sort_values("id")
+        .reset_index(drop=True)
     )
     dst_df = (
         lr.read_lance(str(dst_path))
         .to_pandas()
+        .pipe(to_numpy_backed)
         .sort_values("id")
         .reset_index(drop=True)
     )
@@ -375,11 +381,16 @@ def test_stream_copy_resume_local(temp_dir: str) -> None:
     )
 
     src_df = (
-        ray.data.from_arrow(table).to_pandas().sort_values("id").reset_index(drop=True)
+        ray.data.from_arrow(table)
+        .to_pandas()
+        .pipe(to_numpy_backed)
+        .sort_values("id")
+        .reset_index(drop=True)
     )
     dst_df = (
         lr.read_lance(str(dst_path))
         .to_pandas()
+        .pipe(to_numpy_backed)
         .sort_values("id")
         .reset_index(drop=True)
     )

--- a/tests/test_blob_v2.py
+++ b/tests/test_blob_v2.py
@@ -28,6 +28,7 @@ from ray.exceptions import RayTaskError
 from _utils import (
     fragment_write_options_skip_reason,
     missing_fragment_write_options,
+    to_numpy_backed,
 )
 
 # Prefer the local Lance Python package when running in a monorepo layout
@@ -163,6 +164,7 @@ def test_blob_v2_roundtrip_with_projection_and_filter(tmp_path: Path) -> None:
         df = (
             lr.read_lance(str(path))
             .to_pandas()
+            .pipe(to_numpy_backed)
             .sort_values("id")
             .reset_index(drop=True)
         )
@@ -182,6 +184,7 @@ def test_blob_v2_roundtrip_with_projection_and_filter(tmp_path: Path) -> None:
     df_proj = (
         lr.read_lance(str(path), columns=["blob"], filter="id >= 2")
         .to_pandas()
+        .pipe(to_numpy_backed)
         .reset_index(drop=True)
     )
     assert df_proj.columns.tolist() == ["blob"]
@@ -261,7 +264,13 @@ def test_blob_v2_reference_outside_bases_write_lance(tmp_path: Path) -> None:
         allow_external_blob_outside_bases=True,
     )
 
-    df = lr.read_lance(str(path)).to_pandas().sort_values("id").reset_index(drop=True)
+    df = (
+        lr.read_lance(str(path))
+        .to_pandas()
+        .pipe(to_numpy_backed)
+        .sort_values("id")
+        .reset_index(drop=True)
+    )
     assert df["blob"].tolist() == [payload]
 
 
@@ -304,7 +313,13 @@ def test_blob_v2_external_blob_ingest_write_lance(
 
     blob_path.unlink()
 
-    df = lr.read_lance(str(path)).to_pandas().sort_values("id").reset_index(drop=True)
+    df = (
+        lr.read_lance(str(path))
+        .to_pandas()
+        .pipe(to_numpy_backed)
+        .sort_values("id")
+        .reset_index(drop=True)
+    )
     assert df["blob"].tolist() == [payload]
 
 
@@ -346,7 +361,13 @@ def test_blob_v2_reference_outside_bases_manual_fragment_writer(
         .write_datasink(LanceFragmentCommitter(str(path)))
     )
 
-    df = lr.read_lance(str(path)).to_pandas().sort_values("id").reset_index(drop=True)
+    df = (
+        lr.read_lance(str(path))
+        .to_pandas()
+        .pipe(to_numpy_backed)
+        .sort_values("id")
+        .reset_index(drop=True)
+    )
     assert df["blob"].tolist() == [payload]
 
 
@@ -376,6 +397,7 @@ def test_blob_v2_reference_multi_base_all_lance_ray_paths(tmp_path: Path) -> Non
     df = (
         lr.read_lance(str(path), base_store_params=base_store_params)
         .to_pandas()
+        .pipe(to_numpy_backed)
         .sort_values("id")
         .reset_index(drop=True)
     )
@@ -390,6 +412,7 @@ def test_blob_v2_reference_multi_base_all_lance_ray_paths(tmp_path: Path) -> Non
             base_store_params=base_store_params,
         )
         .to_pandas()
+        .pipe(to_numpy_backed)
         .reset_index(drop=True)
     )
     assert df_proj["blob"].tolist() == [external_payload, None]
@@ -409,6 +432,7 @@ def test_blob_v2_reference_multi_base_all_lance_ray_paths(tmp_path: Path) -> Non
     stream_df = (
         lr.read_lance(str(stream_path), base_store_params=base_store_params)
         .to_pandas()
+        .pipe(to_numpy_backed)
         .sort_values("id")
         .reset_index(drop=True)
     )
@@ -439,6 +463,7 @@ def test_blob_v2_reference_multi_base_all_lance_ray_paths(tmp_path: Path) -> Non
     manual_df = (
         lr.read_lance(str(manual_path), base_store_params=base_store_params)
         .to_pandas()
+        .pipe(to_numpy_backed)
         .sort_values("id")
         .reset_index(drop=True)
     )
@@ -547,6 +572,7 @@ def test_blob_v2_create_with_initial_bases_and_target_bases(tmp_path: Path) -> N
     df = (
         lr.read_lance(str(path), base_store_params=base_store_params)
         .to_pandas()
+        .pipe(to_numpy_backed)
         .sort_values("id")
         .reset_index(drop=True)
     )
@@ -659,6 +685,7 @@ def test_blob_v2_target_bases_multi_base_routing(tmp_path: Path) -> None:
     df = (
         lr.read_lance(str(path), base_store_params=base_store_params)
         .to_pandas()
+        .pipe(to_numpy_backed)
         .sort_values("id")
         .reset_index(drop=True)
     )
@@ -744,6 +771,7 @@ def test_blob_v2_append_with_target_bases_stream(tmp_path: Path) -> None:
     df = (
         lr.read_lance(str(path), base_store_params=base_store_params)
         .to_pandas()
+        .pipe(to_numpy_backed)
         .sort_values("id")
         .reset_index(drop=True)
     )

--- a/uv.lock
+++ b/uv.lock
@@ -284,7 +284,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -1176,7 +1176,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "certifi", marker = "python_full_version < '3.11'" },
+    { name = "certifi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/10/a8480ea27ea4bbe896c168808854d00f2a9b49f95c0319ddcbba693c8a90/pyproj-3.7.1.tar.gz", hash = "sha256:60d72facd7b6b79853f19744779abcd3f804c4e0d4fa8815469db20c9f640a47", size = 226339, upload-time = "2025-02-16T04:28:46.621Z" }
 wheels = [
@@ -1223,7 +1223,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "certifi", marker = "python_full_version >= '3.11'" },
+    { name = "certifi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/90/67bd7260b4ea9b8b20b4f58afef6c223ecb3abf368eb4ec5bc2cdef81b49/pyproj-3.7.2.tar.gz", hash = "sha256:39a0cf1ecc7e282d1d30f36594ebd55c9fae1fda8a2622cee5d100430628f88c", size = 226279, upload-time = "2025-08-14T12:05:42.18Z" }
 wheels = [
@@ -1401,7 +1401,7 @@ wheels = [
 
 [[package]]
 name = "ray"
-version = "2.53.0"
+version = "2.58.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1414,21 +1414,22 @@ dependencies = [
     { name = "requests" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/99/21986c7f8135dafbf7c49229c52faaa9d2d365db7d86fffe978dde8ee967/ray-2.53.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:4db914a0a6dd608fa49c066929a1282745a2dbd73caee67d7b80fe684ca65bdd", size = 69473649, upload-time = "2025-12-20T16:05:40.58Z" },
-    { url = "https://files.pythonhosted.org/packages/70/d9/58b5426a3f11993851db3c93841358cebdddd948153481d355b720f31f9d/ray-2.53.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:4108280d8a1cb90d7d68e5c954c35e63b8bb9a4ba15f88c5e7da0e2025647712", size = 71342662, upload-time = "2025-12-20T16:05:46.936Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/05/4aa32370b313481c2d1d41cb53ec786daebdb2ef665b01ef2ac43d9cf457/ray-2.53.0-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:4dbb5fce1364763f29741055f50abe33cf726397141f9cc0e845dd3cc963e455", size = 72188620, upload-time = "2025-12-20T16:05:52.817Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/c6/21efe5886898421df20078a333b0984eade7d7aa4bdc68a336f0c66db27e/ray-2.53.0-cp310-cp310-win_amd64.whl", hash = "sha256:90faf630d20b6abf3135997fb3edb5842134aff92e04ee709865db04816d97ef", size = 27200553, upload-time = "2025-12-20T16:05:57.655Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/64/d5c29a4b014d8b9a624203a88b67630072c1d6960425dbf7a1f0fa5d6b74/ray-2.53.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:bd3ec4c342776ddac23ae2b108c64f5939f417ccc4875900d586c7c978463269", size = 69479296, upload-time = "2025-12-20T16:06:05.111Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/41/9e19d1e5d9458a5ba157c36642e2874bcb22fddbd7c1e77b668e5afc3f3d/ray-2.53.0-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:a0bbb98b0b0f25a3ee075ca10171e1260e70b6bc690cd509ecd7ce1228af854d", size = 71463449, upload-time = "2025-12-20T16:06:10.983Z" },
-    { url = "https://files.pythonhosted.org/packages/63/de/58c19906b0dd16ea06b4f2465b7327f5f180e6b6e1c8c9b610d7c589ea5f/ray-2.53.0-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:eb000c17f7301071fdd15c44c4cd3ac0f7953bb4c7c227e61719fe7048195bcd", size = 72305102, upload-time = "2025-12-20T16:06:17.989Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/43/72cc1cfe17d26abe62a793eab10445f9546dce24192b85a6cd0cdc47ed86/ray-2.53.0-cp311-cp311-win_amd64.whl", hash = "sha256:4a1bb3fe09ab4cd0d16ddc96b9f60c9ed83b3f93b87aa8506e0d3b746fd4e825", size = 27194174, upload-time = "2025-12-20T16:06:23.042Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/44/562718a634e63e8ef7985285288a167d4af62bc2a7decce3300cf937776a/ray-2.53.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:d8b95d047d947493803fb8417aea31225dcacdab15afdc75b8a238901949d457", size = 69463763, upload-time = "2025-12-20T16:06:28.685Z" },
-    { url = "https://files.pythonhosted.org/packages/38/68/8e59b8413f3751fe7ce8b98ee8787d13964b47a4043587950790a9dd2151/ray-2.53.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:65e2ce58d3dc6baa3cf45824d889c1968ebde565ee54dfd80a98af8f31af8e4a", size = 71504450, upload-time = "2025-12-20T16:06:34.922Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/db/978a50d264565ca42e2a4bf115ec9a1f04f19ca5e620e6aa2f280747b644/ray-2.53.0-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:14f46363e9b4cf0c1c8b4d8623ec337c5bd408377831b5e5b50067930137bbca", size = 72370424, upload-time = "2025-12-20T16:06:40.821Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/6c/bba6f22a9d83ee8f236000ba315f0c197bdc79888b4fa42fd762f729cbbd/ray-2.53.0-cp312-cp312-win_amd64.whl", hash = "sha256:b828c147f9ff2f277b1d254e4fe9a746fdfaee7e313a93a97c7edf4dae9b81a4", size = 27178106, upload-time = "2025-12-20T16:06:45.594Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/38/450cf9cf3c490fa4cc6d470597f819444da60f85579d2b34b95ee79fcb6f/ray-2.53.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:85b472ab6fb8f1189f8cef81913fd91b24dd69b3fa7dcca7e144827bd924f6c0", size = 69409819, upload-time = "2025-12-20T16:06:50.668Z" },
-    { url = "https://files.pythonhosted.org/packages/71/5e/d452970b07174d5e4f8688abae889d01321b51ced827db1f1d1cb7d56d44/ray-2.53.0-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:7196e5358dfcc8211be864f45e6dfe4827202df294af3c7a76ff8fbc080e0522", size = 71409529, upload-time = "2025-12-20T16:06:56.2Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/84/50b317a125617a638a64694c12f56183edd5df01828a35fa4c55c7b13c66/ray-2.53.0-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:73dbbaa7962a7f5e38aa8cf9483e0e9817205e989aa3dc859c738c2af1ae01df", size = 72283961, upload-time = "2025-12-20T16:07:05.831Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/41/760f9a076085d043d9fbb8f840436e1d21e47682c976d3620efbf02a3b9e/ray-2.58.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:a2235a5a17e865be053e8aff6d9e9e36d1edb45ad8162f57f7cdfd0202a5a397", size = 67217855, upload-time = "2026-08-23T04:45:46.075Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/0c/1e992208dce02e3c4bae8308b97da27dad8f98d416302ea6c4f904be20d5/ray-2.58.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:62dd70c70f32cf0d4c69e752fdf85d421bc567475a8fb8bd2e8a306c360bea4b", size = 77283076, upload-time = "2026-08-23T04:45:52.509Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f9/2502e9dfc0a470a1108f8e3489cc639120ab58afa54d2b8220412cf4a64f/ray-2.58.0-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:5a45ede3edbf89b3ca61c72b84a4e64e701ef369c9e7d3968804a45937b79cf9", size = 78260794, upload-time = "2026-08-23T04:45:58.421Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/07/3c1d99171820029f8aaf5dd17fd51142bc5d47f14d8d1890422cb905f9fc/ray-2.58.0-cp310-cp310-win_amd64.whl", hash = "sha256:7b8910da3853c38ebbf72cca09091a3e1de956b81ee7275bf3cc70329260ba13", size = 28964316, upload-time = "2026-08-23T04:46:03.142Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/83/39861803b95064a8dbc9a81563c296da819d64cd6cf1128d1f32a2aaa28f/ray-2.58.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:a55b33653aadc21c298bb029cc3ed9878b32b2b087fe2913c5e6e0e2db1f699e", size = 67216567, upload-time = "2026-08-23T04:46:07.748Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/77/d24fad9475a6c826120124ef9db2421062d788adbc4915009b6b3d1238df/ray-2.58.0-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:c20bc4cba21d26c5634495d6599277ac47db7fc33bd3b26c0ec7781f8ccc3b3c", size = 77363260, upload-time = "2026-08-23T04:46:13.76Z" },
+    { url = "https://files.pythonhosted.org/packages/50/7b/3a7970817f15e662cb0ea50fcc949c37ecc94e56fea5bcd2920a3440c789/ray-2.58.0-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:fc3dd2decebb35d1f3682c211ec9d6c9807b3152f0defa42ec0942817013e180", size = 78338252, upload-time = "2026-08-23T04:46:22.184Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/eb/06297b5642728d9fd01f83673f663dcc37e134be4d6c16ac81b0c08b307f/ray-2.58.0-cp311-cp311-win_amd64.whl", hash = "sha256:e4294fb246f980a2c2dee6a4ea34d6bc16ed568e7de9644f1abda469df30529a", size = 28959649, upload-time = "2026-08-23T04:46:26.73Z" },
+    { url = "https://files.pythonhosted.org/packages/62/04/99fbdee83ae77a8201e226e8548ff24aae15153f4d6d14a2ef0d302740cb/ray-2.58.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:308863a6468dc969d1d52a99233569d7a2a9c2745f589b74ff277e9769486077", size = 67203436, upload-time = "2026-08-23T04:46:31.553Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fd/c61c335990deb55215c5ed6ebaf59400c95d0b247276acb9f04d715f6d8c/ray-2.58.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:62f2f17a4d50150969dcf0a4ccbdafbdafa87d6be225ee1208a7b56bd373a37c", size = 77382773, upload-time = "2026-08-23T04:46:36.926Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7d/414e1f271bd5f849fbdb4e8646d23c2897719b0c0399a626c73a3815e2ef/ray-2.58.0-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:1e20c4a8d2563d9580e78f7c15297a9f8afe92401b698bceb4106c34b30c01c6", size = 78389778, upload-time = "2026-08-23T04:46:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/19/0682c7e47979411383bbfee774815021b522be7b66a655f4eef2a4313109/ray-2.58.0-cp312-cp312-win_amd64.whl", hash = "sha256:d49ff40e28bafeae29eed8118ce4269a56589e3952268059fb57e60c8721df86", size = 28942354, upload-time = "2026-08-23T04:46:46.529Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/77/473ba58257ab73fa4bdb182df5ed7f2efcf788d6e8c567109e900f01c37c/ray-2.58.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:8a664cb1fbe0f7fd794ec6624ddc772494f8faafcefa83a58569f9a9c6994562", size = 67149247, upload-time = "2026-08-23T04:46:51.537Z" },
+    { url = "https://files.pythonhosted.org/packages/21/6f/5e14e8dc2911c63467cc4086648c2cadb50ae54dc7b2e1de5be57dbb43d5/ray-2.58.0-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:b911ba8b517f2d09c5d5f30865853e2589d039417a5491283df21892dc86498c", size = 77322299, upload-time = "2026-08-23T04:46:56.652Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/1f/59306bf0583844fc935497c7400b30abf3914d85c6a0fd664d5cf184d6ef/ray-2.58.0-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:b2262140a199458c5ad6f7917ec758d057d1669f824048f785119c6ce2539363", size = 78330547, upload-time = "2026-08-23T04:47:02.412Z" },
+    { url = "https://files.pythonhosted.org/packages/25/74/7545a1461aeb49920438098007687c82a445380cc64b6fef234497a0097b/ray-2.58.0-cp313-cp313-win_amd64.whl", hash = "sha256:643cb5eb01dd02282bacc640959c2282c329c08df6fd20ffedd5a5be51dca135", size = 28894898, upload-time = "2026-08-23T04:47:06.671Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Ray 2.56 turned on `DataContext.enable_arrow_backed_pandas_conversion`, so `Dataset.to_pandas()` now maps Arrow types onto `pd.ArrowDtype` instead of numpy dtypes. Seven tests compared those frames against plain pandas frames and Python literals and started failing: two on dtype (`int64` vs `int64[pyarrow]`) and five on nulls (`None` vs `pd.NA`).

`lance_ray` itself is unaffected - it drives Ray with `batch_format="pyarrow"` throughout - so the fix is confined to the assertions. `to_numpy_backed()` normalises a frame back to numpy dtypes and is a no-op when no column is Arrow-backed, which keeps the assertions exact on both sides of the 2.56 release rather than relaxing them with `check_dtype=False`.

uv.lock moves ray 2.53.0 -> 2.58.0 so CI exercises the new default.

Verified: full suite green on ray 2.58.0, and the three touched files green on 2.53.0 and 2.55.0.