### PR TITLE
feat: support max_bytes_per_file in write_lance

### DIFF
--- a/lance_ray/datasink.py
+++ b/lance_ray/datasink.py
@@ -275,6 +275,9 @@ class LanceDatasink(_BaseLanceDatasink):
             The minimum number of rows per file. Default is 1024 * 1024.
         max_rows_per_file : int, optional
             The maximum number of rows per file. Default is 64 * 1024 * 1024.
+        max_bytes_per_file : int, optional
+            The maximum number of bytes per file. This is a soft limit. If not
+            provided, the PyLance default is used.
         data_storage_version: optional, str, default None
             The version of the data storage format to use. Newer versions are more
             efficient but require newer versions of lance to read.  The default is
@@ -323,6 +326,7 @@ class LanceDatasink(_BaseLanceDatasink):
         mode: Literal["create", "append", "overwrite"] = "create",
         min_rows_per_file: int = 1024 * 1024,
         max_rows_per_file: int = 64 * 1024 * 1024,
+        max_bytes_per_file: Optional[int] = None,
         data_storage_version: Optional[str] = None,
         enable_stable_row_ids: bool = False,
         storage_options: Optional[dict[str, Any]] = None,
@@ -369,6 +373,7 @@ class LanceDatasink(_BaseLanceDatasink):
             )
         self.min_rows_per_file = min_rows_per_file
         self.max_rows_per_file = max_rows_per_file
+        self.max_bytes_per_file = max_bytes_per_file
         self.data_storage_version = data_storage_version
         self.external_blob_mode = external_blob_mode
         self.allow_external_blob_outside_bases = allow_external_blob_outside_bases
@@ -402,6 +407,7 @@ class LanceDatasink(_BaseLanceDatasink):
             self.dataset_uri,
             schema=self.schema,
             max_rows_per_file=self.max_rows_per_file,
+            max_bytes_per_file=self.max_bytes_per_file,
             data_storage_version=self.data_storage_version,
             enable_stable_row_ids=self.enable_stable_row_ids,
             storage_options=self.storage_options,

--- a/lance_ray/io.py
+++ b/lance_ray/io.py
@@ -164,6 +164,7 @@ def write_lance(
     mode: Literal["create", "append", "overwrite"] = "create",
     min_rows_per_file: int = 1024 * 1024,
     max_rows_per_file: int = 64 * 1024 * 1024,
+    max_bytes_per_file: Optional[int] = None,
     data_storage_version: Optional[str] = None,
     enable_stable_row_ids: bool = False,
     storage_options: Optional[dict[str, Any]] = None,
@@ -217,6 +218,8 @@ def write_lance(
         mode: The write mode. Can be "create", "append", or "overwrite".
         min_rows_per_file: The minimum number of rows per file.
         max_rows_per_file: The maximum number of rows per file.
+        max_bytes_per_file: The maximum number of bytes per file. This is a soft
+            limit. If not provided, the PyLance default is used.
         data_storage_version: The version of the data storage format to use. Newer versions are more
             efficient but require newer versions of lance to read.  The default is
             "legacy" which will use the legacy v1 version.  See the user guide
@@ -269,6 +272,7 @@ def write_lance(
             mode=mode,
             min_rows_per_file=min_rows_per_file,
             max_rows_per_file=max_rows_per_file,
+            max_bytes_per_file=max_bytes_per_file,
             data_storage_version=data_storage_version,
             enable_stable_row_ids=enable_stable_row_ids,
             storage_options=storage_options,
@@ -367,6 +371,7 @@ def write_lance(
             uri=dest_uri,
             schema=schema,  # if None, writer infers from first batch (preserves Arrow metadata)
             max_rows_per_file=max_rows_per_file,
+            max_bytes_per_file=max_bytes_per_file,
             max_rows_per_group=min_rows_per_file,  # keep naming aligned with v1 semantics
             data_storage_version=data_storage_version,
             enable_stable_row_ids=enable_stable_row_ids,

--- a/tests/test_basic_read_write.py
+++ b/tests/test_basic_read_write.py
@@ -92,6 +92,32 @@ class TestWriteLance:
         lr.write_lance(dataset, str(path), schema=schema)
         assert path.exists()
 
+    @pytest.mark.parametrize("stream", [False, True])
+    def test_write_lance_with_max_bytes_per_file(
+        self, temp_dir: str, stream: bool
+    ) -> None:
+        path = Path(temp_dir) / f"max_bytes_{stream}.lance"
+        schema = pa.schema([pa.field("value", pa.string())])
+        batches = [
+            pa.record_batch([pa.array(["0" * 1024] * (1024 * 8))], schema=schema),
+            pa.record_batch([pa.array(["1" * 1024] * (1024 * 8))], schema=schema),
+        ]
+        table = pa.Table.from_batches(batches)
+
+        lr.write_lance(
+            ray.data.from_arrow(table),
+            str(path),
+            min_rows_per_file=512,
+            max_rows_per_file=table.num_rows,
+            max_bytes_per_file=1024,
+            stream=stream,
+            batch_size=table.num_rows,
+        )
+
+        dataset = lance.dataset(str(path))
+        assert dataset.count_rows() == table.num_rows
+        assert len(dataset.get_fragments()) > 1
+
     def test_write_lance_invalid_input(self, temp_dir: str) -> None:
         """Test error handling for invalid inputs."""
         path = Path(temp_dir) / "invalid.lance"


### PR DESCRIPTION
## Summary
- expose `max_bytes_per_file` in `write_lance`
- forward it through regular and streaming writes

## Tests
- `pytest tests/test_basic_read_write.py::TestWriteLance`
- `ruff check` and `mypy`